### PR TITLE
Fix joining paths when target is absolute

### DIFF
--- a/src/reader/driver.rs
+++ b/src/reader/driver.rs
@@ -30,6 +30,13 @@ pub(crate) fn normalize_path(path: &str) -> PathBuf {
     ret
 }
 
+pub(crate) fn join_paths(base_path: &str, target: &str) -> String {
+    match target.split_once('/') {
+        Some(("", target)) => normalize_path_to_str(target),
+        _ => normalize_path_to_str(&format!("{}/{}", base_path, target)),
+    }
+}
+
 pub(crate) fn normalize_path_to_str(path: &str) -> String {
     let ret = normalize_path(path);
     ret.to_str().unwrap_or("").to_string().replace('\\', "/")

--- a/src/structs/raw/raw_file.rs
+++ b/src/structs/raw/raw_file.rs
@@ -63,7 +63,7 @@ impl RawFile {
         base_path: &str,
         target: &str,
     ) {
-        let path_str = normalize_path_to_str(&format!("{}/{}", base_path, target));
+        let path_str = join_paths(base_path, target);
         let mut r = io::BufReader::new(arv.by_name(&path_str).unwrap());
         let mut buf = Vec::new();
         r.read_to_end(&mut buf).unwrap();

--- a/src/structs/raw/raw_relationships.rs
+++ b/src/structs/raw/raw_relationships.rs
@@ -61,7 +61,7 @@ impl RawRelationships {
         target: &str,
     ) -> bool {
         let data = {
-            let path_str = normalize_path_to_str(&format!("{}/{}", base_path, target));
+            let path_str = join_paths(base_path, target);
             let file_path = match arv.by_name(&path_str) {
                 Ok(v) => v,
                 Err(_) => {


### PR DESCRIPTION
This happens when reading an Excel file with comments, their paths start with `/xl/comments` which crashes in `src/structs/raw/raw_file.rs:67`.