### PR TITLE
[Update] refactor cell `set_value*` methods

### DIFF
--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -101,89 +101,98 @@ impl Cell {
         self
     }
 
-    pub fn set_value_from_string<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.cell_value.set_value_from_string(value);
+    pub fn set_value_string<S: Into<String>>(&mut self, value: S) -> &mut Self {
+        self.cell_value.set_value_string(value);
         self
     }
 
-    pub fn set_value_from_bool(&mut self, value: bool) -> &mut Self {
-        self.cell_value.set_value_from_bool(value);
+    pub fn set_value_bool(&mut self, value: bool) -> &mut Self {
+        self.cell_value.set_value_bool(value);
         self
     }
 
+    #[deprecated(note = "use `set_value_bool` instead")]
     pub fn set_value_from_bool_ref(&mut self, value: &bool) -> &mut Self {
         self.cell_value.set_value_from_bool_ref(value);
         self
     }
 
+    pub fn set_value_number<T>(&mut self, value: T) -> &mut Self
+    where
+        T: Into<f64>,
+    {
+        self.cell_value.set_value_number(value);
+        self
+    }
+
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u16(&mut self, value: u16) -> &mut Self {
-        self.cell_value.set_value_from_u16(value);
-        self
+        self.set_value_number(value)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u16_ref(&mut self, value: &u16) -> &mut Self {
-        self.cell_value.set_value_from_u16_ref(value);
-        self
+        self.set_value_number(value.clone())
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u32(&mut self, value: u32) -> &mut Self {
-        self.cell_value.set_value_from_u32(value);
-        self
+        self.set_value_number(value)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u32_ref(&mut self, value: &u32) -> &mut Self {
-        self.cell_value.set_value_from_u32_ref(value);
-        self
+        self.set_value_number(value.clone() as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u64(&mut self, value: u64) -> &mut Self {
-        self.cell_value.set_value_from_u64(value);
-        self
+        self.set_value_number(value as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u64_ref(&mut self, value: &u64) -> &mut Self {
-        self.cell_value.set_value_from_u64_ref(value);
-        self
+        self.set_value_number(value.clone() as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i16(&mut self, value: i16) -> &mut Self {
-        self.cell_value.set_value_from_i16(value);
-        self
+        self.set_value_number(value)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i16_ref(&mut self, value: &i16) -> &mut Self {
-        self.cell_value.set_value_from_i16_ref(value);
-        self
+        self.set_value_number(value.clone() as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i32(&mut self, value: i32) -> &mut Self {
-        self.cell_value.set_value_from_i32(value);
-        self
+        self.set_value_number(value)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i32_ref(&mut self, value: &i32) -> &mut Self {
-        self.cell_value.set_value_from_i32_ref(value);
-        self
+        self.set_value_number(value.clone() as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i64(&mut self, value: i64) -> &mut Self {
-        self.cell_value.set_value_from_i64(value);
-        self
+        self.set_value_number(value as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i64_ref(&mut self, value: &i64) -> &mut Self {
-        self.cell_value.set_value_from_i64_ref(value);
-        self
+        self.set_value_number(value.clone() as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_usize(&mut self, value: usize) -> &mut Self {
-        self.cell_value.set_value_from_usize(value);
-        self
+        self.set_value_number(value as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_usize_ref(&mut self, value: &usize) -> &mut Self {
-        self.cell_value.set_value_from_usize_ref(value);
-        self
+        self.set_value_number(value.clone() as f64)
     }
 
     pub fn set_rich_text(&mut self, value: RichText) -> &mut Self {
@@ -191,6 +200,7 @@ impl Cell {
         self
     }
 
+    #[deprecated(note = "use `set_rich_text` instead")]
     pub fn set_rich_text_ref(&mut self, value: &RichText) -> &mut Self {
         self.cell_value.set_rich_text_ref(value);
         self
@@ -390,7 +400,7 @@ impl Cell {
                             self.set_shared_string_item(shared_string_item.clone());
                         } else if type_value == "b" {
                             let prm = &string_value == "1";
-                            let _ = self.set_value_from_bool(prm);
+                            let _ = self.set_value_bool(prm);
                         } else if type_value == "e" {
                             let _ = self.set_error();
                         } else if type_value == "" || type_value == "n" {

--- a/src/structs/cell_value.rs
+++ b/src/structs/cell_value.rs
@@ -80,23 +80,27 @@ impl CellValue {
         self
     }
 
-    pub fn set_value_from_string<S: Into<String>>(&mut self, value: S) -> &mut Self {
+    pub fn set_value_string<S: Into<String>>(&mut self, value: S) -> &mut Self {
         self.raw_value = CellRawValue::String(value.into());
         self.remove_formula();
         self
     }
 
-    pub fn set_value_from_bool(&mut self, value: bool) -> &mut Self {
+    pub fn set_value_bool(&mut self, value: bool) -> &mut Self {
         self.raw_value = CellRawValue::Bool(value);
         self.remove_formula();
         self
     }
 
+    #[deprecated(note = "use `set_value_bool` instead")]
     pub fn set_value_from_bool_ref(&mut self, value: &bool) -> &mut Self {
-        self.set_value_from_bool(*value)
+        self.set_value_bool(*value)
     }
 
-    pub fn set_value_from_numberic<V: Into<f64>>(&mut self, value: V) -> &mut Self {
+    pub fn set_value_number<T>(&mut self, value: T) -> &mut Self
+    where
+        T: Into<f64>,
+    {
         self.raw_value = CellRawValue::Numeric(value.into());
         self.remove_formula();
         self
@@ -108,6 +112,7 @@ impl CellValue {
         self
     }
 
+    #[deprecated(note = "use `set_rich_text` instead")]
     pub fn set_rich_text_ref(&mut self, value: &RichText) -> &mut Self {
         self.set_rich_text(value.clone())
     }
@@ -131,7 +136,7 @@ impl CellValue {
     pub(crate) fn set_shared_string_item(&mut self, value: SharedStringItem) -> &mut Self {
         match value.get_text() {
             Some(v) => {
-                self.set_value_from_string(v.get_value());
+                self.set_value_string(v.get_value());
             }
             None => {}
         }
@@ -159,60 +164,74 @@ impl CellValue {
         ""
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u16(&mut self, value: u16) -> &mut Self {
-        self.set_value_from_numberic(value)
+        self.set_value_number(value)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u16_ref(&mut self, value: &u16) -> &mut Self {
-        self.set_value_from_numberic(value.clone())
+        self.set_value_number(value.clone())
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u32(&mut self, value: u32) -> &mut Self {
-        self.set_value_from_numberic(value)
+        self.set_value_number(value)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u32_ref(&mut self, value: &u32) -> &mut Self {
-        self.set_value_from_numberic(value.clone())
+        self.set_value_number(value.clone())
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u64(&mut self, value: u64) -> &mut Self {
-        self.set_value_from_numberic(value as f64)
+        self.set_value_number(value as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_u64_ref(&mut self, value: &u64) -> &mut Self {
-        self.set_value_from_numberic(value.clone() as f64)
+        self.set_value_number(value.clone() as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i16(&mut self, value: i16) -> &mut Self {
-        self.set_value_from_numberic(value)
+        self.set_value_number(value)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i16_ref(&mut self, value: &i16) -> &mut Self {
-        self.set_value_from_numberic(value.clone())
+        self.set_value_number(value.clone())
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i32(&mut self, value: i32) -> &mut Self {
-        self.set_value_from_numberic(value)
+        self.set_value_number(value)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i32_ref(&mut self, value: &i32) -> &mut Self {
-        self.set_value_from_numberic(value.clone())
+        self.set_value_number(value.clone())
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i64(&mut self, value: i64) -> &mut Self {
-        self.set_value_from_numberic(value as f64)
+        self.set_value_number(value as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_i64_ref(&mut self, value: &i64) -> &mut Self {
-        self.set_value_from_numberic(value.clone() as f64)
+        self.set_value_number(value.clone() as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_usize(&mut self, value: usize) -> &mut Self {
-        self.set_value_from_numberic(value as f64)
+        self.set_value_number(value as f64)
     }
 
+    #[deprecated(note = "use `set_value_number` instead")]
     pub fn set_value_from_usize_ref(&mut self, value: &usize) -> &mut Self {
-        self.set_value_from_numberic(value.clone() as f64)
+        self.set_value_number(value.clone() as f64)
     }
 
     pub(crate) fn guess_typed_data(value: &str) -> CellRawValue {
@@ -319,13 +338,13 @@ mod tests {
     fn set_value() {
         let mut obj = CellValue::default();
 
-        obj.set_value_from_string(String::from("TEST"));
+        obj.set_value_string(String::from("TEST"));
         assert_eq!(obj.get_value(), "TEST");
 
-        obj.set_value_from_string("TEST");
+        obj.set_value_string("TEST");
         assert_eq!(obj.get_value(), "TEST");
 
-        obj.set_value_from_bool(true);
+        obj.set_value_bool(true);
         assert_eq!(obj.get_value(), "TRUE");
 
         obj.set_value_from_bool_ref(&true);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -95,7 +95,7 @@ fn lazy_read_and_wite_large_string() {
     for r in 1..5000 {
         for c in 1..30 {
             let cell = ns.get_cell_mut((c, r));
-            let _ = cell.set_value_from_string(format!("r{}c{}", r, c));
+            let _ = cell.set_value_string(format!("r{}c{}", r, c));
         }
     }
     let end = start.elapsed();
@@ -796,7 +796,7 @@ fn new_file_and_edit() {
     book.get_sheet_by_name_mut("Sheet2")
         .unwrap()
         .get_cell_mut((3, 3))
-        .set_value_from_bool(true);
+        .set_value_bool(true);
     let a1_value = book
         .get_sheet_by_name("Sheet2")
         .unwrap()


### PR DESCRIPTION
  ## Changes:

  ### cell_value.rs

  - rename `set_value_from_numberic` to `set_value_number`
  - mark `set_value_from*` methods that only call `set_value_number` as deprecated
  - mark `set_*_ref` methods as deprecated
  - rename `set_value_from*` methods that were not deprecated to `set_value*`

  ### cell.rs

  - add method `set_value_number`
  - mark `set_value_from*` methods that only call `cell_value.set_value_number` as deprecated
  - mark `set_*_ref` methods as deprecated
  - rename `set_value_from*` methods that were not deprecated to `set_value*`