### PR TITLE
Fixes XLOOKUP function in excel

### DIFF
--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -236,6 +236,13 @@ impl Cell {
         &self.cell_value.get_formula()
     }
 
+    pub(crate) fn get_formula_attributes(&self) -> Vec<(&str, &str)> {
+        self.cell_value.get_formula_attributes()
+    }
+    pub(crate) fn set_formula_attributes(&mut self, attributes: Vec<(String, String)>) {
+        self.cell_value.set_formula_attributes(attributes);
+    }
+
     pub(crate) fn get_width_point(&self, column_font_size: &f64) -> f64 {
         // get cell value len.
         let char_cnt = self.get_width_point_cell();
@@ -331,6 +338,22 @@ impl Cell {
         loop {
             match reader.read_event(&mut buf) {
                 Ok(Event::Text(e)) => string_value = e.unescape_and_decode(&reader).unwrap(),
+                Ok(Event::Start(ref s)) => {
+                    if s.name() == b"f" {
+                        let mut attrs = vec![];
+                        s.attributes().for_each(|a| {
+                            if let Ok(attribute) = a {
+                                if let (Ok(key), Ok(value)) = (
+                                    std::str::from_utf8(attribute.key),
+                                    std::str::from_utf8(attribute.value.as_ref()),
+                                ) {
+                                    attrs.push((key.to_owned(), value.to_owned()));
+                                }
+                            }
+                        });
+                        self.set_formula_attributes(attrs);
+                    }
+                }
                 Ok(Event::End(ref e)) => match e.name() {
                     b"f" => {
                         self.set_formula(string_value.clone());
@@ -382,13 +405,13 @@ impl Cell {
             xf_index_str = xf_index.to_string();
             attributes.push(("s", &xf_index_str));
         }
-        write_start_tag(writer, "c", attributes, empty_flag);
 
         if empty_flag == false {
+            write_start_tag(writer, "c", attributes, empty_flag);
             // f
             match &self.cell_value.formula {
                 Some(v) => {
-                    write_start_tag(writer, "f", vec![], false);
+                    write_start_tag(writer, "f", self.get_formula_attributes(), false);
                     write_text_node(writer, v);
                     write_end_tag(writer, "f");
                 }

--- a/src/structs/cell_value.rs
+++ b/src/structs/cell_value.rs
@@ -9,6 +9,7 @@ pub struct CellValue {
     pub(crate) value: Option<String>,
     pub(crate) rich_text: Option<RichText>,
     pub(crate) formula: Option<String>,
+    pub(crate) formula_attributes: Vec<(String, String)>,
 }
 impl CellValue {
     // Data types
@@ -21,6 +22,15 @@ impl CellValue {
     pub const TYPE_INLINE: &'static str = "inlineStr";
     pub const TYPE_ERROR: &'static str = "e";
 
+    pub fn set_formula_attributes(&mut self, formula_attributes: Vec<(String, String)>) {
+        self.formula_attributes = formula_attributes;
+    }
+    pub fn get_formula_attributes(&self) -> Vec<(&str, &str)> {
+        self.formula_attributes
+            .iter()
+            .map(|(a, b)| (a.as_str(), b.as_str()))
+            .collect()
+    }
     pub fn get_value(&self) -> &str {
         match &self.value {
             Some(v) => {


### PR DESCRIPTION
When using a `XLOOKUP` function, which results in multiple values, excel seems to put some xml attributes on the formula element (`t=arr` and `ref=START:END`). This pull request just parses all attributes and puts all of them back as they were present when the spread sheet was opened. Adding those attributes let's Excel correctly show the XLOOKUP. There is still some difference to the original Excel version though, which probably needs further investigation.

Further, this PR fixes a problem, when a `empty_tag` was not false. In this case, a `c` start-tag would have been emitted, without the corresponding end tag (since the end tag was within the if clause).