### PR TITLE
Set column and row index to one

### DIFF
--- a/src/structs/column_reference.rs
+++ b/src/structs/column_reference.rs
@@ -1,10 +1,20 @@
 use helper::coordinate::*;
 
-#[derive(Clone, Default, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ColumnReference {
     num: u32,
     is_lock: bool,
 }
+
+impl Default for ColumnReference {
+    fn default() -> Self {
+        Self {
+            num: 1,
+            is_lock: false,
+        }
+    }
+}
+
 impl ColumnReference {
     pub fn get_num(&self) -> &u32 {
         &self.num

--- a/src/structs/row_reference.rs
+++ b/src/structs/row_reference.rs
@@ -1,10 +1,20 @@
 use helper::coordinate::*;
 
-#[derive(Clone, Default, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct RowReference {
     num: u32,
     is_lock: bool,
 }
+
+impl Default for RowReference {
+    fn default() -> Self {
+        Self {
+            num: 1,
+            is_lock: false,
+        }
+    }
+}
+
 impl RowReference {
     pub fn get_num(&self) -> &u32 {
         &self.num


### PR DESCRIPTION
When adding a comment to a xlsx sheet the process panics due to the index currently starting at 0 by default. This doesn't work as indices start at 1 in the sheet, so it makes sense to adjust the default value.