### PR TITLE
writer: support io::Write

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@
 //! 
 //! // writer
 //! let path = std::path::Path::new("C:/spread_test_data/ccc.xlsx");
-//! let _ = umya_spreadsheet::writer::xlsx::write(&book, path);
+//! let _ = umya_spreadsheet::writer::xlsx::write_to_file(&book, path);
 //! ```
 //! ## License
 //! MIT

--- a/src/writer/driver.rs
+++ b/src/writer/driver.rs
@@ -1,52 +1,8 @@
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::Writer;
-use tempdir::TempDir;
-use walkdir::WalkDir;
-use zip::write::FileOptions;
 use std::borrow::Cow;
-use std::fs;
-use std::fs::File;
 use std::io;
-use std::io::{Cursor, Read, Write};
-use std::path::Path;
-
-pub(crate) fn write_to_file(path: &Path, dir: &TempDir) -> Result<(), io::Error> {
-    let file = File::create(&path)?;
-    let mut zip = zip::ZipWriter::new(file);
-    let options = FileOptions::default()
-        .compression_method(zip::CompressionMethod::Deflated)
-        .unix_permissions(0o644);
-    let walkdir = WalkDir::new(dir.path());
-    let it = walkdir.into_iter();
-
-    for dent in it.filter_map(|e| e.ok()) {
-        let path = dent.path();
-        let name = path
-            .strip_prefix(Path::new(dir.path()))
-            .unwrap()
-            .to_str()
-            .unwrap();
-
-        if path.is_file() {
-            //println!("adding {:?} as {:?} ...", path, name);
-            let _= zip.start_file(name, options);
-            let mut f = File::open(path)?;
-            let mut buffer = Vec::new();
-            f.read_to_end(&mut buffer)?;
-            zip.write_all(&*buffer)?;
-        }
-        /*
-         else {
-            let mut dir_name = String::from(name);
-            dir_name.push('/');
-            let _ = zip.add_directory(dir_name.as_str(), FileOptions::default());
-        }
-        */
-    }
-
-    let _= zip.finish();
-    Ok(())
-}
+use std::io::{Cursor, Write};
 
 pub(crate) fn write_start_tag<'a, S>(
     writer: &mut Writer<Cursor<Vec<u8>>>,
@@ -87,42 +43,29 @@ pub(crate) fn write_new_line(writer: &mut Writer<Cursor<Vec<u8>>>)
     let _ = write_text_node(writer, "\r\n");
 }
 
