### PR TITLE
[Update] refactor index_from_coordinate

### DIFF
--- a/src/helper/coordinate.rs
+++ b/src/helper/coordinate.rs
@@ -73,15 +73,17 @@ pub fn coordinate_from_string(coordinate: &str) -> [Option<&str>; 4] {
         let col = v.get(3).map(|v| v.as_str()); // col number: [A-Z]{1,3}
         let row = v.get(6).map(|v| v.as_str()); // row number: [0-9]+
 
-        let lock_col_flg = v
-            .get(2) // col lock flag: \$
-            .map(|_v| "1")
-            .or_else(|| if col.is_some() { Some("0") } else { None });
+        let lock_col_flg = col.map(|_col| {
+            v.get(2) // col lock flag: (\$)?
+                .map(|_v| "1")
+                .unwrap_or("0")
+        });
 
-        let lock_row_flg = v
-            .get(5) // row lock flag: \$
-            .map(|_v| "1")
-            .or_else(|| if row.is_some() { Some("0") } else { None });
+        let lock_row_flg = row.map(|_row| {
+            v.get(5) // row lock flag: (\$)?
+                .map(|_v| "1")
+                .unwrap_or("0")
+        });
 
         [col, row, lock_col_flg, lock_row_flg]
     })

--- a/src/helper/formula.rs
+++ b/src/helper/formula.rs
@@ -17,6 +17,7 @@ pub fn adjustment_insert_formula_coordinate(
         let with_wksheet: bool;
         let wksheet: String;
         let range: String;
+
         if split_str.len() == 2 {
             with_wksheet = true;
             wksheet = split_str.get(0).unwrap().to_string();
@@ -26,32 +27,45 @@ pub fn adjustment_insert_formula_coordinate(
             wksheet = self_worksheet_name.to_string();
             range = split_str.get(0).unwrap().to_string();
         }
+
         if &wksheet != &worksheet_name {
             return caps_string;
         }
+
         let split_range: Vec<&str> = range.split(':').collect();
         let mut result = String::from("");
+
         for coordinate in split_range {
             let index_coordinate = index_from_coordinate(coordinate);
-            let mut col_num = index_coordinate[0].unwrap();
-            let mut row_num = index_coordinate[1].unwrap();
-            let is_lock_col = index_coordinate[2].unwrap() == 1;
-            let is_lock_row = index_coordinate[3].unwrap() == 1;
-            col_num = adjustment_insert_coordinate(&col_num, root_col_num, offset_col_num);
-            row_num = adjustment_insert_coordinate(&row_num, root_row_num, offset_row_num);
+            let is_lock_col = index_coordinate.2.unwrap();
+            let is_lock_row = index_coordinate.3.unwrap();
+            let col_num = adjustment_insert_coordinate(
+                &index_coordinate.0.unwrap(),
+                root_col_num,
+                offset_col_num,
+            );
+            let row_num = adjustment_insert_coordinate(
+                &index_coordinate.1.unwrap(),
+                root_row_num,
+                offset_row_num,
+            );
             let new_corrdinate =
                 coordinate_from_index_with_lock(&col_num, &row_num, &is_lock_col, &is_lock_row);
+
             if !&result.is_empty() {
                 result = format!("{}:", result);
             }
             result = format!("{}{}", result, new_corrdinate);
         }
+
         if with_wksheet {
             result = format!("{}!{}", wksheet, result);
         }
+
         result
     });
