### PR TITLE
remove onig and use regex instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ description = "umya-spreadsheet is a library written in pure Rust and read and w
 
 [dependencies]
 quick-xml = { version = "0.17", features = [ "serialize" ] }
-zip = "0.5.6"
+zip = {version = "0.5.6", default-features = false, features = ["deflate"]}
 regex = "1.3.7"
 md-5 = "0.10.1"
 lazy_static = "1.4.0"
 thousands = "0.2.0"
-onig = { version = "6.1.1", default-features = false }
+# onig = { version = "6.1.1", default-features = false }
 chrono = "0.4.19"
 encoding_rs = "0.8.30"
 image = "0.24.1"

--- a/src/helper/formula.rs
+++ b/src/helper/formula.rs
@@ -1,5 +1,5 @@
 use helper::coordinate::*;
-use onig::*;
+use regex::{Regex, Captures};
 
 pub fn adjustment_insert_formula_coordinate(
     formula: &str,
@@ -11,10 +11,9 @@ pub fn adjustment_insert_formula_coordinate(
     self_worksheet_name: &str,
 ) -> String {
     let re = Regex::new(r#"[^\(]*!*[A-Z]+[0-9]+\:[A-Z]+[0-9]+"#).unwrap();
-
-    re.replace_all(formula, |caps: &Captures| {
-        let caps_string: String = caps.at(0).unwrap().parse().unwrap();
-        let split_str: Vec<&str> = caps_string.split('!').collect();
+    let result = re.replace_all(formula, |caps: &Captures| {
+        let caps_string = (&caps.get(0).unwrap()).as_str().to_string();
+        let split_str: Vec<&str> = caps_string.split("!").collect();
         let with_wksheet: bool;
         let wksheet: String;
         let range: String;
@@ -51,7 +50,8 @@ pub fn adjustment_insert_formula_coordinate(
             result = format!("{}!{}", wksheet, result);
         }
         result
-    })
+    });
+    result.to_string()
 }
 
 pub fn adjustment_remove_formula_coordinate(
@@ -64,10 +64,9 @@ pub fn adjustment_remove_formula_coordinate(
     self_worksheet_name: &str,
 ) -> String {
     let re = Regex::new(r#"[^\(]*!*[A-Z]+[0-9]+\:[A-Z]+[0-9]+"#).unwrap();
-
-    re.replace_all(formula, |caps: &Captures| {
-        let caps_string: String = caps.at(0).unwrap().parse().unwrap();
-        let split_str: Vec<&str> = caps_string.split('!').collect();
+    let result = re.replace_all(formula, |caps: &Captures| {
+        let caps_string = (&caps.get(0).unwrap()).as_str().to_string();
+        let split_str: Vec<&str> = caps_string.split("!").collect();
         let with_wksheet: bool;
         let wksheet: String;
         let range: String;
@@ -104,5 +103,6 @@ pub fn adjustment_remove_formula_coordinate(
             result = format!("{}!{}", wksheet, result);
         }
         result
-    })
+    });
+    result.into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@
 extern crate chrono;
 extern crate image;
 extern crate md5;
-extern crate onig;
+// extern crate onig;
 extern crate quick_xml;
 extern crate regex;
 extern crate thousands;

--- a/src/structs/text.rs
+++ b/src/structs/text.rs
@@ -1,9 +1,10 @@
 // t
 use md5::Digest;
-use onig::*;
+// use onig::*;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use regex::Regex;
 use std::io::Cursor;
 use writer::driver::*;
 


### PR DESCRIPTION
PR for https://github.com/MathNya/umya-spreadsheet/issues/41

This PR removes `onig` and relays on `regex` instead. Further only the `flate2` dependency with `rust_backend` feature is used (`bzip2` disabled), such that it can be built for wasm.