-pub(crate) fn make_file_from_writer(
+pub(crate) fn make_file_from_writer<W: io::Seek + io::Write>(
     path: &str,
-    temp_dir: &TempDir,
+    arv: &mut zip::ZipWriter<W>,
     writer: Writer<Cursor<Vec<u8>>>,
     dir: Option<&str>,
 ) -> Result<(), io::Error> {
-    match dir {
-        Some(dir) => {
-            let dir_path = temp_dir.path().join(dir);
-            fs::create_dir_all(dir_path)?;
-        }
-        None => {}
-    }
-    let file_path = temp_dir.path().join(path);
-    let mut f = File::create(file_path)?;
-    f.write_all(writer.into_inner().get_ref())?;
-    f.sync_all()?;
-    Ok(())
+    make_file_from_bin(path, arv, &writer.into_inner().into_inner(), dir)
 }
 
-pub(crate) fn make_file_from_bin(
+pub(crate) fn make_file_from_bin<W: io::Seek + io::Write>(
     path: &str,
-    temp_dir: &TempDir,
+    arv: &mut zip::ZipWriter<W>,
     writer: &Vec<u8>,
     dir: Option<&str>,
 ) -> Result<(), io::Error> {
+    let zip_opt = zip::write::FileOptions::default();
+    arv.start_file(&to_path(path, dir), zip_opt)?;
+    arv.write_all(writer)
+}
+
+pub(crate) fn to_path(path: &str, dir: Option<&str>) -> String {
     match dir {
-        Some(dir) => {
-            let dir_path = temp_dir.path().join(dir);
-            fs::create_dir_all(dir_path)?;
-        }
-        None => {}
+        Some(dir) => format!("{}{}", dir, path),
+        None => path.to_owned()
     }
-    let file_path = temp_dir.path().join(path);
-    let mut f = File::create(file_path)?;
-    f.write_all(writer)?;
-    f.sync_all()?;
-    Ok(())
 }

--- a/src/writer/xlsx.rs
+++ b/src/writer/xlsx.rs
@@ -1,6 +1,6 @@
-use tempdir::TempDir;
-use std::path::Path;
+use std::fs;
 use std::io;
+use std::path::Path;
 use std::string::FromUtf8Error;
 
 use structs::Spreadsheet;
@@ -62,39 +62,39 @@ impl From<FromUtf8Error> for XlsxError {
 /// write spreadsheet file.
 /// # Arguments
 /// * `spreadsheet` - Spreadsheet structs object.
-/// * `path` - file path to save.
+/// * `writer` - writer.
 /// # Return value
 /// * `Result` - OK is void. Err is error message. 
 /// # Examples
 /// ```
 /// let mut book = umya_spreadsheet::new_file();
-/// let path = std::path::Path::new("./tests/result_files/zzz.xlsx");
-/// let _ = umya_spreadsheet::writer::xlsx::write(&book, path);
+/// let mut b: Vec::<u8> = Vec::new();
+/// let _ = umya_spreadsheet::writer::xlsx::write(&book, std::io::Cursor::new(&mut b));
 /// ```
-pub fn write(spreadsheet: &Spreadsheet, path: &Path) -> Result<(), XlsxError> {
-    let dir = TempDir::new("shreadsheet")?;
+pub fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, writer: W) -> Result<(), XlsxError> {
+    let mut arv = zip::ZipWriter::new(writer);
 
     // Add Content_Types
-    let _= content_types::write(spreadsheet, &dir, "[Content_Types].xml");
+    let _= content_types::write(spreadsheet, &mut arv, "[Content_Types].xml");
 
     // Add docProps App
-    let _= doc_props_app::write(spreadsheet, &dir, "docProps", "app.xml");
+    let _= doc_props_app::write(spreadsheet, &mut arv, "docProps", "app.xml");
 
     // Add docProps Core
-    let _= doc_props_core::write(spreadsheet, &dir, "docProps", "core.xml");
+    let _= doc_props_core::write(spreadsheet, &mut arv, "docProps", "core.xml");
 
     // Add vbaProject.bin
-    let _= vba_project_bin::write(spreadsheet, &dir, "xl", "vbaProject.bin");
+    let _= vba_project_bin::write(spreadsheet, &mut arv, "xl", "vbaProject.bin");
 
     // Add relationships
-    let _ = rels::write(spreadsheet, &dir, "_rels", ".rels");
-    let _ = workbook_rels::write(spreadsheet, &dir, "xl/_rels", "workbook.xml.rels");
+    let _ = rels::write(spreadsheet, &mut arv, "_rels", ".rels");
+    let _ = workbook_rels::write(spreadsheet, &mut arv, "xl/_rels", "workbook.xml.rels");
 
     // Add theme
-    let _ = theme::write(spreadsheet.get_theme(), &dir, "xl/theme", "theme1.xml");
+    let _ = theme::write(spreadsheet.get_theme(), &mut arv, "xl/theme", "theme1.xml");
 
     // Add workbook
-    let _ = workbook::write(spreadsheet, &dir, "xl", "workbook.xml");
+    let _ = workbook::write(spreadsheet, &mut arv, "xl", "workbook.xml");
 
     // Add worksheets and relationships (drawings, ...)
     let mut chart_id = 1;
@@ -106,13 +106,13 @@ pub fn write(spreadsheet: &Spreadsheet, path: &Path) -> Result<(), XlsxError> {
     stylesheet.init_setup();
     for i in 0..spreadsheet.get_sheet_count() {
         let p_worksheet_id:&str = &(i+1).to_string();
-        let _ = worksheet::write(&spreadsheet, &i, &mut shared_string_table, &mut stylesheet, &dir);
+        let _ = worksheet::write(&spreadsheet, &i, &mut shared_string_table, &mut stylesheet, &mut arv);
         let worksheet = &spreadsheet.get_sheet_collection()[i];
-        let _ = worksheet_rels::write(worksheet, p_worksheet_id, &drawing_id, &comment_id,  &dir);
-        let _ = drawing::write(worksheet, &drawing_id, &dir);
-        let _ = drawing_rels::write(worksheet, &drawing_id, &chart_id, &dir);
-        let _ = comment::write(worksheet, &comment_id,  &dir);
-        let _ = vml_drawing::write(worksheet, &comment_id,  &dir);
+        let _ = worksheet_rels::write(worksheet, p_worksheet_id, &drawing_id, &comment_id,  &mut arv);
+        let _ = drawing::write(worksheet, &drawing_id, &mut arv);
+        let _ = drawing_rels::write(worksheet, &drawing_id, &chart_id, &mut arv);
+        let _ = comment::write(worksheet, &comment_id,  &mut arv);
+        let _ = vml_drawing::write(worksheet, &comment_id,  &mut arv);
 
         if worksheet.has_drawing_object() {
             drawing_id += 1;
@@ -124,22 +124,37 @@ pub fn write(spreadsheet: &Spreadsheet, path: &Path) -> Result<(), XlsxError> {
 
         for graphic_frame in worksheet.get_worksheet_drawing().get_graphic_frame_collection(){
             let chart_space = graphic_frame.get_graphic().get_graphic_data().get_chart_space();
-            let _ = chart::write(chart_space, &chart_id, &dir);
+            let _ = chart::write(chart_space, &chart_id, &mut arv);
             chart_id += 1;
         }
 
         for picture in worksheet.get_worksheet_drawing().get_picture_collection(){
-            let _ = media::write(picture, &dir, "xl/media");
+            let _ = media::write(picture, &mut arv, "xl/media");
         }
     }
 
     // Add SharedStrings
-    let _ = shared_strings::write(&shared_string_table, &dir).unwrap();
+    let _ = shared_strings::write(&shared_string_table, &mut arv).unwrap();
 
     // Add Styles
-    let _ = styles::write(&stylesheet, &dir).unwrap();
+    let _ = styles::write(&stylesheet, &mut arv).unwrap();
 
-    driver::write_to_file(path, &dir)?;
-    dir.close()?;
+    arv.finish()?;
     Ok(())
+}
+
+/// write spreadsheet file.
+/// # Arguments
+/// * `spreadsheet` - Spreadsheet structs object.
+/// * `path` - file path to save.
+/// # Return value
+/// * `Result` - OK is void. Err is error message. 
+/// # Examples
+/// ```
+/// let mut book = umya_spreadsheet::new_file();
+/// let path = std::path::Path::new("./tests/result_files/zzz.xlsx");
+/// let _ = umya_spreadsheet::writer::xlsx::write_to_file(&book, path);
+/// ```
+pub fn write_to_file(spreadsheet: &Spreadsheet, path: &Path) -> Result<(), XlsxError> {
+    write(spreadsheet, &mut io::BufWriter::new(fs::File::create(path)?))
 }

--- a/src/writer/xlsx/chart.rs
+++ b/src/writer/xlsx/chart.rs
@@ -1,21 +1,20 @@
 use structs::drawing::charts::ChartSpace;
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 use super::driver::*;
 use super::XlsxError;
 
 const SUB_DIR: &'static str = "xl/charts";
 
-pub(crate) fn write(
+pub(crate) fn write<W: io::Seek + io::Write>(
     chart_space: &ChartSpace,
     p_chart_id: &usize,
-    dir: &TempDir
+    arv: &mut zip::ZipWriter<W>
 ) -> Result<(), XlsxError> {
     let file_name = format!("chart{}.xml", p_chart_id);
 
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
@@ -23,6 +22,6 @@ pub(crate) fn write(
     // c:chartSpace
     chart_space.write_to(&mut writer);
 
-    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), dir, writer, Some(SUB_DIR)).unwrap();
+    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/comment.rs
+++ b/src/writer/xlsx/comment.rs
@@ -1,18 +1,16 @@
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
-use onig::*;
+use std::io;
 use ::structs::Worksheet;
 use super::driver::*;
 use super::XlsxError;
 
 const SUB_DIR: &'static str = "xl";
 
-pub(crate) fn write(
+pub(crate) fn write<W: io::Seek + io::Write>(
     worksheet: &Worksheet,
     comment_id: &usize,
-    dir: &TempDir
+    arv: &mut zip::ZipWriter<W>
 ) -> Result<(), XlsxError> {
     if worksheet.get_comments().len() == 0 {
         return Ok(());
@@ -20,7 +18,7 @@ pub(crate) fn write(
 
     let file_name = format!("comments{}.xml", comment_id);
 
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
@@ -59,7 +57,7 @@ pub(crate) fn write(
     write_end_tag(&mut writer, "commentList");
     write_end_tag(&mut writer, "comments");
 
-    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), dir, writer, Some(SUB_DIR)).unwrap();
+    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
     Ok(())
 }
 

--- a/src/writer/xlsx/content_types.rs
+++ b/src/writer/xlsx/content_types.rs
@@ -1,14 +1,13 @@
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 
 use ::structs::Spreadsheet;
 use super::driver::*;
 use super::XlsxError;
 
-pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, file_name: &str) -> Result<(), XlsxError> {
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mut zip::ZipWriter<W>, file_name: &str) -> Result<(), XlsxError> {
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
@@ -201,6 +200,6 @@ pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, file_name: &str) -
     ], true);
 
     write_end_tag(&mut writer, "Types");
-    let _ = make_file_from_writer(format!("{}",file_name).as_str(), dir, writer, None).unwrap();
+    let _ = make_file_from_writer(format!("{}",file_name).as_str(), arv, writer, None).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/doc_props_app.rs
+++ b/src/writer/xlsx/doc_props_app.rs
@@ -1,14 +1,13 @@
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 
 use ::structs::Spreadsheet;
 use super::driver::*;
 use super::XlsxError;
 
-pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, sub_dir: &str, file_name: &str) -> Result<(), XlsxError> {
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mut zip::ZipWriter<W>, sub_dir: &str, file_name: &str) -> Result<(), XlsxError> {
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
@@ -118,6 +117,6 @@ pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, sub_dir: &str, fil
     write_end_tag(&mut writer, "AppVersion");
 
     write_end_tag(&mut writer, "Properties");
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), dir, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/doc_props_core.rs
+++ b/src/writer/xlsx/doc_props_core.rs
@@ -1,14 +1,13 @@
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 
 use ::structs::Spreadsheet;
 use super::driver::*;
 use super::XlsxError;
 
-pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, sub_dir: &str, file_name: &str) -> Result<(), XlsxError> {
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mut zip::ZipWriter<W>, sub_dir: &str, file_name: &str) -> Result<(), XlsxError> {
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
@@ -96,6 +95,6 @@ pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, sub_dir: &str, fil
     }
 
     write_end_tag(&mut writer, "cp:coreProperties");
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), dir, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/drawing.rs
+++ b/src/writer/xlsx/drawing.rs
@@ -1,7 +1,6 @@
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 
 use ::structs::Worksheet;
 use super::driver::*;
@@ -9,10 +8,10 @@ use super::XlsxError;
 
 const SUB_DIR: &'static str = "xl/drawings";
 
-pub(crate) fn write(
+pub(crate) fn write<W: io::Seek + io::Write>(
     worksheet: &Worksheet,
     drawing_id: &usize,
-    dir: &TempDir
+    arv: &mut zip::ZipWriter<W>
 ) -> Result<(), XlsxError> 
 {
     if worksheet.has_drawing_object() == false {
@@ -21,13 +20,13 @@ pub(crate) fn write(
 
     let file_name = format!("drawing{}.xml", drawing_id);
 
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
 
     worksheet.get_worksheet_drawing().write_to(&mut writer);
     
-    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), dir, writer, Some(SUB_DIR)).unwrap();
+    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/drawing_rels.rs
+++ b/src/writer/xlsx/drawing_rels.rs
@@ -1,7 +1,6 @@
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 
 use ::structs::Worksheet;
 use super::driver::*;
@@ -9,17 +8,17 @@ use super::XlsxError;
 
 const SUB_DIR: &'static str = "xl/drawings/_rels";
 
-pub(crate) fn write(
+pub(crate) fn write<W: io::Seek + io::Write>(
     worksheet: &Worksheet,
     drawing_id: &usize,
     chart_start_id: &usize,
-    dir: &TempDir
+    arv: &mut zip::ZipWriter<W>
 ) -> Result<(), XlsxError> 
 {
     let file_name = format!("drawing{}.xml.rels", drawing_id);
     let mut is_write = false;
 
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
@@ -65,12 +64,12 @@ pub(crate) fn write(
     write_end_tag(&mut writer, "Relationships");
 
     if is_write {
-        let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), dir, writer, Some(SUB_DIR)).unwrap();
+        let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
     }
     Ok(())
 }
 
-fn write_relationship(writer: &mut Writer<Cursor<Vec<u8>>>, r_id: &i32, p_type: &str, p_target: &str, p_target_mode: &str) -> bool
+fn write_relationship(writer: &mut Writer<io::Cursor<Vec<u8>>>, r_id: &i32, p_type: &str, p_target: &str, p_target_mode: &str) -> bool
 {
     let tag_name = "Relationship";
     let r_id_str = format!("rId{}", r_id);

--- a/src/writer/xlsx/media.rs
+++ b/src/writer/xlsx/media.rs
@@ -1,12 +1,12 @@
-use tempdir::TempDir;
+use std::io;
 
 use structs::drawing::spreadsheet::Picture;
 use super::driver::*;
 use super::XlsxError;
 
-pub(crate) fn write(picture: &Picture, dir: &TempDir, sub_dir: &str) -> Result<(), XlsxError> {
+pub(crate) fn write<W: io::Seek + io::Write>(picture: &Picture, arv: &mut zip::ZipWriter<W>, sub_dir: &str) -> Result<(), XlsxError> {
     let file_name = picture.get_blip_fill().get_blip().get_image_name();
     let writer = picture.get_blip_fill().get_blip().get_image_data().as_ref().unwrap();
-    let _ = make_file_from_bin(format!("{}/{}",sub_dir,file_name).as_str(), dir, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_bin(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/rels.rs
+++ b/src/writer/xlsx/rels.rs
@@ -1,14 +1,13 @@
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 
 use ::structs::Spreadsheet;
 use super::driver::*;
 use super::XlsxError;
 
-pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, sub_dir: &str, file_name: &str) -> Result<(), XlsxError> {
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mut zip::ZipWriter<W>, sub_dir: &str, file_name: &str) -> Result<(), XlsxError> {
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
@@ -68,11 +67,11 @@ pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, sub_dir: &str, fil
     }
     
     write_end_tag(&mut writer, "Relationships");
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), dir, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }
 
-fn write_relationship(writer: &mut Writer<Cursor<Vec<u8>>>, p_id: &str, p_type: &str, p_target: &str, p_target_mode: &str)
+fn write_relationship(writer: &mut Writer<io::Cursor<Vec<u8>>>, p_id: &str, p_type: &str, p_target: &str, p_target_mode: &str)
 {
     let tag_name = "Relationship";
     let mut attributes: Vec<(&str, &str)> = Vec::new();

--- a/src/writer/xlsx/shared_strings.rs
+++ b/src/writer/xlsx/shared_strings.rs
@@ -1,27 +1,26 @@
-use std::io::Cursor;
+use std::io;
 use std::result;
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use tempdir::TempDir;
 use super::XlsxError;
 use ::structs::SharedStringTable;
 use super::driver::*;
 
 const SHARED_STRINGS: &'static str = "xl/sharedStrings.xml";
 
-pub(crate) fn write(shared_string_table: &SharedStringTable, dir: &TempDir) -> result::Result<(), XlsxError> {
+pub(crate) fn write<W: io::Seek + io::Write>(shared_string_table: &SharedStringTable, arv: &mut zip::ZipWriter<W>) -> result::Result<(), XlsxError> {
 
     if shared_string_table.get_shared_string_item().len() == 0 {
         return Ok(())
     }
     
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
 
     shared_string_table.write_to(&mut writer);
 
-    let _ = make_file_from_writer(SHARED_STRINGS, dir, writer, Some("xl"))?;
+    let _ = make_file_from_writer(SHARED_STRINGS, arv, writer, Some("xl"))?;
     Ok(())
 }

--- a/src/writer/xlsx/styles.rs
+++ b/src/writer/xlsx/styles.rs
@@ -1,7 +1,6 @@
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 use ::structs::Stylesheet;
 use super::driver::*;
 use super::XlsxError;
@@ -9,14 +8,14 @@ use super::XlsxError;
 const SUB_DIR: &'static str = "xl";
 const FILE_NAME: &'static str = "styles.xml";
 
-pub(crate) fn write(stylesheet: &Stylesheet, dir: &TempDir) -> Result<(), XlsxError> {
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+pub(crate) fn write<W: io::Seek + io::Write>(stylesheet: &Stylesheet, arv: &mut zip::ZipWriter<W>) -> Result<(), XlsxError> {
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
 
     stylesheet.write_to(&mut writer);
 
-    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, FILE_NAME).as_str(), dir, writer, Some(SUB_DIR)).unwrap();
+    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, FILE_NAME).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/theme.rs
+++ b/src/writer/xlsx/theme.rs
@@ -1,7 +1,6 @@
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 
 use super::driver::*;
 use super::XlsxError;
@@ -74,14 +73,14 @@ const MINOR_FONTS: &'static [(&'static str, &'static str)] = &[
     ("Geor", "Sylfaen"),
 ];
 
-pub(crate) fn write(
+pub(crate) fn write<W: io::Seek + io::Write>(
     theme: &Theme,
-    dir: &TempDir,
+    arv: &mut zip::ZipWriter<W>,
     sub_dir: &str,
     file_name: &str
 ) -> Result<(), XlsxError> 
 {
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
@@ -930,6 +929,6 @@ pub(crate) fn write(
 
     write_end_tag(&mut writer, "a:theme");
 
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), dir, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/vba_project_bin.rs
+++ b/src/writer/xlsx/vba_project_bin.rs
@@ -1,15 +1,15 @@
-use tempdir::TempDir;
+use std::io;
 
 use ::structs::Spreadsheet;
 use super::driver::*;
 use super::XlsxError;
 
-pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, sub_dir: &str, file_name: &str) -> Result<(), XlsxError> {
+pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mut zip::ZipWriter<W>, sub_dir: &str, file_name: &str) -> Result<(), XlsxError> {
     match spreadsheet.get_has_macros() {
         &true => {},
         &false => return Ok(())
     }
     let writer = spreadsheet.get_macros_code().as_ref().unwrap();
-    let _ = make_file_from_bin(format!("{}/{}",sub_dir,file_name).as_str(), dir, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_bin(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/vml_drawing.rs
+++ b/src/writer/xlsx/vml_drawing.rs
@@ -1,6 +1,5 @@
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 
 use ::structs::Worksheet;
 use ::structs::Comment;
@@ -9,10 +8,10 @@ use super::XlsxError;
 
 const SUB_DIR: &'static str = "xl/drawings";
 
-pub(crate) fn write(
+pub(crate) fn write<W: io::Seek + io::Write>(
     worksheet: &Worksheet,
     comment_id: &usize,
-    dir: &TempDir
+    arv: &mut zip::ZipWriter<W>
 ) -> Result<(), XlsxError> {
     if worksheet.get_comments().len() == 0 {
         return Ok(());
@@ -20,7 +19,7 @@ pub(crate) fn write(
 
     let file_name = format!("vmlDrawing{}.vml", comment_id);
 
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // xml
     write_start_tag(&mut writer, "xml", vec![
         ("xmlns:v", "urn:schemas-microsoft-com:vml"),
@@ -160,7 +159,7 @@ pub(crate) fn write(
 
     write_end_tag(&mut writer, "xml");
 
-    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), dir, writer, Some(SUB_DIR)).unwrap();
+    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
     Ok(())
 }
 

--- a/src/writer/xlsx/workbook.rs
+++ b/src/writer/xlsx/workbook.rs
@@ -1,15 +1,14 @@
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 
 use ::structs::Spreadsheet;
 use super::driver::*;
 use super::XlsxError;
 
-pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, sub_dir: &str, file_name: &str) -> Result<(), XlsxError>
+pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mut zip::ZipWriter<W>, sub_dir: &str, file_name: &str) -> Result<(), XlsxError>
 {
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
@@ -119,6 +118,6 @@ pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, sub_dir: &str, fil
     ], true);
     
     write_end_tag(&mut writer, "workbook");
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), dir, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/workbook_rels.rs
+++ b/src/writer/xlsx/workbook_rels.rs
@@ -1,14 +1,13 @@
 use quick_xml::events::{Event, BytesDecl};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use std::io;
 
 use ::structs::Spreadsheet;
 use super::driver::*;
 use super::XlsxError;
 
-pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, sub_dir: &str, file_name: &str) -> Result<(), XlsxError> {
-    let mut writer = Writer::new(Cursor::new(Vec::new()));
+pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mut zip::ZipWriter<W>, sub_dir: &str, file_name: &str) -> Result<(), XlsxError> {
+    let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(b"1.0", Some(b"UTF-8"), Some(b"yes"))));
     write_new_line(&mut writer);
@@ -74,11 +73,11 @@ pub(crate) fn write(spreadsheet: &Spreadsheet, dir: &TempDir, sub_dir: &str, fil
     }
     
     write_end_tag(&mut writer, root_tag_name);
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), dir, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }
 
-fn write_relationship(writer: &mut Writer<Cursor<Vec<u8>>>, p_id: &str, p_type: &str, p_target: &str, p_target_mode: &str)
+fn write_relationship(writer: &mut Writer<io::Cursor<Vec<u8>>>, p_id: &str, p_type: &str, p_target: &str, p_target_mode: &str)
 {
     let tag_name = "Relationship";
     let mut attributes: Vec<(&str, &str)> = Vec::new();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -42,7 +42,7 @@ fn read_and_wite() {
 
     // writer
     let path = std::path::Path::new("./tests/result_files/bbb.xlsx");
-    let _ = umya_spreadsheet::writer::xlsx::write(&book, path);
+    let _ = umya_spreadsheet::writer::xlsx::write_to_file(&book, path);
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn read_and_wite_by_empty() {
 
     // writer
     let path = std::path::Path::new("./tests/result_files/bbb_empty.xlsx");
-    let _ = umya_spreadsheet::writer::xlsx::write(&book, path);
+    let _ = umya_spreadsheet::writer::xlsx::write_to_file(&book, path);
 }
 
 #[test]
@@ -71,7 +71,7 @@ fn read_and_wite_xlsm() {
 
     // writer
     let path = std::path::Path::new("./tests/result_files/bbb.xlsm");
-    let _ = umya_spreadsheet::writer::xlsx::write(&book, path);
+    let _ = umya_spreadsheet::writer::xlsx::write_to_file(&book, path);
 }
 
 #[test]
@@ -89,7 +89,7 @@ fn insert_and_remove_cells() {
 
     // writer
     let path = std::path::Path::new("./tests/result_files/bbb_insertCell.xlsx");
-    let _ = umya_spreadsheet::writer::xlsx::write(&book, path);
+    let _ = umya_spreadsheet::writer::xlsx::write_to_file(&book, path);
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn new_and_wite() {
 
     // writer.
     let path = std::path::Path::new("./tests/result_files/eee.xlsx");
-    let _ = umya_spreadsheet::writer::xlsx::write(&book, path).unwrap();
+    let _ = umya_spreadsheet::writer::xlsx::write_to_file(&book, path).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Hi! Would you be interested in this change?
This modifies the writer to allow passing in an arbitrary `io::Write`, and writes directly into the final zip archive, rather than into an intermediate temp directory.