-    result.to_string()
+
+    result.into()
 }
 
 pub fn adjustment_remove_formula_coordinate(
@@ -70,6 +84,7 @@ pub fn adjustment_remove_formula_coordinate(
         let with_wksheet: bool;
         let wksheet: String;
         let range: String;
+
         if split_str.len() == 2 {
             with_wksheet = true;
             wksheet = split_str.get(0).unwrap().to_string();
@@ -79,30 +94,44 @@ pub fn adjustment_remove_formula_coordinate(
             wksheet = self_worksheet_name.to_string();
             range = split_str.get(0).unwrap().to_string();
         }
+
         if &wksheet != &worksheet_name {
             return caps_string;
         }
+
         let split_range: Vec<&str> = range.split(':').collect();
         let mut result = String::from("");
+
         for coordinate in split_range {
             let index_coordinate = index_from_coordinate(coordinate);
-            let mut col_num = index_coordinate[0].unwrap();
-            let mut row_num = index_coordinate[1].unwrap();
-            let is_lock_col = index_coordinate[2].unwrap() == 1;
-            let is_lock_row = index_coordinate[3].unwrap() == 1;
-            col_num = adjustment_remove_coordinate(&col_num, root_col_num, offset_col_num);
-            row_num = adjustment_remove_coordinate(&row_num, root_row_num, offset_row_num);
+            let is_lock_col = index_coordinate.2.unwrap();
+            let is_lock_row = index_coordinate.3.unwrap();
+            let col_num = adjustment_remove_coordinate(
+                &index_coordinate.0.unwrap(),
+                root_col_num,
+                offset_col_num,
+            );
+            let row_num = adjustment_remove_coordinate(
+                &index_coordinate.1.unwrap(),
+                root_row_num,
+                offset_row_num,
+            );
             let new_corrdinate =
                 coordinate_from_index_with_lock(&col_num, &row_num, &is_lock_col, &is_lock_row);
+
             if !&result.is_empty() {
                 result = format!("{}:", result);
             }
+
             result = format!("{}{}", result, new_corrdinate);
         }
+
         if with_wksheet {
             result = format!("{}!{}", wksheet, result);
         }
+
         result
     });
+
     result.into()
 }

--- a/src/helper/range.rs
+++ b/src/helper/range.rs
@@ -1,6 +1,11 @@
 use helper::coordinate::*;
 
