### PR TITLE
reader/xlsx: support io::Reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ description = "umya-spreadsheet is a library written in pure Rust and read and w
 [dependencies]
 quick-xml = { version = "0.17", features = [ "serialize" ] }
 zip = "0.5.6"
-tempdir = "0.3"
-walkdir = "2.3.1"
 regex = "1.3.7"
 md5 = "0.7.0"
 lazy_static = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,6 @@
 //! MIT
 
 extern crate quick_xml;
-extern crate tempdir;
-extern crate walkdir;
 extern crate zip;
 extern crate regex;
 extern crate md5;

--- a/src/reader/xlsx/chart.rs
+++ b/src/reader/xlsx/chart.rs
@@ -1,13 +1,13 @@
-use std::result;
+use std::{io, result};
 use quick_xml::Reader;
 use quick_xml::events::{Event};
-use tempdir::TempDir;
 use super::XlsxError;
 use structs::drawing::charts::ChartSpace;
+use super::driver::normalize_path;
 
-pub(crate) fn read(dir: &TempDir, target: &String, chart_space: &mut ChartSpace) -> result::Result<(), XlsxError> {
-    let path = dir.path().join(format!("xl/drawings/{}", target));
-    let mut reader = Reader::from_file(path).unwrap();
+pub(crate) fn read<R: io::Read + io::Seek>(arv: &mut zip::read::ZipArchive<R>, target: &String, chart_space: &mut ChartSpace) -> result::Result<(), XlsxError> {
+    let r = io::BufReader::new(arv.by_name(normalize_path(&format!("xl/drawings/{}", target)).to_str().unwrap_or(""))?);
+    let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
     let mut buf = Vec::new();
 

--- a/src/reader/xlsx/comment.rs
+++ b/src/reader/xlsx/comment.rs
@@ -1,7 +1,6 @@
-use std::result;
+use std::{io, result};
 use quick_xml::Reader;
 use quick_xml::events::{Event};
-use tempdir::TempDir;
 use super::XlsxError;
 use std::collections::HashMap; 
 use super::driver::*;
@@ -9,15 +8,15 @@ use structs::Theme;
 use structs::Worksheet;
 use structs::Comment;
 
-pub(crate) fn read(
-    dir: &TempDir,
+pub(crate) fn read<R: io::Read + io::Seek>(
+    arv: &mut zip::read::ZipArchive<R>,
     target: &str,
     worksheet: &mut Worksheet,
     comment_list: &mut HashMap<String, Comment>,
     theme: &Theme
 ) -> result::Result<(), XlsxError> {
-    let path = dir.path().join(format!("xl/worksheets/{}", target));
-    let mut reader = Reader::from_file(path)?;
+    let r = io::BufReader::new(arv.by_name(normalize_path(&format!("xl/worksheets/{}", target)).to_str().unwrap_or(""))?);
+    let mut reader = Reader::from_reader(r);
     reader.trim_text(false);
     let mut buf = Vec::new();
 

--- a/src/reader/xlsx/doc_props_app.rs
+++ b/src/reader/xlsx/doc_props_app.rs
@@ -1,16 +1,15 @@
-use std::result;
+use std::{io, result};
 use quick_xml::Reader;
 use quick_xml::events::{Event};
-use tempdir::TempDir;
 use super::XlsxError;
 
 use ::structs::Spreadsheet;
 
 const FILE_PATH: &'static str = "docProps/app.xml";
 
-pub(crate) fn read(dir: &TempDir, spreadsheet:&mut Spreadsheet) -> result::Result<(), XlsxError> {
-    let path = dir.path().join(FILE_PATH);
-    let mut reader = Reader::from_file(path)?;
+pub(crate) fn read<R: io::Read + io::Seek>(arv: &mut zip::ZipArchive<R>, spreadsheet:&mut Spreadsheet) -> result::Result<(), XlsxError> {
+    let  r = io::BufReader::new(arv.by_name(FILE_PATH)?);
+    let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
     let mut buf = Vec::new();
     let mut string_value: String = String::from("");

--- a/src/reader/xlsx/doc_props_core.rs
+++ b/src/reader/xlsx/doc_props_core.rs
@@ -1,16 +1,15 @@
-use std::result;
+use std::{io, result};
 use quick_xml::Reader;
 use quick_xml::events::{Event};
-use tempdir::TempDir;
 use super::XlsxError;
 
 use ::structs::Spreadsheet;
 
 const FILE_PATH: &'static str = "docProps/core.xml";
 
-pub(crate) fn read(dir: &TempDir, spreadsheet:&mut Spreadsheet) -> result::Result<(), XlsxError> {
-    let path = dir.path().join(FILE_PATH);
-    let mut reader = Reader::from_file(path)?;
+pub(crate) fn read<R: io::Read + io::Seek>(arv: &mut zip::ZipArchive<R>, spreadsheet:&mut Spreadsheet) -> result::Result<(), XlsxError> {
+    let r = io::BufReader::new(arv.by_name(FILE_PATH)?);
+    let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
     let mut buf = Vec::new();
     let mut string_value: String = String::from("");

--- a/src/reader/xlsx/drawing_rels.rs
+++ b/src/reader/xlsx/drawing_rels.rs
@@ -1,13 +1,13 @@
-use std::result;
+use std::{io, result};
 use quick_xml::Reader;
 use quick_xml::events::{Event};
-use tempdir::TempDir;
 use super::XlsxError;
 use super::driver::*;
 
-pub(crate) fn read(dir: &TempDir, target: &str) -> result::Result<Vec<(String, String, String)>, XlsxError> {
-    let path = dir.path().join(format!("xl/drawings/_rels/{}.rels", target.replace("../drawings/", "")));
-    let mut reader = Reader::from_file(path)?;
+pub(crate) fn read<R: io::Read + io::Seek>(arv: &mut zip::ZipArchive<R>, target: &str) -> result::Result<Vec<(String, String, String)>, XlsxError> {
+    let path = normalize_path(&format!("xl/drawings/_rels/{}.rels", target.replace("../drawings/", "")));
+    let r = io::BufReader::new(arv.by_name(path.to_str().unwrap_or(""))?);
+    let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
     let mut buf = Vec::new();
 

--- a/src/reader/xlsx/media.rs
+++ b/src/reader/xlsx/media.rs
@@ -1,17 +1,12 @@
-use std::result;
-use std::fs::File;
+use std::{io, result};
 use std::io::Read;
-use tempdir::TempDir;
 use super::XlsxError;
+use super::driver::normalize_path;
 
-pub fn read(dir: &TempDir, target: &String) -> result::Result<Vec<u8>, XlsxError> {
-    let path = dir.path().join(format!("xl/drawings/{}", target));
-    let mut file = match File::open(path) {
-        Ok(v) => {v},
-        Err(_) => {panic!("Error not find image.")}
-    };
+pub fn read<R: io::Read + io::Seek>(arv: &mut zip::read::ZipArchive<R>, target: &String) -> result::Result<Vec<u8>, XlsxError> {
+    let mut r = io::BufReader::new(arv.by_name(normalize_path(&format!("xl/drawings/{}", target)).to_str().unwrap_or(""))?);
     let mut buf = Vec::new();
-    let _ = file.read_to_end(&mut buf)?;
+    let _ = r.read_to_end(&mut buf)?;
 
     return Ok(buf);
 }

--- a/src/reader/xlsx/styles.rs
+++ b/src/reader/xlsx/styles.rs
@@ -1,16 +1,15 @@
-use std::result;
+use std::{io, result};
 use quick_xml::Reader;
 use quick_xml::events::{Event};
-use tempdir::TempDir;
 use super::XlsxError;
 use structs::Spreadsheet;
 use structs::Stylesheet;
 
 const FILE_PATH: &'static str = "xl/styles.xml";
 
-pub fn read(dir: &TempDir, spreadsheet:&mut Spreadsheet) -> result::Result<(), XlsxError> {
-    let path = dir.path().join(FILE_PATH);
-    let mut reader = Reader::from_file(path)?;
+pub fn read<R: io::Read + io::Seek>(arv: &mut zip::ZipArchive<R>, spreadsheet:&mut Spreadsheet) -> result::Result<(), XlsxError> {
+    let r = io::BufReader::new(arv.by_name(FILE_PATH)?);
+    let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
     let mut buf = Vec::new();
 

--- a/src/reader/xlsx/theme.rs
+++ b/src/reader/xlsx/theme.rs
@@ -1,16 +1,15 @@
-use std::result;
+use std::{io, result};
 use quick_xml::Reader;
 use quick_xml::events::{Event};
-use tempdir::TempDir;
 use super::XlsxError;
 use super::driver::*;
 use std::mem;
 
 use ::structs::Theme;
 
-pub fn read(dir: &TempDir, target: &str) -> result::Result<Theme, XlsxError> {
-    let path = dir.path().join(format!("xl/{}", target));
-    let mut reader = Reader::from_file(path)?;
+pub fn read<R: io::Read + io::Seek>(arv: &mut zip::ZipArchive<R>, target: &str) -> result::Result<Theme, XlsxError> {
+    let r = io::BufReader::new(arv.by_name(&format!("xl/{}", target))?);
+    let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
     let mut buf = Vec::new();
 

--- a/src/reader/xlsx/vba_project_bin.rs
+++ b/src/reader/xlsx/vba_project_bin.rs
@@ -1,21 +1,19 @@
-use std::result;
-use std::fs::File;
+use std::{io, result};
 use std::io::Read;
-use tempdir::TempDir;
 use super::XlsxError;
 
 use ::structs::Spreadsheet;
 
 const FILE_PATH: &'static str = "xl/vbaProject.bin";
 
-pub(crate) fn read(dir: &TempDir, spreadsheet:&mut Spreadsheet) -> result::Result<(), XlsxError> {
-    let path = dir.path().join(FILE_PATH);
-    let mut file = match File::open(path) {
-        Ok(v) => {v},
-        Err(_) => {return Ok(());}
-    };
+pub(crate) fn read<R: io::Read + io::Seek>(arv: &mut zip::ZipArchive<R>, spreadsheet:&mut Spreadsheet) -> result::Result<(), XlsxError> {
+    let mut r = io::BufReader::new(match arv.by_name(FILE_PATH) {
+        Ok(v) => v,
+        Err(zip::result::ZipError::FileNotFound) => {return Ok(());},
+        Err(e) => {return Err(e.into());}
+    });
     let mut buf = Vec::new();
-    let _ = file.read_to_end(&mut buf)?;
+    let _ = r.read_to_end(&mut buf)?;
 
     spreadsheet.set_macros_code(buf);
     spreadsheet.set_has_macros(true);

--- a/src/reader/xlsx/vml_drawing.rs
+++ b/src/reader/xlsx/vml_drawing.rs
@@ -1,7 +1,6 @@
-use std::result;
+use std::{io, result};
 use quick_xml::Reader;
 use quick_xml::events::{Event};
-use tempdir::TempDir;
 use super::XlsxError;
 use super::driver::*;
 use std::collections::HashMap;
@@ -9,13 +8,14 @@ use structs::Comment;
 use structs::Color;
 use structs::Anchor;
 use helper::coordinate::*;
+use super::driver::normalize_path;
 
-pub(crate) fn read(
-    dir: &TempDir,
+pub(crate) fn read<R: io::Read + io::Seek>(
+    arv: &mut zip::read::ZipArchive<R>,
     target: &str,
 ) -> result::Result<HashMap<String, Comment>, XlsxError> {
-    let path = dir.path().join(format!("xl/drawings/{}", target));
-    let mut reader = Reader::from_file(path)?;
+    let r = io::BufReader::new(arv.by_name(normalize_path(&format!("xl/drawings/{}", target)).to_str().unwrap_or(""))?);
+    let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
     let mut buf = Vec::new();
 

--- a/src/reader/xlsx/workbook.rs
+++ b/src/reader/xlsx/workbook.rs
@@ -1,7 +1,6 @@
-use std::result;
+use std::{io, result};
 use quick_xml::Reader;
 use quick_xml::events::{Event};
-use tempdir::TempDir;
 use super::XlsxError;
 use super::driver::*;
 
@@ -11,10 +10,10 @@ use ::structs::WorkbookView;
 
 const FILE_PATH: &'static str = "xl/workbook.xml";
 
-pub(crate) fn read(dir: &TempDir) -> result::Result<(Spreadsheet, Vec<(String, String, String)>), XlsxError>
-{
-    let path = dir.path().join(FILE_PATH);
-    let mut reader = Reader::from_file(path)?;
+pub(crate) fn read<R: io::Read + io::Seek>(arv: &mut zip::read::ZipArchive<R>) -> result::Result<(Spreadsheet, Vec<(String, String, String)>), XlsxError>
+{    
+    let r = io::BufReader::new(arv.by_name(FILE_PATH)?);
+    let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
     let mut buf = Vec::new();
     let mut spreadsheet = Spreadsheet::default();

--- a/src/reader/xlsx/workbook_rels.rs
+++ b/src/reader/xlsx/workbook_rels.rs
@@ -1,16 +1,15 @@
-use std::result;
+use std::{io, result};
 use quick_xml::Reader;
 use quick_xml::events::{Event};
-use tempdir::TempDir;
 use super::XlsxError;
 use super::driver::*;
 
 const FILE_PATH: &'static str = "xl/_rels/workbook.xml.rels";
 
-pub(crate) fn read(dir: &TempDir) -> result::Result<Vec<(String, String, String)>, XlsxError> 
+pub(crate) fn read<R: io::Read + io::Seek>(arv: &mut zip::read::ZipArchive<R>) -> result::Result<Vec<(String, String, String)>, XlsxError> 
 {
-    let path = dir.path().join(FILE_PATH);
-    let mut reader = Reader::from_file(path)?;
+    let r = io::BufReader::new(arv.by_name(FILE_PATH)?);
+    let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
     let mut buf = Vec::new();
 

--- a/src/structs/alignment.rs
+++ b/src/structs/alignment.rs
@@ -1,15 +1,15 @@
 // alignment
+use super::BooleanValue;
 use super::EnumValue;
 use super::HorizontalAlignmentValues;
-use super::VerticalAlignmentValues;
-use super::BooleanValue;
 use super::UInt32Value;
-use reader::driver::*;
-use writer::driver::*;
+use super::VerticalAlignmentValues;
+use quick_xml::events::BytesStart;
 use quick_xml::Reader;
-use quick_xml::events::{BytesStart};
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Default, Clone, Debug)]
 pub struct Alignment {
@@ -19,75 +19,79 @@ pub struct Alignment {
     text_rotation: UInt32Value,
 }
 impl Alignment {
-    pub fn get_horizontal(&self)-> &HorizontalAlignmentValues {
+    pub fn get_horizontal(&self) -> &HorizontalAlignmentValues {
         &self.horizontal.get_value()
     }
 
-    pub fn set_horizontal(&mut self, value:HorizontalAlignmentValues) {
+    pub fn set_horizontal(&mut self, value: HorizontalAlignmentValues) {
         self.horizontal.set_value(value);
     }
 
-    pub fn get_vertical(&self)-> &VerticalAlignmentValues {
+    pub fn get_vertical(&self) -> &VerticalAlignmentValues {
         &self.vertical.get_value()
     }
 
-    pub fn set_vertical(&mut self, value:VerticalAlignmentValues) {
+    pub fn set_vertical(&mut self, value: VerticalAlignmentValues) {
         self.vertical.set_value(value);
     }
 
-    pub fn get_wrap_text(&self)-> &bool {
+    pub fn get_wrap_text(&self) -> &bool {
         &self.wrap_text.get_value()
     }
 
-    pub fn set_wrap_text(&mut self, value:bool) {
+    pub fn set_wrap_text(&mut self, value: bool) {
         self.wrap_text.set_value(value);
     }
 
-    pub fn get_text_rotation(&self)-> &u32 {
+    pub fn get_text_rotation(&self) -> &u32 {
         &self.text_rotation.get_value()
     }
 
-    pub fn set_text_rotation(&mut self, value:u32) {
+    pub fn set_text_rotation(&mut self, value: u32) {
         self.text_rotation.set_value(value);
     }
 
-    pub(crate) fn get_hash_code(&self)-> String {
-        format!("{:x}", md5::compute(format!("{}{}{}{}",
-            &self.horizontal.get_hash_string(),
-            &self.vertical.get_hash_string(),
-            &self.wrap_text.get_hash_string(),
-            &self.text_rotation.get_hash_string(),
-        )))
+    pub(crate) fn get_hash_code(&self) -> String {
+        format!(
+            "{:x}",
+            md5::compute(format!(
+                "{}{}{}{}",
+                &self.horizontal.get_hash_string(),
+                &self.vertical.get_hash_string(),
+                &self.wrap_text.get_hash_string(),
+                &self.text_rotation.get_hash_string(),
+            ))
+        )
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        e:&BytesStart
+        _reader: &mut Reader<R>,
+        e: &BytesStart,
     ) {
         match get_attribute(e, b"horizontal") {
             Some(v) => {
                 self.horizontal.set_value_string(v);
-            },
-            None => {},
+            }
+            None => {}
         }
         match get_attribute(e, b"vertical") {
             Some(v) => {
                 self.vertical.set_value_string(v);
-            },
-            None => {},
+            }
+            None => {}
         }
         match get_attribute(e, b"wrapText") {
             Some(v) => {
                 self.wrap_text.set_value_string(v);
-            },
-            None => {},
+            }
+            None => {}
         }
         match get_attribute(e, b"textRotation") {
             Some(v) => {
                 self.text_rotation.set_value_string(v);
-            },
-            None => {},
+            }
+            None => {}
         }
     }
 
@@ -107,5 +111,5 @@ impl Alignment {
             attributes.push(("textRotation", &self.text_rotation.get_value_string()));
         }
         write_start_tag(writer, "alignment", attributes, true);
-   }
+    }
 }

--- a/src/structs/alternate_content.rs
+++ b/src/structs/alternate_content.rs
@@ -40,9 +40,9 @@ impl AlternateContent {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/alternate_content_choice.rs
+++ b/src/structs/alternate_content_choice.rs
@@ -1,51 +1,46 @@
 // mc:Choice
 use super::office2010::drawing::charts::Style;
-use writer::driver::*;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Default, Debug)]
 pub struct AlternateContentChoice {
     style: Style,
 }
 impl AlternateContentChoice {
-
-    pub fn get_style(&self)-> &Style {
+    pub fn get_style(&self) -> &Style {
         &self.style
     }
 
-    pub fn get_style_mut(&mut self)-> &mut Style {
+    pub fn get_style_mut(&mut self) -> &mut Style {
         &mut self.style
     }
 
-    pub fn set_style(&mut self, value:Style)-> &mut AlternateContentChoice {
+    pub fn set_style(&mut self, value: Style) -> &mut AlternateContentChoice {
         self.style = value;
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        _e:&BytesStart
+        reader: &mut Reader<R>,
+        _e: &BytesStart,
     ) {
         let mut buf = Vec::new();
         loop {
             match reader.read_event(&mut buf) {
-                Ok(Event::Empty(ref e)) => {
-                    match e.name() {
-                        b"c14:style" => {
-                            self.style.set_attributes(reader, e);
-                        },
-                        _ => (),
+                Ok(Event::Empty(ref e)) => match e.name() {
+                    b"c14:style" => {
+                        self.style.set_attributes(reader, e);
                     }
+                    _ => (),
                 },
-                Ok(Event::End(ref e)) => {
-                    match e.name() {
-                        b"mc:Choice" => return,
-                        _ => (),
-                    }
+                Ok(Event::End(ref e)) => match e.name() {
+                    b"mc:Choice" => return,
+                    _ => (),
                 },
                 Ok(Event::Eof) => panic!("Error not find {} end element", "mc:Choice"),
                 Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
@@ -57,10 +52,18 @@ impl AlternateContentChoice {
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // mc:Choice
-        write_start_tag(writer, "mc:Choice", vec![
-            ("Requires", "c14"),
-            ("xmlns:c14", "http://schemas.microsoft.com/office/drawing/2007/8/2/chart"),
-        ], false);
+        write_start_tag(
+            writer,
+            "mc:Choice",
+            vec![
+                ("Requires", "c14"),
+                (
+                    "xmlns:c14",
+                    "http://schemas.microsoft.com/office/drawing/2007/8/2/chart",
+                ),
+            ],
+            false,
+        );
 
         // c14:style
         &self.style.write_to(writer);

--- a/src/structs/alternate_content_fallback.rs
+++ b/src/structs/alternate_content_fallback.rs
@@ -25,9 +25,9 @@ impl AlternateContentFallback {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/bold.rs
+++ b/src/structs/bold.rs
@@ -1,35 +1,37 @@
 // b
 use super::BooleanValue;
-use writer::driver::*;
-use reader::driver::*;
+use quick_xml::events::BytesStart;
 use quick_xml::Reader;
-use quick_xml::events::{BytesStart};
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct Bold {
     pub(crate) val: BooleanValue,
 }
 impl Bold {
-    pub fn get_val(&self)-> &bool {
+    pub fn get_val(&self) -> &bool {
         &self.val.get_value()
     }
 
-    pub fn set_val(&mut self, value:bool)-> &mut Self {
+    pub fn set_val(&mut self, value: bool) -> &mut Self {
         self.val.set_value(value);
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        e:&BytesStart
+        _reader: &mut Reader<R>,
+        e: &BytesStart,
     ) {
         self.val.set_value(true);
         match get_attribute(e, b"val") {
-            Some(v) => {self.val.set_value_string(v);},
-            None => {},
+            Some(v) => {
+                self.val.set_value_string(v);
+            }
+            None => {}
         }
     }
 

--- a/src/structs/borders.rs
+++ b/src/structs/borders.rs
@@ -228,9 +228,9 @@ impl Borders {
         )))
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"diagonalUp") {

--- a/src/structs/borders_crate.rs
+++ b/src/structs/borders_crate.rs
@@ -49,9 +49,9 @@ impl BordersCrate {
         }
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -233,9 +233,9 @@ impl Cell {
         &self.cell_value.get_formula()
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         shared_string_table: &SharedStringTable,
         stylesheet: &Stylesheet,

--- a/src/structs/cell_format.rs
+++ b/src/structs/cell_format.rs
@@ -179,9 +179,9 @@ impl CellFormat {
         )))
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         empty_flag:bool,
     ) {

--- a/src/structs/cell_formats.rs
+++ b/src/structs/cell_formats.rs
@@ -43,9 +43,9 @@ impl CellFormats {
         return id;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/cell_style.rs
+++ b/src/structs/cell_style.rs
@@ -42,9 +42,9 @@ impl CellStyle {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"name") {

--- a/src/structs/cell_styles.rs
+++ b/src/structs/cell_styles.rs
@@ -1,59 +1,55 @@
 // cellStyles
 use super::CellStyle;
-use writer::driver::*;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct CellStyles {
     cell_style: Vec<CellStyle>,
 }
 impl CellStyles {
-    pub(crate) fn get_cell_style(&self)-> &Vec<CellStyle> {
+    pub(crate) fn get_cell_style(&self) -> &Vec<CellStyle> {
         &self.cell_style
     }
 
-    pub(crate) fn get_cell_style_mut(&mut self)-> &mut Vec<CellStyle> {
+    pub(crate) fn get_cell_style_mut(&mut self) -> &mut Vec<CellStyle> {
         &mut self.cell_style
     }
 
-    pub(crate) fn set_cell_style(&mut self, value:CellStyle)-> &mut Self {
+    pub(crate) fn set_cell_style(&mut self, value: CellStyle) -> &mut Self {
         self.cell_style.push(value);
         self
     }
 
-    pub(crate) fn get_defalut_value()-> CellStyle {
+    pub(crate) fn get_defalut_value() -> CellStyle {
         let def = CellStyle::default();
         def
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        _e:&BytesStart
+        reader: &mut Reader<R>,
+        _e: &BytesStart,
     ) {
         self.set_cell_style(Self::get_defalut_value());
 
         let mut buf = Vec::new();
         loop {
             match reader.read_event(&mut buf) {
-                Ok(Event::Empty(ref e)) => {
-                    match e.name() {
-                        b"xf" => {
-                            let mut obj = CellStyle::default();
-                            obj.set_attributes(reader, e);
-                            self.set_cell_style(obj);
-                        },
-                        _ => (),
+                Ok(Event::Empty(ref e)) => match e.name() {
+                    b"xf" => {
+                        let mut obj = CellStyle::default();
+                        obj.set_attributes(reader, e);
+                        self.set_cell_style(obj);
                     }
+                    _ => (),
                 },
-                Ok(Event::End(ref e)) => {
-                    match e.name() {
-                        b"cellStyles" => return,
-                        _ => (),
-                    }
+                Ok(Event::End(ref e)) => match e.name() {
+                    b"cellStyles" => return,
+                    _ => (),
                 },
                 Ok(Event::Eof) => panic!("Error not find {} end element", "cellStyles"),
                 Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
@@ -66,9 +62,12 @@ impl CellStyles {
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         if self.cell_style.len() > 0 {
             // cellStyles
-            write_start_tag(writer, "cellStyles", vec![
-                ("count", &self.cell_style.len().to_string()),
-            ], false);
+            write_start_tag(
+                writer,
+                "cellStyles",
+                vec![("count", &self.cell_style.len().to_string())],
+                false,
+            );
 
             // cellStyle
             for cell_style in &self.cell_style {

--- a/src/structs/color.rs
+++ b/src/structs/color.rs
@@ -172,9 +172,9 @@ impl Color {
         )))
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         for a in e.attributes().with_checks(false) {

--- a/src/structs/colors.rs
+++ b/src/structs/colors.rs
@@ -24,9 +24,9 @@ impl Colors {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/column.rs
+++ b/src/structs/column.rs
@@ -1,16 +1,16 @@
-use super::UInt32Value;
 use super::BooleanValue;
 use super::DoubleValue;
-use super::Style;
 use super::SharedStringItem;
-use super::Stylesheet;
 use super::SharedStringTable;
-use writer::driver::*;
-use reader::driver::*;
+use super::Style;
+use super::Stylesheet;
+use super::UInt32Value;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct Column {
@@ -21,100 +21,114 @@ pub struct Column {
     pub(crate) style: Style,
 }
 impl Column {
-    pub fn get_col_num(&self)-> &u32 {
+    pub fn get_col_num(&self) -> &u32 {
         &self.col_num.get_value()
     }
 
-    pub(crate) fn set_col_num(&mut self, value:u32) -> &mut Self {
+    pub(crate) fn set_col_num(&mut self, value: u32) -> &mut Self {
         self.col_num.set_value(value);
         self
     }
 
-    pub fn get_width(&self)-> &f64 {
+    pub fn get_width(&self) -> &f64 {
         &self.width.get_value()
     }
 
-    pub fn set_width(&mut self, value:f64) -> &mut Self {
+    pub fn set_width(&mut self, value: f64) -> &mut Self {
         self.width.set_value(value);
         self
     }
 
-    pub fn get_hidden(&self)-> &bool {
+    pub fn get_hidden(&self) -> &bool {
         &self.hidden.get_value()
     }
 
-    pub fn set_hidden(&mut self, value:bool) -> &mut Self {
+    pub fn set_hidden(&mut self, value: bool) -> &mut Self {
         self.hidden.set_value(value);
         self
     }
 
-    pub fn get_best_fit(&self)-> &bool {
+    pub fn get_best_fit(&self) -> &bool {
         &self.best_fit.get_value()
     }
 
-    pub fn set_best_fit(&mut self, value:bool) -> &mut Self {
+    pub fn set_best_fit(&mut self, value: bool) -> &mut Self {
         self.best_fit.set_value(value);
         self
     }
 
-    pub fn get_style(&self)-> &Style {
+    pub fn get_style(&self) -> &Style {
         &self.style
     }
 
-    pub fn get_style_mut(&mut self)-> &mut Style {
+    pub fn get_style_mut(&mut self) -> &mut Style {
         &mut self.style
     }
 
-    pub fn set_style(&mut self, value:Style) -> &mut Self {
+    pub fn set_style(&mut self, value: Style) -> &mut Self {
         self.style = value;
         self
     }
 
-    pub(crate) fn adjustment_insert_coordinate(&mut self, root_col_num:&u32, offset_col_num:&u32) {
-        if self.col_num.get_value() >= root_col_num {
-            self.col_num.set_value(self.col_num.get_value() + offset_col_num);
-        }
-    }
-
-    pub(crate) fn adjustment_remove_coordinate(&mut self, root_col_num:&u32, offset_col_num:&u32) {
-        if self.col_num.get_value() >= root_col_num {
-            self.col_num.set_value(self.col_num.get_value() - offset_col_num);
-        }
-    }
-
-    pub(crate) fn get_hash_code(&self)-> String {
-        format!("{:x}", md5::compute(format!("{}{}{}{}",
-            &self.width.get_value_string(),
-            &self.hidden.get_value_string(),
-            &self.best_fit.get_value_string(),
-            &self.style.get_hash_code(),
-        )))
-    }
-
-    pub(crate) fn set_attributes(
+    pub(crate) fn adjustment_insert_coordinate(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        e:&BytesStart,
-        stylesheet: &Stylesheet
+        root_col_num: &u32,
+        offset_col_num: &u32,
+    ) {
+        if self.col_num.get_value() >= root_col_num {
+            self.col_num
+                .set_value(self.col_num.get_value() + offset_col_num);
+        }
+    }
+
+    pub(crate) fn adjustment_remove_coordinate(
+        &mut self,
+        root_col_num: &u32,
+        offset_col_num: &u32,
+    ) {
+        if self.col_num.get_value() >= root_col_num {
+            self.col_num
+                .set_value(self.col_num.get_value() - offset_col_num);
+        }
+    }
+
+    pub(crate) fn get_hash_code(&self) -> String {
+        format!(
+            "{:x}",
+            md5::compute(format!(
+                "{}{}{}{}",
+                &self.width.get_value_string(),
+                &self.hidden.get_value_string(),
+                &self.best_fit.get_value_string(),
+                &self.style.get_hash_code(),
+            ))
+        )
+    }
+
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
+        &mut self,
+        _reader: &mut Reader<R>,
+        e: &BytesStart,
+        stylesheet: &Stylesheet,
     ) {
         match get_attribute(e, b"width") {
             Some(v) => {
                 self.width.set_value_string(v);
-            },
+            }
             None => {}
         }
 
         match get_attribute(e, b"hidden") {
             Some(v) => {
                 self.hidden.set_value_string(v);
-            },
+            }
             None => {}
         }
 
         match get_attribute(e, b"bestFit") {
             Some(v) => {
                 self.best_fit.set_value_string(v);
-            },
+            }
             None => {}
         }
 
@@ -122,7 +136,7 @@ impl Column {
             Some(v) => {
                 let style = stylesheet.get_style(v.parse::<usize>().unwrap());
                 self.set_style(style);
-            },
+            }
             None => {}
         }
     }

--- a/src/structs/columns.rs
+++ b/src/structs/columns.rs
@@ -36,9 +36,9 @@ impl Columns {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart,
         stylesheet: &Stylesheet,
     ) {

--- a/src/structs/diagonal_border.rs
+++ b/src/structs/diagonal_border.rs
@@ -66,9 +66,9 @@ impl DiagonalBorder {
         )))
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"style") {

--- a/src/structs/differential_formats.rs
+++ b/src/structs/differential_formats.rs
@@ -47,9 +47,9 @@ impl DifferentialFormats {
         return id;        
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/adjust_value_list.rs
+++ b/src/structs/drawing/adjust_value_list.rs
@@ -28,9 +28,9 @@ impl AdjustValueList {
         self.shape_guide_collection.push(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/alpha.rs
+++ b/src/structs/drawing/alpha.rs
@@ -19,9 +19,9 @@ impl Alpha {
         self.val = value.into();
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.set_val(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/background_color.rs
+++ b/src/structs/drawing/background_color.rs
@@ -24,9 +24,9 @@ impl BackgroundColor {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/bevel.rs
+++ b/src/structs/drawing/bevel.rs
@@ -1,21 +1,18 @@
 // a:bevel
-use writer::driver::*;
+use quick_xml::events::BytesStart;
 use quick_xml::Reader;
-use quick_xml::events::{BytesStart};
 use quick_xml::Writer;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Default, Debug)]
-pub struct Bevel {
-
-}
+pub struct Bevel {}
 impl Bevel {
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        _e:&BytesStart
+        reader: &mut Reader<R>,
+        _e: &BytesStart,
     ) {
-
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/bevel_bottom.rs
+++ b/src/structs/drawing/bevel_bottom.rs
@@ -43,9 +43,9 @@ impl BevelBottom {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"w") {

--- a/src/structs/drawing/bevel_top.rs
+++ b/src/structs/drawing/bevel_top.rs
@@ -43,9 +43,9 @@ impl BevelTop {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"w") {

--- a/src/structs/drawing/blip.rs
+++ b/src/structs/drawing/blip.rs
@@ -1,13 +1,12 @@
 // a:blip
-use writer::driver::*;
-use reader::driver::*;
+use quick_xml::events::BytesStart;
 use quick_xml::Reader;
-use quick_xml::events::{BytesStart};
 use quick_xml::Writer;
-use std::io::Cursor;
-use tempdir::TempDir;
+use reader::driver::*;
 use reader::xlsx::drawing_rels;
 use reader::xlsx::media;
+use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Default, Debug)]
 pub struct Blip {
@@ -20,7 +19,7 @@ impl Blip {
         &self.image_name
     }
 
-    pub fn set_image_name<S: Into<String>>(&mut self, value:S) {
+    pub fn set_image_name<S: Into<String>>(&mut self, value: S) {
         self.image_name = value.into();
     }
 
@@ -28,7 +27,7 @@ impl Blip {
         &self.image_data
     }
 
-    pub fn set_image_data(&mut self, value:Vec<u8>) {
+    pub fn set_image_data(&mut self, value: Vec<u8>) {
         self.image_data = Some(value);
     }
 
@@ -36,57 +35,55 @@ impl Blip {
         &self.cstate
     }
 
-    pub fn set_cstate<S: Into<String>>(&mut self, value:S) {
+    pub fn set_cstate<S: Into<String>>(&mut self, value: S) {
         self.cstate = value.into();
     }
 
-    pub(crate) fn get_extension(&self)->String {
+    pub(crate) fn get_extension(&self) -> String {
         let v: Vec<&str> = self.image_name.split('.').collect();
         let extension = v.last().unwrap().clone();
         let extension_lower = extension.to_lowercase();
         extension_lower
     }
 
-    pub(crate) fn is_jpeg(&self)-> bool
-    {
+    pub(crate) fn is_jpeg(&self) -> bool {
         self.get_extension() == "jpeg"
     }
 
-    pub(crate) fn is_jpg(&self)-> bool
-    {
+    pub(crate) fn is_jpg(&self) -> bool {
         self.get_extension() == "jpg"
     }
 
-    pub(crate) fn is_png(&self)-> bool
-    {
+    pub(crate) fn is_png(&self) -> bool {
         self.get_extension() == "png"
     }
 
-    pub(crate) fn is_tiff(&self)-> bool
-    {
+    pub(crate) fn is_tiff(&self) -> bool {
         self.get_extension() == "tiff"
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead, A: std::io::Read + std::io::Seek>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        e:&BytesStart,
-        dir: &TempDir,
+        _reader: &mut Reader<R>,
+        e: &BytesStart,
+        arv: &mut zip::read::ZipArchive<A>,
         target: &str,
     ) {
         match get_attribute(e, b"cstate") {
-            Some(v) => {&mut self.set_cstate(v);},
+            Some(v) => {
+                &mut self.set_cstate(v);
+            }
             None => {}
         }
-        
+
         let picture_id = get_attribute(e, b"r:embed").unwrap();
-        let drawing_rel = drawing_rels::read(dir, target).unwrap();
+        let drawing_rel = drawing_rels::read(arv, target).unwrap();
         for (drawing_id, _, drawing_target) in &drawing_rel {
             if &picture_id == drawing_id {
                 let v: Vec<&str> = drawing_target.split('/').collect();
                 let image_name = v.last().unwrap().clone();
                 &mut self.set_image_name(image_name);
-                &mut self.set_image_data(media::read(&dir, &drawing_target).unwrap());
+                &mut self.set_image_data(media::read(arv, &drawing_target).unwrap());
             }
         }
     }
@@ -95,7 +92,10 @@ impl Blip {
         // a:blip
         let r_id_str = format!("rId{}", r_id);
         let mut attributes: Vec<(&str, &str)> = Vec::new();
-        attributes.push(("xmlns:r" , "http://schemas.openxmlformats.org/officeDocument/2006/relationships"));
+        attributes.push((
+            "xmlns:r",
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+        ));
         attributes.push(("r:embed", r_id_str.as_str()));
         if &self.cstate != "" {
             attributes.push(("cstate", &self.cstate));
@@ -106,15 +106,26 @@ impl Blip {
         write_start_tag(writer, "a:extLst", vec![], false);
 
         // a:ext
-        write_start_tag(writer, "a:ext", vec![
-            ("uri", "{28A0092B-C50C-407E-A947-70E740481C1C}"),
-        ], false);
+        write_start_tag(
+            writer,
+            "a:ext",
+            vec![("uri", "{28A0092B-C50C-407E-A947-70E740481C1C}")],
+            false,
+        );
 
         // a14:useLocalDpi
-        write_start_tag(writer, "a14:useLocalDpi", vec![
-            ("xmlns:a14", "http://schemas.microsoft.com/office/drawing/2010/main"),
-            ("val", "0"),
-        ], true);
+        write_start_tag(
+            writer,
+            "a14:useLocalDpi",
+            vec![
+                (
+                    "xmlns:a14",
+                    "http://schemas.microsoft.com/office/drawing/2010/main",
+                ),
+                ("val", "0"),
+            ],
+            true,
+        );
         write_end_tag(writer, "a:ext");
         write_end_tag(writer, "a:extLst");
         write_end_tag(writer, "a:blip");

--- a/src/structs/drawing/body_properties.rs
+++ b/src/structs/drawing/body_properties.rs
@@ -110,9 +110,9 @@ impl BodyProperties {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         empty_flag:bool,
     ) {

--- a/src/structs/drawing/camera.rs
+++ b/src/structs/drawing/camera.rs
@@ -22,9 +22,9 @@ impl Camera {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"prst") {

--- a/src/structs/drawing/charts/area_3d_chart.rs
+++ b/src/structs/drawing/charts/area_3d_chart.rs
@@ -94,9 +94,9 @@ impl Area3DChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/area_chart.rs
+++ b/src/structs/drawing/charts/area_chart.rs
@@ -94,9 +94,9 @@ impl AreaChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/area_chart_series.rs
+++ b/src/structs/drawing/charts/area_chart_series.rs
@@ -241,9 +241,9 @@ impl AreaChartSeries {
         result
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/auto_labeled.rs
+++ b/src/structs/drawing/charts/auto_labeled.rs
@@ -21,9 +21,9 @@ impl AutoLabeled {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/auto_title_deleted.rs
+++ b/src/structs/drawing/charts/auto_title_deleted.rs
@@ -21,9 +21,9 @@ impl AutoTitleDeleted {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/axis_id.rs
+++ b/src/structs/drawing/charts/axis_id.rs
@@ -21,9 +21,9 @@ impl AxisId {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/axis_position.rs
+++ b/src/structs/drawing/charts/axis_position.rs
@@ -22,9 +22,9 @@ impl AxisPosition {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/back_wall.rs
+++ b/src/structs/drawing/charts/back_wall.rs
@@ -24,9 +24,9 @@ impl BackWall {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/bar_3d_chart.rs
+++ b/src/structs/drawing/charts/bar_3d_chart.rs
@@ -139,9 +139,9 @@ impl Bar3DChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/bar_chart.rs
+++ b/src/structs/drawing/charts/bar_chart.rs
@@ -139,9 +139,9 @@ impl BarChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/bar_direction.rs
+++ b/src/structs/drawing/charts/bar_direction.rs
@@ -22,9 +22,9 @@ impl BarDirection {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/bubble_3d.rs
+++ b/src/structs/drawing/charts/bubble_3d.rs
@@ -21,9 +21,9 @@ impl Bubble3D {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/bubble_chart.rs
+++ b/src/structs/drawing/charts/bubble_chart.rs
@@ -109,9 +109,9 @@ impl BubbleChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/bubble_scale.rs
+++ b/src/structs/drawing/charts/bubble_scale.rs
@@ -21,9 +21,9 @@ impl BubbleScale {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/bubble_size.rs
+++ b/src/structs/drawing/charts/bubble_size.rs
@@ -24,9 +24,9 @@ impl BubbleSize {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/category_axis.rs
+++ b/src/structs/drawing/charts/category_axis.rs
@@ -219,9 +219,9 @@ impl CategoryAxis {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/category_axis_data.rs
+++ b/src/structs/drawing/charts/category_axis_data.rs
@@ -24,9 +24,9 @@ impl CategoryAxisData {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/chart.rs
+++ b/src/structs/drawing/charts/chart.rs
@@ -182,9 +182,9 @@ impl Chart {
         self.get_plot_area_mut().get_formula_mut()
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/chart_space.rs
+++ b/src/structs/drawing/charts/chart_space.rs
@@ -114,9 +114,9 @@ impl ChartSpace {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/chart_text.rs
+++ b/src/structs/drawing/charts/chart_text.rs
@@ -24,9 +24,9 @@ impl ChartText {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/cross_between.rs
+++ b/src/structs/drawing/charts/cross_between.rs
@@ -22,9 +22,9 @@ impl CrossBetween {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/crosses.rs
+++ b/src/structs/drawing/charts/crosses.rs
@@ -22,9 +22,9 @@ impl Crosses {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/crossing_axis.rs
+++ b/src/structs/drawing/charts/crossing_axis.rs
@@ -21,9 +21,9 @@ impl CrossingAxis {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/data_labels.rs
+++ b/src/structs/drawing/charts/data_labels.rs
@@ -114,9 +114,9 @@ impl DataLabels {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/date1904.rs
+++ b/src/structs/drawing/charts/date1904.rs
@@ -21,9 +21,9 @@ impl Date1904 {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/delete.rs
+++ b/src/structs/drawing/charts/delete.rs
@@ -21,9 +21,9 @@ impl Delete {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/display_blanks_as.rs
+++ b/src/structs/drawing/charts/display_blanks_as.rs
@@ -22,9 +22,9 @@ impl DisplayBlanksAs {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/doughnut_chart.rs
+++ b/src/structs/drawing/charts/doughnut_chart.rs
@@ -89,9 +89,9 @@ impl DoughnutChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/editing_language.rs
+++ b/src/structs/drawing/charts/editing_language.rs
@@ -21,9 +21,9 @@ impl EditingLanguage {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/explosion.rs
+++ b/src/structs/drawing/charts/explosion.rs
@@ -21,9 +21,9 @@ impl Explosion {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/first_slice_angle.rs
+++ b/src/structs/drawing/charts/first_slice_angle.rs
@@ -21,9 +21,9 @@ impl FirstSliceAngle {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/floor.rs
+++ b/src/structs/drawing/charts/floor.rs
@@ -24,9 +24,9 @@ impl Floor {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/format_code.rs
+++ b/src/structs/drawing/charts/format_code.rs
@@ -19,9 +19,9 @@ impl FormatCode {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/formula.rs
+++ b/src/structs/drawing/charts/formula.rs
@@ -33,9 +33,9 @@ impl Formula {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/gap_width.rs
+++ b/src/structs/drawing/charts/gap_width.rs
@@ -21,9 +21,9 @@ impl GapWidth {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/grouping.rs
+++ b/src/structs/drawing/charts/grouping.rs
@@ -22,9 +22,9 @@ impl Grouping {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/header_footer.rs
+++ b/src/structs/drawing/charts/header_footer.rs
@@ -11,9 +11,9 @@ pub struct HeaderFooter {
 }
 impl HeaderFooter {
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
 

--- a/src/structs/drawing/charts/height.rs
+++ b/src/structs/drawing/charts/height.rs
@@ -21,9 +21,9 @@ impl Height {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/height_mode.rs
+++ b/src/structs/drawing/charts/height_mode.rs
@@ -22,9 +22,9 @@ impl HeightMode {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/hole_size.rs
+++ b/src/structs/drawing/charts/hole_size.rs
@@ -21,9 +21,9 @@ impl HoleSize {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/index.rs
+++ b/src/structs/drawing/charts/index.rs
@@ -21,9 +21,9 @@ impl Index {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/invert_if_negative.rs
+++ b/src/structs/drawing/charts/invert_if_negative.rs
@@ -21,9 +21,9 @@ impl InvertIfNegative {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/label_alignment.rs
+++ b/src/structs/drawing/charts/label_alignment.rs
@@ -22,9 +22,9 @@ impl LabelAlignment {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/label_offset.rs
+++ b/src/structs/drawing/charts/label_offset.rs
@@ -21,9 +21,9 @@ impl LabelOffset {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/layout.rs
+++ b/src/structs/drawing/charts/layout.rs
@@ -28,9 +28,9 @@ impl Layout {
         self.manual_layout.is_none()
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart,
         empty_flag:bool,
     ) {

--- a/src/structs/drawing/charts/layout_target.rs
+++ b/src/structs/drawing/charts/layout_target.rs
@@ -22,9 +22,9 @@ impl LayoutTarget {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/left.rs
+++ b/src/structs/drawing/charts/left.rs
@@ -21,9 +21,9 @@ impl Left {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/left_mode.rs
+++ b/src/structs/drawing/charts/left_mode.rs
@@ -22,9 +22,9 @@ impl LeftMode {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/legend.rs
+++ b/src/structs/drawing/charts/legend.rs
@@ -68,9 +68,9 @@ impl Legend  {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/legend_position.rs
+++ b/src/structs/drawing/charts/legend_position.rs
@@ -22,9 +22,9 @@ impl LegendPosition {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/line_3d_chart.rs
+++ b/src/structs/drawing/charts/line_3d_chart.rs
@@ -94,9 +94,9 @@ impl Line3DChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/line_chart.rs
+++ b/src/structs/drawing/charts/line_chart.rs
@@ -124,9 +124,9 @@ impl LineChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/major_gridlines.rs
+++ b/src/structs/drawing/charts/major_gridlines.rs
@@ -10,9 +10,9 @@ pub struct MajorGridlines {
 }
 impl MajorGridlines {
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
     }

--- a/src/structs/drawing/charts/major_tick_mark.rs
+++ b/src/structs/drawing/charts/major_tick_mark.rs
@@ -22,9 +22,9 @@ impl MajorTickMark {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/manual_layout.rs
+++ b/src/structs/drawing/charts/manual_layout.rs
@@ -162,9 +162,9 @@ impl ManualLayout {
         false
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/marker.rs
+++ b/src/structs/drawing/charts/marker.rs
@@ -24,9 +24,9 @@ impl Marker {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _:&BytesStart,
         empty_flag:bool,
     ) {

--- a/src/structs/drawing/charts/minor_tick_mark.rs
+++ b/src/structs/drawing/charts/minor_tick_mark.rs
@@ -22,9 +22,9 @@ impl MinorTickMark {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/no_multi_level_labels.rs
+++ b/src/structs/drawing/charts/no_multi_level_labels.rs
@@ -21,9 +21,9 @@ impl NoMultiLevelLabels {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/number_reference.rs
+++ b/src/structs/drawing/charts/number_reference.rs
@@ -39,9 +39,9 @@ impl NumberReference {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/numbering_cache.rs
+++ b/src/structs/drawing/charts/numbering_cache.rs
@@ -60,9 +60,9 @@ impl NumberingCache {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/numbering_format.rs
+++ b/src/structs/drawing/charts/numbering_format.rs
@@ -32,9 +32,9 @@ impl NumberingFormat {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.format_code.set_value_string(get_attribute(e, b"formatCode").unwrap());

--- a/src/structs/drawing/charts/numeric_value.rs
+++ b/src/structs/drawing/charts/numeric_value.rs
@@ -19,9 +19,9 @@ impl NumericValue {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/of_pie_chart.rs
+++ b/src/structs/drawing/charts/of_pie_chart.rs
@@ -119,9 +119,9 @@ impl OfPieChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/of_pie_type.rs
+++ b/src/structs/drawing/charts/of_pie_type.rs
@@ -22,9 +22,9 @@ impl OfPieType {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/order.rs
+++ b/src/structs/drawing/charts/order.rs
@@ -21,9 +21,9 @@ impl Order {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/orientation.rs
+++ b/src/structs/drawing/charts/orientation.rs
@@ -22,9 +22,9 @@ impl Orientation {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/overlap.rs
+++ b/src/structs/drawing/charts/overlap.rs
@@ -21,9 +21,9 @@ impl Overlap {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/overlay.rs
+++ b/src/structs/drawing/charts/overlay.rs
@@ -21,9 +21,9 @@ impl Overlay {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/page_margins.rs
+++ b/src/structs/drawing/charts/page_margins.rs
@@ -71,9 +71,9 @@ impl PageMargins {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.bottom.set_value_string(get_attribute(e, b"b").unwrap());

--- a/src/structs/drawing/charts/page_setup.rs
+++ b/src/structs/drawing/charts/page_setup.rs
@@ -11,9 +11,9 @@ pub struct PageSetup {
 }
 impl PageSetup {
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
 

--- a/src/structs/drawing/charts/perspective.rs
+++ b/src/structs/drawing/charts/perspective.rs
@@ -21,9 +21,9 @@ impl Perspective {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/pie_3d_chart.rs
+++ b/src/structs/drawing/charts/pie_3d_chart.rs
@@ -59,9 +59,9 @@ impl Pie3DChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/pie_chart.rs
+++ b/src/structs/drawing/charts/pie_chart.rs
@@ -74,9 +74,9 @@ impl PieChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/plot_area.rs
+++ b/src/structs/drawing/charts/plot_area.rs
@@ -471,9 +471,9 @@ impl PlotArea {
         false
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/plot_visible_only.rs
+++ b/src/structs/drawing/charts/plot_visible_only.rs
@@ -21,9 +21,9 @@ impl PlotVisibleOnly {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/point_count.rs
+++ b/src/structs/drawing/charts/point_count.rs
@@ -21,9 +21,9 @@ impl PointCount {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/print_settings.rs
+++ b/src/structs/drawing/charts/print_settings.rs
@@ -54,9 +54,9 @@ impl PrintSettings {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/radar_chart.rs
+++ b/src/structs/drawing/charts/radar_chart.rs
@@ -94,9 +94,9 @@ impl RadarChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/radar_style.rs
+++ b/src/structs/drawing/charts/radar_style.rs
@@ -22,9 +22,9 @@ impl RadarStyle {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/rich_text.rs
+++ b/src/structs/drawing/charts/rich_text.rs
@@ -51,9 +51,9 @@ impl RichText {
         self.paragraph.push(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/right_angle_axes.rs
+++ b/src/structs/drawing/charts/right_angle_axes.rs
@@ -21,9 +21,9 @@ impl RightAngleAxes {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/rotate_x.rs
+++ b/src/structs/drawing/charts/rotate_x.rs
@@ -21,9 +21,9 @@ impl RotateX {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/rotate_y.rs
+++ b/src/structs/drawing/charts/rotate_y.rs
@@ -21,9 +21,9 @@ impl RotateY {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/rounded_corners.rs
+++ b/src/structs/drawing/charts/rounded_corners.rs
@@ -21,9 +21,9 @@ impl RoundedCorners {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/scaling.rs
+++ b/src/structs/drawing/charts/scaling.rs
@@ -24,9 +24,9 @@ impl Scaling {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/scatter_chart.rs
+++ b/src/structs/drawing/charts/scatter_chart.rs
@@ -94,9 +94,9 @@ impl ScatterChart {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/scatter_style.rs
+++ b/src/structs/drawing/charts/scatter_style.rs
@@ -22,9 +22,9 @@ impl ScatterStyle {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/second_pie_size.rs
+++ b/src/structs/drawing/charts/second_pie_size.rs
@@ -21,9 +21,9 @@ impl SecondPieSize {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/series_axis.rs
+++ b/src/structs/drawing/charts/series_axis.rs
@@ -174,9 +174,9 @@ impl SeriesAxis {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/series_lines.rs
+++ b/src/structs/drawing/charts/series_lines.rs
@@ -11,9 +11,9 @@ pub struct SeriesLines {
 }
 impl SeriesLines {
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
 

--- a/src/structs/drawing/charts/shape.rs
+++ b/src/structs/drawing/charts/shape.rs
@@ -22,9 +22,9 @@ impl Shape {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/shape_properties.rs
+++ b/src/structs/drawing/charts/shape_properties.rs
@@ -129,9 +129,9 @@ impl ShapeProperties {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/show_bubble_size.rs
+++ b/src/structs/drawing/charts/show_bubble_size.rs
@@ -21,9 +21,9 @@ impl ShowBubbleSize {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/show_category_name.rs
+++ b/src/structs/drawing/charts/show_category_name.rs
@@ -21,9 +21,9 @@ impl ShowCategoryName {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/show_data_labels_over_maximum.rs
+++ b/src/structs/drawing/charts/show_data_labels_over_maximum.rs
@@ -21,9 +21,9 @@ impl ShowDataLabelsOverMaximum {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/show_leader_lines.rs
+++ b/src/structs/drawing/charts/show_leader_lines.rs
@@ -21,9 +21,9 @@ impl ShowLeaderLines {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/show_legend_key.rs
+++ b/src/structs/drawing/charts/show_legend_key.rs
@@ -21,9 +21,9 @@ impl ShowLegendKey {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/show_marker.rs
+++ b/src/structs/drawing/charts/show_marker.rs
@@ -21,9 +21,9 @@ impl ShowMarker {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/show_negative_bubbles.rs
+++ b/src/structs/drawing/charts/show_negative_bubbles.rs
@@ -21,9 +21,9 @@ impl ShowNegativeBubbles {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/show_percent.rs
+++ b/src/structs/drawing/charts/show_percent.rs
@@ -21,9 +21,9 @@ impl ShowPercent {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/show_series_name.rs
+++ b/src/structs/drawing/charts/show_series_name.rs
@@ -21,9 +21,9 @@ impl ShowSeriesName {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/show_value.rs
+++ b/src/structs/drawing/charts/show_value.rs
@@ -21,9 +21,9 @@ impl ShowValue {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/side_wall.rs
+++ b/src/structs/drawing/charts/side_wall.rs
@@ -24,9 +24,9 @@ impl SideWall {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/smooth.rs
+++ b/src/structs/drawing/charts/smooth.rs
@@ -21,9 +21,9 @@ impl Smooth {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/string_cache.rs
+++ b/src/structs/drawing/charts/string_cache.rs
@@ -45,9 +45,9 @@ impl StringCache {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/string_point.rs
+++ b/src/structs/drawing/charts/string_point.rs
@@ -36,9 +36,9 @@ impl StringPoint {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.index.set_value_string(get_attribute(e, b"idx").unwrap());

--- a/src/structs/drawing/charts/string_reference.rs
+++ b/src/structs/drawing/charts/string_reference.rs
@@ -39,9 +39,9 @@ impl StringReference {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/style.rs
+++ b/src/structs/drawing/charts/style.rs
@@ -21,9 +21,9 @@ impl Style {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/symbol.rs
+++ b/src/structs/drawing/charts/symbol.rs
@@ -22,9 +22,9 @@ impl Symbol {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/text_properties.rs
+++ b/src/structs/drawing/charts/text_properties.rs
@@ -54,9 +54,9 @@ impl TextProperties {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/thickness.rs
+++ b/src/structs/drawing/charts/thickness.rs
@@ -21,9 +21,9 @@ impl Thickness {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/tick_label_position.rs
+++ b/src/structs/drawing/charts/tick_label_position.rs
@@ -22,9 +22,9 @@ impl TickLabelPosition {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/title.rs
+++ b/src/structs/drawing/charts/title.rs
@@ -54,9 +54,9 @@ impl Title {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/top.rs
+++ b/src/structs/drawing/charts/top.rs
@@ -21,9 +21,9 @@ impl Top {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/top_mode.rs
+++ b/src/structs/drawing/charts/top_mode.rs
@@ -22,9 +22,9 @@ impl TopMode {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/value_axis.rs
+++ b/src/structs/drawing/charts/value_axis.rs
@@ -204,9 +204,9 @@ impl ValueAxis {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/values.rs
+++ b/src/structs/drawing/charts/values.rs
@@ -24,9 +24,9 @@ impl Values {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/vary_colors.rs
+++ b/src/structs/drawing/charts/vary_colors.rs
@@ -21,9 +21,9 @@ impl VaryColors {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/view_3d.rs
+++ b/src/structs/drawing/charts/view_3d.rs
@@ -69,9 +69,9 @@ impl View3D {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/width.rs
+++ b/src/structs/drawing/charts/width.rs
@@ -21,9 +21,9 @@ impl Width {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/width_mode.rs
+++ b/src/structs/drawing/charts/width_mode.rs
@@ -22,9 +22,9 @@ impl WidthMode {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/charts/x_values.rs
+++ b/src/structs/drawing/charts/x_values.rs
@@ -24,9 +24,9 @@ impl XValues {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/charts/y_values.rs
+++ b/src/structs/drawing/charts/y_values.rs
@@ -24,9 +24,9 @@ impl YValues {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/default_run_properties.rs
+++ b/src/structs/drawing/default_run_properties.rs
@@ -211,9 +211,9 @@ impl TextCharacterPropertiesType for DefaultRunProperties {
 }
 
 impl DefaultRunProperties {
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         empty_flag:bool,
     ) {

--- a/src/structs/drawing/east_asian_font.rs
+++ b/src/structs/drawing/east_asian_font.rs
@@ -40,9 +40,9 @@ impl EastAsianFont {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"typeface") {

--- a/src/structs/drawing/effect_list.rs
+++ b/src/structs/drawing/effect_list.rs
@@ -51,9 +51,9 @@ impl EffectList {
         self.soft_edge = Some(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart,
         empty_flag: bool,
     ) {

--- a/src/structs/drawing/end_connection.rs
+++ b/src/structs/drawing/end_connection.rs
@@ -29,9 +29,9 @@ impl EndConnection {
         self.index.set_value(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.id.set_value_string(get_attribute(e, b"id").unwrap());

--- a/src/structs/drawing/end_paragraph_run_properties.rs
+++ b/src/structs/drawing/end_paragraph_run_properties.rs
@@ -211,9 +211,9 @@ impl TextCharacterPropertiesType for EndParagraphRunProperties {
 }
 
 impl EndParagraphRunProperties {
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         empty_flag:bool,
     ) {

--- a/src/structs/drawing/extents.rs
+++ b/src/structs/drawing/extents.rs
@@ -31,9 +31,9 @@ impl Extents {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.cx.set_value_string(get_attribute(e, b"cx").unwrap());

--- a/src/structs/drawing/fill_rectangle.rs
+++ b/src/structs/drawing/fill_rectangle.rs
@@ -45,9 +45,9 @@ impl FillRectangle {
         self.top = value;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
 

--- a/src/structs/drawing/foreground_color.rs
+++ b/src/structs/drawing/foreground_color.rs
@@ -24,9 +24,9 @@ impl ForegroundColor {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/glow.rs
+++ b/src/structs/drawing/glow.rs
@@ -31,9 +31,9 @@ impl Glow {
         self.scheme_color = Some(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.radius.set_value_string(get_attribute(e, b"rad").unwrap());

--- a/src/structs/drawing/gradient_fill.rs
+++ b/src/structs/drawing/gradient_fill.rs
@@ -78,9 +78,9 @@ impl GradientFill {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"flip") {

--- a/src/structs/drawing/gradient_stop.rs
+++ b/src/structs/drawing/gradient_stop.rs
@@ -50,9 +50,9 @@ impl GradientStop {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"pos") {

--- a/src/structs/drawing/gradient_stop_list.rs
+++ b/src/structs/drawing/gradient_stop_list.rs
@@ -29,9 +29,9 @@ impl GradientStopList {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/graphic.rs
+++ b/src/structs/drawing/graphic.rs
@@ -5,7 +5,6 @@ use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
 use quick_xml::Reader;
 use std::io::Cursor;
-use tempdir::TempDir;
 
 #[derive(Default, Debug)]
 pub struct Graphic {
@@ -25,11 +24,11 @@ impl Graphic {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead, A: std::io::Read + std::io::Seek>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart,
-        dir: &TempDir,
+        arv: &mut zip::read::ZipArchive<A>,
         target: &str,
     ) {
         let mut buf = Vec::new();
@@ -39,7 +38,7 @@ impl Graphic {
                 Ok(Event::Start(ref e)) => {
                     match e.name() {
                         b"a:graphicData" => {
-                            &mut self.graphic_data.set_attributes(reader, e, dir, target);
+                            &mut self.graphic_data.set_attributes(reader, e, arv, target);
                         },
                         _ => (),
                     }

--- a/src/structs/drawing/latin_font.rs
+++ b/src/structs/drawing/latin_font.rs
@@ -40,9 +40,9 @@ impl LatinFont {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"typeface") {

--- a/src/structs/drawing/light_rig.rs
+++ b/src/structs/drawing/light_rig.rs
@@ -33,9 +33,9 @@ impl LightRig {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"rig") {

--- a/src/structs/drawing/linear_gradient_fill.rs
+++ b/src/structs/drawing/linear_gradient_fill.rs
@@ -32,9 +32,9 @@ impl LinearGradientFill {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"ang") {

--- a/src/structs/drawing/list_style.rs
+++ b/src/structs/drawing/list_style.rs
@@ -23,9 +23,9 @@ impl ListStyle {
         self.effect_list = Some(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/miter.rs
+++ b/src/structs/drawing/miter.rs
@@ -21,9 +21,9 @@ impl Miter {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"lim") {

--- a/src/structs/drawing/no_fill.rs
+++ b/src/structs/drawing/no_fill.rs
@@ -10,9 +10,9 @@ pub struct NoFill {
 }
 impl NoFill {
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         _:&BytesStart
     ) {
     }

--- a/src/structs/drawing/offset.rs
+++ b/src/structs/drawing/offset.rs
@@ -29,9 +29,9 @@ impl Offset {
         self.y.set_value(value);
     }
     
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.x.set_value_string(get_attribute(e, b"x").unwrap());

--- a/src/structs/drawing/outer_shadow.rs
+++ b/src/structs/drawing/outer_shadow.rs
@@ -125,9 +125,9 @@ impl OuterShadow {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"blurRad") {

--- a/src/structs/drawing/outline.rs
+++ b/src/structs/drawing/outline.rs
@@ -139,9 +139,9 @@ impl Outline {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/paragraph.rs
+++ b/src/structs/drawing/paragraph.rs
@@ -53,9 +53,9 @@ impl Paragraph {
         self.end_para_run_properties = None;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/paragraph_properties.rs
+++ b/src/structs/drawing/paragraph_properties.rs
@@ -47,9 +47,9 @@ impl ParagraphProperties {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         empty_flag:bool,
     ) {

--- a/src/structs/drawing/pattern_fill.rs
+++ b/src/structs/drawing/pattern_fill.rs
@@ -59,9 +59,9 @@ impl PatternFill {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"prst") {

--- a/src/structs/drawing/picture_locks.rs
+++ b/src/structs/drawing/picture_locks.rs
@@ -19,9 +19,9 @@ impl PictureLocks {
         self.no_change_aspect = value;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"noChangeAspect") {

--- a/src/structs/drawing/preset_color.rs
+++ b/src/structs/drawing/preset_color.rs
@@ -33,9 +33,9 @@ impl PresetColor {
         self.alpha = Some(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.set_val(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/preset_dash.rs
+++ b/src/structs/drawing/preset_dash.rs
@@ -22,9 +22,9 @@ impl PresetDash {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/preset_geometry.rs
+++ b/src/structs/drawing/preset_geometry.rs
@@ -222,9 +222,9 @@ impl PresetGeometry {
         self.adjust_value_list = value;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.set_geometry(get_attribute(e, b"prst").unwrap());

--- a/src/structs/drawing/rgb_color_model_hex.rs
+++ b/src/structs/drawing/rgb_color_model_hex.rs
@@ -97,9 +97,9 @@ impl RgbColorModelHex {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         empty_flag: bool
     ) {

--- a/src/structs/drawing/run.rs
+++ b/src/structs/drawing/run.rs
@@ -31,9 +31,9 @@ impl Run {
         self.run_properties = value;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/run_properties.rs
+++ b/src/structs/drawing/run_properties.rs
@@ -210,9 +210,9 @@ impl TextCharacterPropertiesType for RunProperties {
 }
 
 impl RunProperties {
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         empty_flag:bool,
     ) {

--- a/src/structs/drawing/saturation_modulation.rs
+++ b/src/structs/drawing/saturation_modulation.rs
@@ -21,9 +21,9 @@ impl SaturationModulation {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/scene_3d_type.rs
+++ b/src/structs/drawing/scene_3d_type.rs
@@ -31,9 +31,9 @@ impl Scene3DType {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/scheme_color.rs
+++ b/src/structs/drawing/scheme_color.rs
@@ -68,9 +68,9 @@ impl SchemeColor {
         self.lum_mod.is_some() ||  self.lum_off.is_some() || self.shade.is_some() || self.sat_mod.is_some() || self.alpha.is_some()
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         empty_flag: bool
     ) {

--- a/src/structs/drawing/shade.rs
+++ b/src/structs/drawing/shade.rs
@@ -21,9 +21,9 @@ impl Shade {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/shape_3d_type.rs
+++ b/src/structs/drawing/shape_3d_type.rs
@@ -50,9 +50,9 @@ impl Shape3DType {
         self.bevel_bottom = Some(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.preset_material.set_value_string(get_attribute(e, b"prstMaterial").unwrap());

--- a/src/structs/drawing/shape_auto_fit.rs
+++ b/src/structs/drawing/shape_auto_fit.rs
@@ -10,9 +10,9 @@ pub struct ShapeAutoFit {
 }
 impl ShapeAutoFit {
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         _:&BytesStart
     ) {
     }

--- a/src/structs/drawing/soft_edge.rs
+++ b/src/structs/drawing/soft_edge.rs
@@ -21,9 +21,9 @@ impl SoftEdge {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.radius.set_value_string(get_attribute(e, b"rad").unwrap());

--- a/src/structs/drawing/solid_fill.rs
+++ b/src/structs/drawing/solid_fill.rs
@@ -37,9 +37,9 @@ impl SolidFill {
         self.rgb_color_model_hex = Some(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/source_rectangle.rs
+++ b/src/structs/drawing/source_rectangle.rs
@@ -46,9 +46,9 @@ impl SourceRectangle {
         &self.b
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart,
     ) {
         for a in e.attributes().with_checks(false) {

--- a/src/structs/drawing/spreadsheet/connection_shape.rs
+++ b/src/structs/drawing/spreadsheet/connection_shape.rs
@@ -65,9 +65,9 @@ impl ConnectionShape {
         self.shape_style = value;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/extent.rs
+++ b/src/structs/drawing/spreadsheet/extent.rs
@@ -31,9 +31,9 @@ impl Extent {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"cx") {

--- a/src/structs/drawing/spreadsheet/from_marker.rs
+++ b/src/structs/drawing/spreadsheet/from_marker.rs
@@ -65,9 +65,9 @@ impl FromMarker {
         self.col = if &self.col > num_cols { self.col - num_cols } else { 1 };
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
     ) {
         let mut string_value:String = String::from("");

--- a/src/structs/drawing/spreadsheet/graphic_frame.rs
+++ b/src/structs/drawing/spreadsheet/graphic_frame.rs
@@ -10,7 +10,6 @@ use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
 use quick_xml::Reader;
 use std::io::Cursor;
-use tempdir::TempDir;
 
 #[derive(Default, Debug)]
 pub struct GraphicFrame {
@@ -68,11 +67,11 @@ impl GraphicFrame {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead, A: std::io::Read + std::io::Seek>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
-        dir: &TempDir,
+        arv: &mut zip::read::ZipArchive<A>,
         target: &str
     ) {
         match get_attribute(e, b"macro") {
@@ -93,7 +92,7 @@ impl GraphicFrame {
                             &mut self.transform.set_attributes(reader, e);
                         },
                         b"a:graphic" => {
-                            &mut self.graphic.set_attributes(reader, e, dir, target);
+                            &mut self.graphic.set_attributes(reader, e, arv, target);
                         },
                         _ => (),
                     }

--- a/src/structs/drawing/spreadsheet/non_visual_connection_shape_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_connection_shape_properties.rs
@@ -39,9 +39,9 @@ impl NonVisualConnectionShapeProperties {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/non_visual_connector_shape_drawing_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_connector_shape_drawing_properties.rs
@@ -37,9 +37,9 @@ impl NonVisualConnectorShapeDrawingProperties {
         self.end_connection = None;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/non_visual_drawing_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_drawing_properties.rs
@@ -30,9 +30,9 @@ impl NonVisualDrawingProperties  {
         self.id.set_value(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.id.set_value_string(get_attribute(e, b"id").unwrap());

--- a/src/structs/drawing/spreadsheet/non_visual_graphic_frame_drawing_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_graphic_frame_drawing_properties.rs
@@ -11,9 +11,9 @@ pub struct NonVisualGraphicFrameDrawingProperties {
 }
 impl NonVisualGraphicFrameDrawingProperties {
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
 

--- a/src/structs/drawing/spreadsheet/non_visual_graphic_frame_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_graphic_frame_properties.rs
@@ -39,9 +39,9 @@ impl NonVisualGraphicFrameProperties {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/non_visual_picture_drawing_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_picture_drawing_properties.rs
@@ -23,9 +23,9 @@ impl NonVisualPictureDrawingProperties {
         self.picture_locks = value;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/non_visual_picture_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_picture_properties.rs
@@ -37,9 +37,9 @@ impl NonVisualPictureProperties {
         self.non_visual_picture_drawing_properties = value;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/non_visual_shape_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_shape_properties.rs
@@ -23,9 +23,9 @@ impl NonVisualShapeProperties  {
         self.non_visual_drawing_properties = value;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/one_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/one_cell_anchor.rs
@@ -70,9 +70,9 @@ impl OneCellAnchor {
         &mut self.from_marker.adjustment_remove_colmun(num_cols);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/shape.rs
+++ b/src/structs/drawing/spreadsheet/shape.rs
@@ -78,9 +78,9 @@ impl Shape {
         self.text_body = value;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/shape_properties.rs
+++ b/src/structs/drawing/spreadsheet/shape_properties.rs
@@ -99,9 +99,9 @@ impl ShapeProperties {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/shape_style.rs
+++ b/src/structs/drawing/spreadsheet/shape_style.rs
@@ -46,9 +46,9 @@ impl ShapeStyle {
         self.font_reference = Some(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/text_body.rs
+++ b/src/structs/drawing/spreadsheet/text_body.rs
@@ -50,9 +50,9 @@ impl TextBody {
         self.paragraph.push(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/to_marker.rs
+++ b/src/structs/drawing/spreadsheet/to_marker.rs
@@ -65,9 +65,9 @@ impl ToMarker {
         self.col = if &self.col > num_cols { self.col - num_cols } else { 1 };
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
     ) {
         let mut string_value:String = String::from("");

--- a/src/structs/drawing/spreadsheet/transform.rs
+++ b/src/structs/drawing/spreadsheet/transform.rs
@@ -69,9 +69,9 @@ impl Transform {
         self.horizontal_flip.set_value(value);
     }
     
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/spreadsheet/two_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/two_cell_anchor.rs
@@ -13,7 +13,6 @@ use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
 use quick_xml::Reader;
 use std::io::Cursor;
-use tempdir::TempDir;
 
 #[derive(Default, Debug)]
 pub struct TwoCellAnchor {
@@ -143,11 +142,11 @@ impl TwoCellAnchor {
         true
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead, A: std::io::Read + std::io::Seek>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
-        dir: &TempDir,
+        arv: &mut zip::read::ZipArchive<A>,
         target: &str,
     ) {
         match get_attribute(e, b"editAs") {
@@ -168,7 +167,7 @@ impl TwoCellAnchor {
                         },
                         b"xdr:graphicFrame" => {
                             let mut obj = GraphicFrame::default();
-                            obj.set_attributes(reader, e, dir, target);
+                            obj.set_attributes(reader, e, arv, target);
                             self.set_graphic_frame(obj);
                         },
                         b"xdr:sp" => {
@@ -183,7 +182,7 @@ impl TwoCellAnchor {
                         }
                         b"xdr:pic" => {
                             let mut obj = Picture::default();
-                            obj.set_attributes(reader, e, dir, target);
+                            obj.set_attributes(reader, e, arv, target);
                             self.set_picture(obj);
                         }
                         _ => (),

--- a/src/structs/drawing/spreadsheet/worksheet_drawing.rs
+++ b/src/structs/drawing/spreadsheet/worksheet_drawing.rs
@@ -10,7 +10,6 @@ use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
 use quick_xml::Reader;
 use std::io::Cursor;
-use tempdir::TempDir;
 
 #[derive(Default, Debug)]
 pub struct WorksheetDrawing {
@@ -159,11 +158,11 @@ impl WorksheetDrawing {
         result
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead, A: std::io::Read + std::io::Seek>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart,
-        dir: &TempDir,
+        arv: &mut zip::read::ZipArchive<A>,
         target: &str,
     ) {
         let mut is_alternate_content = false;
@@ -185,7 +184,7 @@ impl WorksheetDrawing {
                                 continue;
                             }
                             let mut obj = TwoCellAnchor::default();
-                            obj.set_attributes(reader, e, dir, target);
+                            obj.set_attributes(reader, e, arv, target);
                             if obj.is_support() {
                                 &mut self.add_two_cell_anchor_collection(obj);
                             }

--- a/src/structs/drawing/start_connection.rs
+++ b/src/structs/drawing/start_connection.rs
@@ -29,9 +29,9 @@ impl StartConnection {
         self.index.set_value(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         &mut self.id.set_value_string(get_attribute(e, b"id").unwrap());

--- a/src/structs/drawing/stretch.rs
+++ b/src/structs/drawing/stretch.rs
@@ -23,9 +23,9 @@ impl Stretch {
         self.fill_rectangle = Some(value);
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/drawing/style_matrix_reference_type.rs
+++ b/src/structs/drawing/style_matrix_reference_type.rs
@@ -29,9 +29,9 @@ impl StyleMatrixReferenceType {
         self.scheme_color = Some(value.into());
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         empty_flag: bool
     ) {

--- a/src/structs/drawing/tail_end.rs
+++ b/src/structs/drawing/tail_end.rs
@@ -19,9 +19,9 @@ impl TailEnd {
         self.r#type = value.into();
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"type") {

--- a/src/structs/drawing/tile_rectangle.rs
+++ b/src/structs/drawing/tile_rectangle.rs
@@ -10,9 +10,9 @@ pub struct TileRectangle {
 
 }
 impl TileRectangle {
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
 

--- a/src/structs/drawing/tint.rs
+++ b/src/structs/drawing/tint.rs
@@ -21,9 +21,9 @@ impl Tint {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/drawing/transform2d.rs
+++ b/src/structs/drawing/transform2d.rs
@@ -73,9 +73,9 @@ impl Transform2D {
         self.flip_h = Some(value.into());
     }
     
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/fills.rs
+++ b/src/structs/fills.rs
@@ -51,9 +51,9 @@ impl Fills {
         }
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/font.rs
+++ b/src/structs/font.rs
@@ -316,9 +316,9 @@ impl Font {
         )))
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/font_char_set.rs
+++ b/src/structs/font_char_set.rs
@@ -1,34 +1,36 @@
 // family
 use super::Int32Value;
-use writer::driver::*;
-use reader::driver::*;
+use quick_xml::events::BytesStart;
 use quick_xml::Reader;
-use quick_xml::events::{BytesStart};
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct FontCharSet {
     pub(crate) val: Int32Value,
 }
 impl FontCharSet {
-    pub fn get_val(&self)-> &i32 {
+    pub fn get_val(&self) -> &i32 {
         &self.val.get_value()
     }
-    
-    pub fn set_val(&mut self, value:i32)-> &mut Self {
+
+    pub fn set_val(&mut self, value: i32) -> &mut Self {
         self.val.set_value(value);
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        e:&BytesStart
+        _reader: &mut Reader<R>,
+        e: &BytesStart,
     ) {
         match get_attribute(e, b"val") {
-            Some(v) => {self.val.set_value_string(v);},
-            None => {},
+            Some(v) => {
+                self.val.set_value_string(v);
+            }
+            None => {}
         }
     }
 

--- a/src/structs/font_family_numbering.rs
+++ b/src/structs/font_family_numbering.rs
@@ -21,9 +21,9 @@ impl FontFamilyNumbering {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"val") {

--- a/src/structs/font_name.rs
+++ b/src/structs/font_name.rs
@@ -21,9 +21,9 @@ impl FontName {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/font_scheme.rs
+++ b/src/structs/font_scheme.rs
@@ -22,9 +22,9 @@ impl FontScheme {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/font_size.rs
+++ b/src/structs/font_size.rs
@@ -21,9 +21,9 @@ impl FontSize {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value_string(get_attribute(e, b"val").unwrap());

--- a/src/structs/gradient_stop.rs
+++ b/src/structs/gradient_stop.rs
@@ -43,9 +43,9 @@ impl GradientStop {
         )))
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         match get_attribute(e, b"position") {

--- a/src/structs/italic.rs
+++ b/src/structs/italic.rs
@@ -1,35 +1,37 @@
 // i
 use super::BooleanValue;
-use writer::driver::*;
-use reader::driver::*;
+use quick_xml::events::BytesStart;
 use quick_xml::Reader;
-use quick_xml::events::{BytesStart};
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct Italic {
     pub(crate) val: BooleanValue,
 }
 impl Italic {
-    pub fn get_val(&self)-> &bool {
+    pub fn get_val(&self) -> &bool {
         &self.val.get_value()
     }
 
-    pub fn set_val(&mut self, value:bool)-> &mut Self {
+    pub fn set_val(&mut self, value: bool) -> &mut Self {
         self.val.set_value(value);
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        e:&BytesStart
+        _reader: &mut Reader<R>,
+        e: &BytesStart,
     ) {
         self.val.set_value(true);
         match get_attribute(e, b"val") {
-            Some(v) => {self.val.set_value_string(v);},
-            None => {},
+            Some(v) => {
+                self.val.set_value_string(v);
+            }
+            None => {}
         }
     }
 

--- a/src/structs/mru_colors.rs
+++ b/src/structs/mru_colors.rs
@@ -1,52 +1,48 @@
 // mruColors
 use super::Color;
-use writer::driver::*;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct MruColors {
     color: Vec<Color>,
 }
 impl MruColors {
-    pub(crate) fn get_color(&self)-> &Vec<Color> {
+    pub(crate) fn get_color(&self) -> &Vec<Color> {
         &self.color
     }
 
-    pub(crate) fn get_color_mut(&mut self)-> &mut Vec<Color> {
+    pub(crate) fn get_color_mut(&mut self) -> &mut Vec<Color> {
         &mut self.color
     }
 
-    pub(crate) fn set_color(&mut self, value:Color)-> &mut Self {
+    pub(crate) fn set_color(&mut self, value: Color) -> &mut Self {
         self.color.push(value);
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        _e:&BytesStart,
+        reader: &mut Reader<R>,
+        _e: &BytesStart,
     ) {
         let mut buf = Vec::new();
         loop {
             match reader.read_event(&mut buf) {
-                Ok(Event::Start(ref e)) => {
-                    match e.name() {
-                        b"color" => {
-                            let mut obj = Color::default();
-                            obj.set_attributes(reader, e);
-                            self.set_color(obj);
-                        },
-                        _ => (),
+                Ok(Event::Start(ref e)) => match e.name() {
+                    b"color" => {
+                        let mut obj = Color::default();
+                        obj.set_attributes(reader, e);
+                        self.set_color(obj);
                     }
+                    _ => (),
                 },
-                Ok(Event::End(ref e)) => {
-                    match e.name() {
-                        b"mruColors" => return,
-                        _ => (),
-                    }
+                Ok(Event::End(ref e)) => match e.name() {
+                    b"mruColors" => return,
+                    _ => (),
                 },
                 Ok(Event::Eof) => panic!("Error not find {} end element", "mruColors"),
                 Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),

--- a/src/structs/numbering_format.rs
+++ b/src/structs/numbering_format.rs
@@ -125,9 +125,9 @@ impl NumberingFormat {
         )))
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart,
     ) {
         self.number_format_id = get_attribute(e, b"numFmtId").unwrap().parse::<u32>().unwrap();

--- a/src/structs/numbering_formats.rs
+++ b/src/structs/numbering_formats.rs
@@ -65,9 +65,9 @@ impl NumberingFormats {
         }
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart,
     ) {
         let mut buf = Vec::new();

--- a/src/structs/office2010/drawing/charts/style.rs
+++ b/src/structs/office2010/drawing/charts/style.rs
@@ -20,9 +20,9 @@ impl Style {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val = get_attribute(e, b"val").unwrap();

--- a/src/structs/pane.rs
+++ b/src/structs/pane.rs
@@ -68,9 +68,9 @@ impl Pane {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
     ) {
         match get_attribute(e, b"xSplit") {

--- a/src/structs/pattern_fill.rs
+++ b/src/structs/pattern_fill.rs
@@ -1,13 +1,13 @@
 // patternFill
-use super::PatternValues;
-use super::EnumValue;
 use super::Color;
-use writer::driver::*;
-use reader::driver::*;
+use super::EnumValue;
+use super::PatternValues;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Default, Debug, Clone)]
 pub struct PatternFill {
@@ -16,58 +16,78 @@ pub struct PatternFill {
     background_color: Option<Color>,
 }
 impl PatternFill {
-    pub fn get_pattern_type(&self)-> &PatternValues {
+    pub fn get_pattern_type(&self) -> &PatternValues {
         &self.pattern_type.get_value()
     }
 
-    pub fn set_pattern_type(&mut self, value:PatternValues)-> &mut Self {
+    pub fn set_pattern_type(&mut self, value: PatternValues) -> &mut Self {
         self.pattern_type.set_value(value);
         self
     }
 
-    pub fn get_foreground_color(&self)-> &Option<Color> {
+    pub fn get_foreground_color(&self) -> &Option<Color> {
         &self.foreground_color
     }
 
-    pub fn get_foreground_color_mut(&mut self)-> &mut Option<Color> {
+    pub fn get_foreground_color_mut(&mut self) -> &mut Option<Color> {
         &mut self.foreground_color
     }
 
-    pub fn set_foreground_color(&mut self, value:Color)-> &mut Self {
+    pub fn set_foreground_color(&mut self, value: Color) -> &mut Self {
         self.foreground_color = Some(value);
         self
     }
 
-    pub fn get_background_color(&self)-> &Option<Color> {
+    pub fn get_background_color(&self) -> &Option<Color> {
         &self.background_color
     }
 
-    pub fn get_background_color_mut(&mut self)-> &mut Option<Color> {
+    pub fn get_background_color_mut(&mut self) -> &mut Option<Color> {
         &mut self.background_color
     }
 
-    pub fn set_background_color(&mut self, value:Color)-> &mut Self {
+    pub fn set_background_color(&mut self, value: Color) -> &mut Self {
         self.background_color = Some(value);
         self
     }
 
-    pub(crate) fn get_hash_code(&self)-> String {
-        format!("{:x}", md5::compute(format!("{}{}{}",
-            &self.pattern_type.get_value_string(),
-            match &self.foreground_color {Some(v) => {v.get_hash_code()}, None => {"None".into()}},
-            match &self.background_color {Some(v) => {v.get_hash_code()}, None => {"None".into()}},
-        )))
+    pub(crate) fn get_hash_code(&self) -> String {
+        format!(
+            "{:x}",
+            md5::compute(format!(
+                "{}{}{}",
+                &self.pattern_type.get_value_string(),
+                match &self.foreground_color {
+                    Some(v) => {
+                        v.get_hash_code()
+                    }
+                    None => {
+                        "None".into()
+                    }
+                },
+                match &self.background_color {
+                    Some(v) => {
+                        v.get_hash_code()
+                    }
+                    None => {
+                        "None".into()
+                    }
+                },
+            ))
+        )
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        e:&BytesStart,
+        reader: &mut Reader<R>,
+        e: &BytesStart,
         empty_flag: bool,
     ) {
         match get_attribute(e, b"patternType") {
-            Some(v) => { self.pattern_type.set_value_string(v); },
-            None => {},
+            Some(v) => {
+                self.pattern_type.set_value_string(v);
+            }
+            None => {}
         }
 
         if empty_flag {
@@ -77,26 +97,22 @@ impl PatternFill {
         let mut buf = Vec::new();
         loop {
             match reader.read_event(&mut buf) {
-                Ok(Event::Empty(ref e)) => {
-                    match e.name() {
-                        b"fgColor" => {
-                            let mut obj = Color::default();
-                            obj.set_attributes(reader, e);
-                            &mut self.set_foreground_color(obj);
-                        },
-                        b"bgColor" => {
-                            let mut obj = Color::default();
-                            obj.set_attributes(reader, e);
-                            &mut self.set_background_color(obj);
-                        },
-                        _ => (),
+                Ok(Event::Empty(ref e)) => match e.name() {
+                    b"fgColor" => {
+                        let mut obj = Color::default();
+                        obj.set_attributes(reader, e);
+                        &mut self.set_foreground_color(obj);
                     }
+                    b"bgColor" => {
+                        let mut obj = Color::default();
+                        obj.set_attributes(reader, e);
+                        &mut self.set_background_color(obj);
+                    }
+                    _ => (),
                 },
-                Ok(Event::End(ref e)) => {
-                    match e.name() {
-                        b"patternFill" => return,
-                        _ => (),
-                    }
+                Ok(Event::End(ref e)) => match e.name() {
+                    b"patternFill" => return,
+                    _ => (),
                 },
                 Ok(Event::Eof) => panic!("Error not find {} end element", "patternFill"),
                 Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
@@ -119,14 +135,18 @@ impl PatternFill {
         if empty_flag == false {
             // fgColor
             match &self.foreground_color {
-                Some(v) => { v.write_to_fg_color(writer); },
-                None => {},
+                Some(v) => {
+                    v.write_to_fg_color(writer);
+                }
+                None => {}
             }
 
             // bgColor
             match &self.background_color {
-                Some(v) => { v.write_to_bg_color(writer); },
-                None => {},
+                Some(v) => {
+                    v.write_to_bg_color(writer);
+                }
+                None => {}
             }
 
             write_end_tag(writer, "patternFill");

--- a/src/structs/phonetic_run.rs
+++ b/src/structs/phonetic_run.rs
@@ -9,9 +9,9 @@ pub(crate) struct PhoneticRun {
 
 }
 impl PhoneticRun {
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/row.rs
+++ b/src/structs/row.rs
@@ -113,9 +113,9 @@ impl Row {
         }
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         worksheet: &mut Worksheet,
         shared_string_table: &SharedStringTable,

--- a/src/structs/run_properties.rs
+++ b/src/structs/run_properties.rs
@@ -332,9 +332,9 @@ impl RunProperties {
         )))
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/selection.rs
+++ b/src/structs/selection.rs
@@ -51,9 +51,9 @@ impl Selection {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart,
     ) {
         match get_attribute(e, b"pane") {

--- a/src/structs/shared_string_item.rs
+++ b/src/structs/shared_string_item.rs
@@ -1,13 +1,13 @@
 // si
-use super::Text;
-use super::RichText;
-use super::TextElement;
 use super::PhoneticRun;
-use writer::driver::*;
+use super::RichText;
+use super::Text;
+use super::TextElement;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct SharedStringItem {
@@ -15,15 +15,15 @@ pub(crate) struct SharedStringItem {
     rich_text: Option<RichText>,
 }
 impl SharedStringItem {
-    pub(crate) fn get_text(&self)-> &Option<Text> {
+    pub(crate) fn get_text(&self) -> &Option<Text> {
         &self.text
     }
 
-    pub(crate) fn get_text_mut(&mut self)-> &mut Option<Text> {
+    pub(crate) fn get_text_mut(&mut self) -> &mut Option<Text> {
         &mut self.text
     }
 
-    pub(crate) fn set_text(&mut self, value:Text) -> &mut Self {
+    pub(crate) fn set_text(&mut self, value: Text) -> &mut Self {
         self.text = Some(value);
         self
     }
@@ -33,83 +33,99 @@ impl SharedStringItem {
         self
     }
 
-    pub(crate) fn get_rich_text(&self)-> &Option<RichText> {
+    pub(crate) fn get_rich_text(&self) -> &Option<RichText> {
         &self.rich_text
     }
 
-    pub(crate) fn get_rich_text_mut(&mut self)-> &mut Option<RichText> {
+    pub(crate) fn get_rich_text_mut(&mut self) -> &mut Option<RichText> {
         &mut self.rich_text
     }
 
-    pub(crate) fn set_rich_text(&mut self, value:RichText)-> &mut Self {
+    pub(crate) fn set_rich_text(&mut self, value: RichText) -> &mut Self {
         self.rich_text = Some(value);
         self
     }
 
-    pub(crate) fn remove_rich_text(&mut self)-> &mut Self {
+    pub(crate) fn remove_rich_text(&mut self) -> &mut Self {
         self.rich_text = None;
         self
     }
 
-    pub(crate) fn get_value(&self)-> &str {
+    pub(crate) fn get_value(&self) -> &str {
         match &self.text {
-            Some(v) => {return v.get_value();},
-            None => {},
+            Some(v) => {
+                return v.get_value();
+            }
+            None => {}
         }
         match &self.rich_text {
             Some(v) => {
                 return v.get_text();
-            },
-            None => {},
+            }
+            None => {}
         }
         ""
     }
 
-    pub(crate) fn get_hash_code(&self)-> String {
-        format!("{:x}", md5::compute(format!("{}{}",
-            match &self.text {Some(v) => {v.get_hash_code()}, None => {String::from("NONE")}},
-            match &self.rich_text {Some(v) => {v.get_hash_code()}, None => {String::from("NONE")}}
-        )))
+    pub(crate) fn get_hash_code(&self) -> String {
+        format!(
+            "{:x}",
+            md5::compute(format!(
+                "{}{}",
+                match &self.text {
+                    Some(v) => {
+                        v.get_hash_code()
+                    }
+                    None => {
+                        String::from("NONE")
+                    }
+                },
+                match &self.rich_text {
+                    Some(v) => {
+                        v.get_hash_code()
+                    }
+                    None => {
+                        String::from("NONE")
+                    }
+                }
+            ))
+        )
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        _e:&BytesStart
+        reader: &mut Reader<R>,
+        _e: &BytesStart,
     ) {
         let mut vec_text_element: Vec<TextElement> = Vec::new();
         let mut buf = Vec::new();
         loop {
             match reader.read_event(&mut buf) {
-                Ok(Event::Start(ref e)) => {
-                    match e.name() {
-                        b"t" => {
-                            let mut obj = Text::default();
-                            obj.set_attributes(reader, e);
-                            self.set_text(obj);
-                        },
-                        b"r" => {
-                            let mut obj = TextElement::default();
-                            obj.set_attributes(reader, e);
-                            vec_text_element.push(obj);
-                        },
-                        b"rPh" => {
-                            let mut obj = PhoneticRun::default();
-                            obj.set_attributes(reader, e);
-                        },
-                        _ => (),
+                Ok(Event::Start(ref e)) => match e.name() {
+                    b"t" => {
+                        let mut obj = Text::default();
+                        obj.set_attributes(reader, e);
+                        self.set_text(obj);
                     }
+                    b"r" => {
+                        let mut obj = TextElement::default();
+                        obj.set_attributes(reader, e);
+                        vec_text_element.push(obj);
+                    }
+                    b"rPh" => {
+                        let mut obj = PhoneticRun::default();
+                        obj.set_attributes(reader, e);
+                    }
+                    _ => (),
                 },
-                Ok(Event::End(ref e)) => {
-                    match e.name() {
-                        b"si" => {
-                            let mut obj = RichText::default();
-                            obj.set_rich_text_elements(vec_text_element);
-                            self.set_rich_text(obj);
-                            return
-                        },
-                        _ => (),
+                Ok(Event::End(ref e)) => match e.name() {
+                    b"si" => {
+                        let mut obj = RichText::default();
+                        obj.set_rich_text_elements(vec_text_element);
+                        self.set_rich_text(obj);
+                        return;
                     }
+                    _ => (),
                 },
                 Ok(Event::Eof) => panic!("Error not find {} end element", "si"),
                 Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
@@ -125,19 +141,21 @@ impl SharedStringItem {
 
         // t
         match &self.text {
-            Some(v) => {v.write_to(writer);},
-            None => {},
+            Some(v) => {
+                v.write_to(writer);
+            }
+            None => {}
         }
 
         // r
         match &self.rich_text {
-            Some(v) => {v.write_to_none(writer);},
-            None => {},
+            Some(v) => {
+                v.write_to_none(writer);
+            }
+            None => {}
         }
 
-        write_start_tag(writer, "phoneticPr", vec![
-            ("fontId", "1"),
-        ], true);
+        write_start_tag(writer, "phoneticPr", vec![("fontId", "1")], true);
 
         write_end_tag(writer, "si");
     }

--- a/src/structs/shared_string_table.rs
+++ b/src/structs/shared_string_table.rs
@@ -1,12 +1,12 @@
 // sst
-use super::SharedStringItem;
 use super::CellValue;
+use super::SharedStringItem;
 use super::Text;
-use writer::driver::*;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct SharedStringTable {
@@ -14,25 +14,25 @@ pub(crate) struct SharedStringTable {
     regist_count: usize,
 }
 impl SharedStringTable {
-    pub(crate) fn get_shared_string_item(&self)-> &Vec<SharedStringItem> {
+    pub(crate) fn get_shared_string_item(&self) -> &Vec<SharedStringItem> {
         &self.shared_string_item
     }
 
-    pub(crate) fn get_shared_string_item_mut(&mut self)-> &mut Vec<SharedStringItem> {
+    pub(crate) fn get_shared_string_item_mut(&mut self) -> &mut Vec<SharedStringItem> {
         &mut self.shared_string_item
     }
 
-    pub(crate) fn set_shared_string_item(&mut self, value:SharedStringItem)-> &mut Self {
+    pub(crate) fn set_shared_string_item(&mut self, value: SharedStringItem) -> &mut Self {
         self.shared_string_item.push(value);
         self
     }
 
-    pub(crate) fn init_setup(&mut self)-> &mut Self {
+    pub(crate) fn init_setup(&mut self) -> &mut Self {
         self.shared_string_item.clear();
         self
     }
 
-    pub(crate) fn set_cell(&mut self, value:&CellValue) -> u32 {
+    pub(crate) fn set_cell(&mut self, value: &CellValue) -> u32 {
         self.regist_count += 1;
 
         let mut shared_string_item = SharedStringItem::default();
@@ -41,13 +41,13 @@ impl SharedStringTable {
                 let mut text = Text::default();
                 text.set_value(v);
                 shared_string_item.set_text(text);
-            },
+            }
             None => {}
         }
         match value.get_rich_text() {
             Some(v) => {
                 shared_string_item.set_rich_text(v.clone());
-            },
+            }
             None => {}
         }
 
@@ -63,29 +63,25 @@ impl SharedStringTable {
         return id;
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        _e:&BytesStart
+        reader: &mut Reader<R>,
+        _e: &BytesStart,
     ) {
         let mut buf = Vec::new();
         loop {
             match reader.read_event(&mut buf) {
-                Ok(Event::Start(ref e)) => {
-                    match e.name() {
-                        b"si" => {
-                            let mut obj = SharedStringItem::default();
-                            obj.set_attributes(reader, e);
-                            self.set_shared_string_item(obj);
-                        },
-                        _ => (),
+                Ok(Event::Start(ref e)) => match e.name() {
+                    b"si" => {
+                        let mut obj = SharedStringItem::default();
+                        obj.set_attributes(reader, e);
+                        self.set_shared_string_item(obj);
                     }
+                    _ => (),
                 },
-                Ok(Event::End(ref e)) => {
-                    match e.name() {
-                        b"sst" => return,
-                        _ => (),
-                    }
+                Ok(Event::End(ref e)) => match e.name() {
+                    b"sst" => return,
+                    _ => (),
                 },
                 Ok(Event::Eof) => panic!("Error not find {} end element", "sst"),
                 Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
@@ -97,11 +93,22 @@ impl SharedStringTable {
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // sst
-        write_start_tag(writer, "sst", vec![
-            ("xmlns", "http://schemas.openxmlformats.org/spreadsheetml/2006/main"),
-            ("count", self.regist_count.to_string().as_str()),
-            ("uniqueCount", self.shared_string_item.len().to_string().as_str()),
-        ], false);
+        write_start_tag(
+            writer,
+            "sst",
+            vec![
+                (
+                    "xmlns",
+                    "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+                ),
+                ("count", self.regist_count.to_string().as_str()),
+                (
+                    "uniqueCount",
+                    self.shared_string_item.len().to_string().as_str(),
+                ),
+            ],
+            false,
+        );
 
         // si
         for obj in &self.shared_string_item {

--- a/src/structs/sheet_view.rs
+++ b/src/structs/sheet_view.rs
@@ -62,9 +62,9 @@ impl SheetView {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         e:&BytesStart,
         empty_flag:bool,
     ) {

--- a/src/structs/strike.rs
+++ b/src/structs/strike.rs
@@ -21,9 +21,9 @@ impl Strike {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.val.set_value(true);

--- a/src/structs/stylesheet.rs
+++ b/src/structs/stylesheet.rs
@@ -302,9 +302,9 @@ impl Stylesheet {
         self.cell_formats.set_cell_format_crate(cell_format)
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         self.numbering_formats.get_build_in_formats();

--- a/src/structs/text.rs
+++ b/src/structs/text.rs
@@ -1,47 +1,43 @@
 // t
-use writer::driver::*;
+use onig::*;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
 use std::io::Cursor;
-use onig::*;
+use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct Text {
     value: String,
 }
 impl Text {
-    pub(crate) fn get_value(&self)-> &str {
+    pub(crate) fn get_value(&self) -> &str {
         &self.value
     }
 
-    pub(crate) fn set_value<S: Into<String>>(&mut self, value:S) -> &mut Self {
+    pub(crate) fn set_value<S: Into<String>>(&mut self, value: S) -> &mut Self {
         self.value = value.into();
         self
     }
 
-    pub(crate) fn get_hash_code(&self)-> String {
-        format!("{:x}", md5::compute(format!("{}",
-            self.value
-        )))
+    pub(crate) fn get_hash_code(&self) -> String {
+        format!("{:x}", md5::compute(format!("{}", self.value)))
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        _e:&BytesStart
+        reader: &mut Reader<R>,
+        _e: &BytesStart,
     ) {
         let mut buf = Vec::new();
         loop {
             match reader.read_event(&mut buf) {
                 Ok(Event::Text(e)) => {
                     self.set_value(e.unescape_and_decode(&reader).unwrap());
-                },
-                Ok(Event::End(ref e)) => {
-                    match e.name() {
-                        b"t" => return,
-                        _ => (),
-                    }
+                }
+                Ok(Event::End(ref e)) => match e.name() {
+                    b"t" => return,
+                    _ => (),
                 },
                 Ok(Event::Eof) => panic!("Error not find {} end element", "t"),
                 Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
@@ -56,7 +52,7 @@ impl Text {
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         let re = Regex::new(r#"^(\s|　)"#).unwrap();
         if re.find(&self.value).is_some() {
-            attributes.push(("xml:space" , "preserve"));
+            attributes.push(("xml:space", "preserve"));
         }
         write_start_tag(writer, "t", attributes, false);
         write_text_node(writer, &self.value);

--- a/src/structs/text_element.rs
+++ b/src/structs/text_element.rs
@@ -63,9 +63,9 @@ impl TextElement  {
         )))
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        reader:&mut Reader<R>,
         _e:&BytesStart
     ) {
         let mut buf = Vec::new();

--- a/src/structs/underline.rs
+++ b/src/structs/underline.rs
@@ -26,9 +26,9 @@ impl Underline  {
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
+        _reader:&mut Reader<R>,
         e:&BytesStart
     ) {
         self.set_val(UnderlineValues::default());

--- a/src/structs/vertical_text_alignment.rs
+++ b/src/structs/vertical_text_alignment.rs
@@ -1,44 +1,49 @@
 // vertAlign
-use super::VerticalAlignmentRunValues;
 use super::EnumValue;
-use writer::driver::*;
-use reader::driver::*;
+use super::VerticalAlignmentRunValues;
+use quick_xml::events::BytesStart;
 use quick_xml::Reader;
-use quick_xml::events::{BytesStart};
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct VerticalTextAlignment {
     pub(crate) val: EnumValue<VerticalAlignmentRunValues>,
 }
 impl VerticalTextAlignment {
-    pub fn get_val(&self)-> &VerticalAlignmentRunValues {
+    pub fn get_val(&self) -> &VerticalAlignmentRunValues {
         &self.val.get_value()
     }
 
-    pub fn set_val(&mut self, value:VerticalAlignmentRunValues)-> &mut Self {
+    pub fn set_val(&mut self, value: VerticalAlignmentRunValues) -> &mut Self {
         self.val.set_value(value);
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        e:&BytesStart
+        _reader: &mut Reader<R>,
+        e: &BytesStart,
     ) {
         match get_attribute(e, b"val") {
-            Some(v) => {self.val.set_value_string(v);},
-            None => {},
+            Some(v) => {
+                self.val.set_value_string(v);
+            }
+            None => {}
         }
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // vertAlign
         if &self.val.has_value() == &true {
-            write_start_tag(writer, "vertAlign", vec![
-                ("val", &self.val.get_value_string()),
-            ], true);
+            write_start_tag(
+                writer,
+                "vertAlign",
+                vec![("val", &self.val.get_value_string())],
+                true,
+            );
         }
     }
 }

--- a/src/structs/workbook_view.rs
+++ b/src/structs/workbook_view.rs
@@ -1,10 +1,10 @@
 use super::UInt32Value;
-use writer::driver::*;
-use reader::driver::*;
+use quick_xml::events::BytesStart;
 use quick_xml::Reader;
-use quick_xml::events::{BytesStart};
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
+use writer::driver::*;
 
 #[derive(Default, Debug)]
 pub struct WorkbookView {
@@ -15,28 +15,25 @@ impl WorkbookView {
         &self.active_tab.get_value()
     }
 
-    pub fn set_active_tab(&mut self, value:u32) -> &mut Self {
+    pub fn set_active_tab(&mut self, value: u32) -> &mut Self {
         self.active_tab.set_value(value);
         self
     }
 
-    pub(crate) fn set_attributes(
+    pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        _reader:&mut Reader<std::io::BufReader<std::fs::File>>,
-        e:&BytesStart,
+        _reader: &mut Reader<R>,
+        e: &BytesStart,
     ) {
         match get_attribute(e, b"activeTab") {
             Some(v) => {
                 self.active_tab.set_value_string(v);
-            },
+            }
             None => {}
         }
     }
-    
-    pub(crate) fn write_to(
-        &self,
-        writer: &mut Writer<Cursor<Vec<u8>>>,
-    ) {
+
+    pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // selection
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         attributes.push(("xWindow", "240"));

--- a/src/writer/xlsx.rs
+++ b/src/writer/xlsx.rs
@@ -59,7 +59,13 @@ impl From<FromUtf8Error> for XlsxError {
     }
 }
 
-pub(crate) fn write_crate<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, writer: W) -> Result<(), XlsxError> {
+/// write spreadsheet file to arbitrary writer.
+/// # Arguments
+/// * `spreadsheet` - Spreadsheet structs object.
+/// * `writer` - writer to write to.
+/// # Return value
+/// * `Result` - OK is void. Err is error message. 
+pub fn write_writer<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, writer: W) -> Result<(), XlsxError> {
     let mut arv = zip::ZipWriter::new(writer);
 
     // Add Content_Types
@@ -144,5 +150,5 @@ pub(crate) fn write_crate<W: io::Seek + io::Write>(spreadsheet: &Spreadsheet, wr
 /// let _ = umya_spreadsheet::writer::xlsx::write(&book, path);
 /// ```
 pub fn write(spreadsheet: &Spreadsheet, path: &Path) -> Result<(), XlsxError> {
-    write_crate(spreadsheet, &mut io::BufWriter::new(fs::File::create(path)?))
+    write_writer(spreadsheet, &mut io::BufWriter::new(fs::File::create(path)?))
 }


### PR DESCRIPTION
So I've made a similar change to my previous PR for making the writer accept any io::Write trait, but this time for the reader (allowing any io::Read). There's a number of formatting changes in other files from an automated refactor where cargo fmt ran automatically. I hope that's ok. if not, let me know, and I may try to to the refactor again, but it would take at least an hour or two.
This also decouples the code entirely from using the filesystem, both for the read and write API, as well as removing the dependence on the temp directory on a file system.

Happy to give you more details on the changes involved.