### PR TITLE
writer: fix path generation

### DIFF
--- a/src/writer/driver.rs
+++ b/src/writer/driver.rs
@@ -65,7 +65,7 @@ pub(crate) fn make_file_from_bin<W: io::Seek + io::Write>(
 
 pub(crate) fn to_path(path: &str, dir: Option<&str>) -> String {
     match dir {
-        Some(dir) => format!("{}{}", dir, path),
+        Some(dir) => format!("{}/{}", dir, path),
         None => path.to_owned()
     }
 }

--- a/src/writer/xlsx/chart.rs
+++ b/src/writer/xlsx/chart.rs
@@ -22,6 +22,6 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     // c:chartSpace
     chart_space.write_to(&mut writer);
 
-    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, Some(SUB_DIR)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/comment.rs
+++ b/src/writer/xlsx/comment.rs
@@ -57,7 +57,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     write_end_tag(&mut writer, "commentList");
     write_end_tag(&mut writer, "comments");
 
-    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, Some(SUB_DIR)).unwrap();
     Ok(())
 }
 

--- a/src/writer/xlsx/content_types.rs
+++ b/src/writer/xlsx/content_types.rs
@@ -200,6 +200,6 @@ pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mu
     ], true);
 
     write_end_tag(&mut writer, "Types");
-    let _ = make_file_from_writer(format!("{}",file_name).as_str(), arv, writer, None).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, None).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/doc_props_app.rs
+++ b/src/writer/xlsx/doc_props_app.rs
@@ -117,6 +117,6 @@ pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mu
     write_end_tag(&mut writer, "AppVersion");
 
     write_end_tag(&mut writer, "Properties");
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/doc_props_core.rs
+++ b/src/writer/xlsx/doc_props_core.rs
@@ -95,6 +95,6 @@ pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mu
     }
 
     write_end_tag(&mut writer, "cp:coreProperties");
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/drawing.rs
+++ b/src/writer/xlsx/drawing.rs
@@ -27,6 +27,6 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     worksheet.get_worksheet_drawing().write_to(&mut writer);
     
-    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, Some(SUB_DIR)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/drawing_rels.rs
+++ b/src/writer/xlsx/drawing_rels.rs
@@ -64,7 +64,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     write_end_tag(&mut writer, "Relationships");
 
     if is_write {
-        let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
+        let _ = make_file_from_writer(&file_name, arv, writer, Some(SUB_DIR)).unwrap();
     }
     Ok(())
 }

--- a/src/writer/xlsx/media.rs
+++ b/src/writer/xlsx/media.rs
@@ -7,6 +7,6 @@ use super::XlsxError;
 pub(crate) fn write<W: io::Seek + io::Write>(picture: &Picture, arv: &mut zip::ZipWriter<W>, sub_dir: &str) -> Result<(), XlsxError> {
     let file_name = picture.get_blip_fill().get_blip().get_image_name();
     let writer = picture.get_blip_fill().get_blip().get_image_data().as_ref().unwrap();
-    let _ = make_file_from_bin(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_bin(&file_name, arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/rels.rs
+++ b/src/writer/xlsx/rels.rs
@@ -67,7 +67,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mu
     }
     
     write_end_tag(&mut writer, "Relationships");
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }
 

--- a/src/writer/xlsx/shared_strings.rs
+++ b/src/writer/xlsx/shared_strings.rs
@@ -6,7 +6,7 @@ use super::XlsxError;
 use ::structs::SharedStringTable;
 use super::driver::*;
 
-const SHARED_STRINGS: &'static str = "xl/sharedStrings.xml";
+const SHARED_STRINGS: &'static str = "sharedStrings.xml";
 
 pub(crate) fn write<W: io::Seek + io::Write>(shared_string_table: &SharedStringTable, arv: &mut zip::ZipWriter<W>) -> result::Result<(), XlsxError> {
 

--- a/src/writer/xlsx/styles.rs
+++ b/src/writer/xlsx/styles.rs
@@ -16,6 +16,6 @@ pub(crate) fn write<W: io::Seek + io::Write>(stylesheet: &Stylesheet, arv: &mut 
 
     stylesheet.write_to(&mut writer);
 
-    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, FILE_NAME).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
+    let _ = make_file_from_writer(FILE_NAME, arv, writer, Some(SUB_DIR)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/theme.rs
+++ b/src/writer/xlsx/theme.rs
@@ -929,6 +929,6 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     write_end_tag(&mut writer, "a:theme");
 
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/vba_project_bin.rs
+++ b/src/writer/xlsx/vba_project_bin.rs
@@ -10,6 +10,6 @@ pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mu
         &false => return Ok(())
     }
     let writer = spreadsheet.get_macros_code().as_ref().unwrap();
-    let _ = make_file_from_bin(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_bin(&file_name, arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/vml_drawing.rs
+++ b/src/writer/xlsx/vml_drawing.rs
@@ -159,7 +159,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     write_end_tag(&mut writer, "xml");
 
-    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, Some(SUB_DIR)).unwrap();
     Ok(())
 }
 

--- a/src/writer/xlsx/workbook.rs
+++ b/src/writer/xlsx/workbook.rs
@@ -118,6 +118,6 @@ pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mu
     ], true);
     
     write_end_tag(&mut writer, "workbook");
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }

--- a/src/writer/xlsx/workbook_rels.rs
+++ b/src/writer/xlsx/workbook_rels.rs
@@ -73,7 +73,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, arv: &mu
     }
     
     write_end_tag(&mut writer, root_tag_name);
-    let _ = make_file_from_writer(format!("{}/{}",sub_dir,file_name).as_str(), arv, writer, Some(sub_dir)).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, Some(sub_dir)).unwrap();
     Ok(())
 }
 

--- a/src/writer/xlsx/worksheet.rs
+++ b/src/writer/xlsx/worksheet.rs
@@ -445,7 +445,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     }
     
     write_end_tag(&mut writer, "worksheet");
-    let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
+    let _ = make_file_from_writer(&file_name, arv, writer, Some(SUB_DIR)).unwrap();
     Ok(())
 }
 

--- a/src/writer/xlsx/worksheet_rels.rs
+++ b/src/writer/xlsx/worksheet_rels.rs
@@ -89,7 +89,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     write_end_tag(&mut writer, "Relationships");
 
     if is_write {
-        let _ = make_file_from_writer(format!("{}/{}", SUB_DIR, file_name).as_str(), arv, writer, Some(SUB_DIR)).unwrap();
+        let _ = make_file_from_writer(&file_name, arv, writer, Some(SUB_DIR)).unwrap();
     }
     Ok(())
 }


### PR DESCRIPTION
This is a bugfix. I didn't realize the old approach actually didn't prepend the `dir` argument into the path, resulting in broken paths (duplicate prefixes prepended). I relied on the integration tests, which apparently didn't catch this issue. I've tested files generated with this code using OpenOffice.