-pub fn get_coordinate_list(range_str: &str) -> Vec<(u32, u32)> {
+/// `(col, row)`
+pub type BasicCellIndex = (u32, u32);
+
+/// # Returns
+/// `Vec<(col, row)>`
+pub fn get_coordinate_list(range_str: &str) -> Vec<BasicCellIndex> {
     let coordinate_collection: Vec<&str> = range_str.split(':').collect();
     if coordinate_collection.is_empty() || coordinate_collection.len() > 2 {
         panic!("Non-standard range.");
@@ -17,29 +22,26 @@ pub fn get_coordinate_list(range_str: &str) -> Vec<(u32, u32)> {
 
     if coordinate_collection.len() == 1 || coordinate_collection.len() == 2 {
         let coordinate_str = coordinate_collection[0].to_string();
-        let nums = index_from_coordinate(coordinate_str);
-        match nums[0] {
-            Some(v) => {
-                is_col_select = true;
-                col_start = v;
-                col_end = v;
-            }
-            None => {}
-        };
-        match nums[1] {
-            Some(v) => {
-                is_row_select = true;
-                row_start = v;
-                row_end = v;
-            }
-            None => {}
+        let (col, row, ..) = index_from_coordinate(coordinate_str);
+
+        if let Some(v) = col {
+            is_col_select = true;
+            col_start = v;
+            col_end = v;
+        }
+
+        if let Some(v) = row {
+            is_row_select = true;
+            row_start = v;
+            row_end = v;
         }
     }
 
     if coordinate_collection.len() == 2 {
         let coordinate_str = coordinate_collection[1].to_string();
-        let nums = index_from_coordinate(coordinate_str);
-        match nums[0] {
+        let (col, row, ..) = index_from_coordinate(coordinate_str);
+
+        match col {
             Some(v) => {
                 col_end = v;
             }
@@ -49,7 +51,8 @@ pub fn get_coordinate_list(range_str: &str) -> Vec<(u32, u32)> {
                 }
             }
         };
-        match nums[1] {
+
+        match row {
             Some(v) => {
                 row_end = v;
             }

--- a/src/structs/coordinate.rs
+++ b/src/structs/coordinate.rs
@@ -45,13 +45,12 @@ impl Coordinate {
     }
 
     pub fn set_coordinate<S: AsRef<str>>(&mut self, value: S) -> &mut Self {
-        let result = index_from_coordinate(value.as_ref());
-        if let [c, r, cl, rl] = result[0..4] {
-            self.column.set_num(c.unwrap());
-            self.row.set_num(r.unwrap());
-            self.column.set_is_lock_usize(cl.unwrap());
-            self.row.set_is_lock_usize(rl.unwrap());
-        };
+        let (c, r, cl, rl) = index_from_coordinate(value.as_ref());
+
+        self.column.set_num(c.unwrap());
+        self.row.set_num(r.unwrap());
+        self.column.set_is_lock(cl.unwrap());
+        self.row.set_is_lock(rl.unwrap());
 
         self
     }

--- a/src/structs/drawing/spreadsheet/marker_type.rs
+++ b/src/structs/drawing/spreadsheet/marker_type.rs
@@ -65,10 +65,9 @@ impl MarkerType {
     }
 
     pub fn set_coordinate<S: Into<String>>(&mut self, value: S) {
-        let value = value.into();
-        let result = index_from_coordinate(value.as_str());
-        self.col = result[0].unwrap() - 1;
-        self.row = result[1].unwrap() - 1;
+        let (col, row, ..) = index_from_coordinate(value.into());
+        self.col = col.unwrap() - 1;
+        self.row = row.unwrap() - 1;
     }
 
     pub(crate) fn _adjustment_insert_row(&mut self, num_rows: &u32) {

--- a/src/structs/range.rs
+++ b/src/structs/range.rs
@@ -20,21 +20,26 @@ impl Range {
 
         if coordinate_collection.len() == 1 || coordinate_collection.len() == 2 {
             let coordinate_str = coordinate_collection[0].to_string();
-            let nums = index_from_coordinate(coordinate_str);
-            match nums[0] {
+            let (
+                row,         //
+                col,         //
+                is_lock_col, //
+                is_lock_row,
+            ) = index_from_coordinate(coordinate_str);
+            match row {
                 Some(v) => {
                     let mut coordinate_start_col = ColumnReference::default();
                     coordinate_start_col.set_num(v);
-                    coordinate_start_col.set_is_lock_usize(nums[2].unwrap());
+                    coordinate_start_col.set_is_lock(is_lock_col.unwrap());
                     self.coordinate_start_col = Some(coordinate_start_col);
                 }
                 None => {}
             };
-            match nums[1] {
+            match col {
                 Some(v) => {
                     let mut coordinate_start_row = RowReference::default();
                     coordinate_start_row.set_num(v);
-                    coordinate_start_row.set_is_lock_usize(nums[3].unwrap());
+                    coordinate_start_row.set_is_lock(is_lock_row.unwrap());
                     self.coordinate_start_row = Some(coordinate_start_row);
                 }
                 None => {}
@@ -43,21 +48,26 @@ impl Range {
 
         if coordinate_collection.len() == 2 {
             let coordinate_str = coordinate_collection[1].to_string();
-            let nums = index_from_coordinate(coordinate_str);
-            match nums[0] {
+            let (
+                row,         //
+                col,         //
+                is_lock_col, //
+                is_lock_row,
+            ) = index_from_coordinate(coordinate_str);
+            match row {
                 Some(v) => {
                     let mut coordinate_end_col = ColumnReference::default();
                     coordinate_end_col.set_num(v);
-                    coordinate_end_col.set_is_lock_usize(nums[2].unwrap());
+                    coordinate_end_col.set_is_lock(is_lock_col.unwrap());
                     self.coordinate_end_col = Some(coordinate_end_col);
                 }
                 None => {}
             };
-            match nums[1] {
+            match col {
                 Some(v) => {
                     let mut coordinate_end_row = RowReference::default();
                     coordinate_end_row.set_num(v);
-                    coordinate_end_row.set_is_lock_usize(nums[3].unwrap());
+                    coordinate_end_row.set_is_lock(is_lock_row.unwrap());
                     self.coordinate_end_row = Some(coordinate_end_row);
                 }
                 None => {}


### PR DESCRIPTION
  ## Changes:

  - change return type of `index_from_coordinate` to tuple
  `(u32, u32, bool, bool)` (the lock flags were previously converted into `&str` first)
