### PR TITLE
support for dataValidation.operator

### DIFF
--- a/src/structs.rs
+++ b/src/structs.rs
@@ -400,6 +400,9 @@ pub use self::formula::*;
 mod data_validation_values;
 pub use self::data_validation_values::*;
 
+mod data_validation_operator_values;
+pub use self::data_validation_operator_values::*;
+
 mod data_validation;
 pub use self::data_validation::*;
 

--- a/src/structs/data_validation.rs
+++ b/src/structs/data_validation.rs
@@ -1,5 +1,6 @@
 // dataValidation
 use super::BooleanValue;
+use super::DataValidationOperatorValues;
 use super::DataValidationValues;
 use super::EnumValue;
 use super::SequenceOfReferences;
@@ -15,6 +16,7 @@ use writer::driver::*;
 #[derive(Default, Debug, Clone)]
 pub struct DataValidation {
     r#type: EnumValue<DataValidationValues>,
+    operator: EnumValue<DataValidationOperatorValues>,
     allow_blank: BooleanValue,
     show_input_message: BooleanValue,
     show_error_message: BooleanValue,
@@ -217,6 +219,10 @@ impl DataValidation {
             ));
         }
 
+        if self.operator.has_value() {
+            attributes.push(("operator", self.operator.get_value_string()));
+        }
+
         if self.show_error_message.has_value() {
             attributes.push((
                 "showErrorMessage",
@@ -233,7 +239,7 @@ impl DataValidation {
         }
 
         let sequence_of_references = &self.sequence_of_references.get_sqref();
-        if sequence_of_references != "" {
+        if !sequence_of_references.is_empty() {
             attributes.push(("sqref", sequence_of_references));
         }
 

--- a/src/structs/data_validation.rs
+++ b/src/structs/data_validation.rs
@@ -36,6 +36,15 @@ impl DataValidation {
         self
     }
 
+    pub fn get_operator(&self) -> &DataValidationOperatorValues {
+        self.operator.get_value()
+    }
+
+    pub fn set_operator(&mut self, value: DataValidationOperatorValues) -> &mut Self {
+        self.operator.set_value(value);
+        self
+    }
+
     pub fn get_allow_blank(&self) -> &bool {
         self.allow_blank.get_value()
     }

--- a/src/structs/data_validation.rs
+++ b/src/structs/data_validation.rs
@@ -118,53 +118,32 @@ impl DataValidation {
         e: &BytesStart,
         empty_flg: bool,
     ) {
-        match get_attribute(e, b"type") {
-            Some(v) => {
-                self.r#type.set_value_string(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"type") {
+            self.r#type.set_value_string(v);
         }
 
-        match get_attribute(e, b"allowBlank") {
-            Some(v) => {
-                self.allow_blank.set_value_string(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"allowBlank") {
+            self.allow_blank.set_value_string(v);
         }
 
-        match get_attribute(e, b"showInputMessage") {
-            Some(v) => {
-                self.show_input_message.set_value_string(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"showInputMessage") {
+            self.show_input_message.set_value_string(v);
         }
 
-        match get_attribute(e, b"showErrorMessage") {
-            Some(v) => {
-                self.show_error_message.set_value_string(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"showErrorMessage") {
+            self.show_error_message.set_value_string(v);
         }
 
-        match get_attribute(e, b"promptTitle") {
-            Some(v) => {
-                self.prompt_title.set_value_string(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"promptTitle") {
+            self.prompt_title.set_value_string(v);
         }
 
-        match get_attribute(e, b"prompt") {
-            Some(v) => {
-                self.prompt.set_value_string(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"prompt") {
+            self.prompt.set_value_string(v);
         }
 
-        match get_attribute(e, b"sqref") {
-            Some(v) => {
-                self.sequence_of_references.set_sqref(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"sqref") {
+            self.sequence_of_references.set_sqref(v);
         }
 
         if empty_flg {

--- a/src/structs/data_validation.rs
+++ b/src/structs/data_validation.rs
@@ -131,6 +131,10 @@ impl DataValidation {
             self.r#type.set_value_string(v);
         }
 
+        if let Some(v) = get_attribute(e, b"operator") {
+            self.operator.set_value_string(v);
+        }
+
         if let Some(v) = get_attribute(e, b"allowBlank") {
             self.allow_blank.set_value_string(v);
         }

--- a/src/structs/data_validation_operator_values.rs
+++ b/src/structs/data_validation_operator_values.rs
@@ -1,0 +1,53 @@
+use super::EnumTrait;
+use std::str::FromStr;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum DataValidationOperatorValues {
+    Between,
+    Equal,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+    NotBetween,
+    NotEqual,
+}
+
+impl EnumTrait for DataValidationOperatorValues {
+    fn get_value_string(&self) -> &str {
+        match self {
+            Self::Between => "between",
+            Self::Equal => "equal",
+            Self::GreaterThan => "greaterThan",
+            Self::GreaterThanOrEqual => "greaterThanOrEqual",
+            Self::LessThan => "lessThan",
+            Self::LessThanOrEqual => "lessThanOrEqual",
+            Self::NotBetween => "notBetween",
+            Self::NotEqual => "notEqual",
+        }
+    }
+}
+
+impl Default for DataValidationOperatorValues {
+    fn default() -> Self {
+        Self::LessThan
+    }
+}
+
+impl FromStr for DataValidationOperatorValues {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        Ok(match input {
+            "between" => Self::Between,
+            "equal" => Self::Equal,
+            "greaterThan" => Self::GreaterThan,
+            "greaterThanOrEqual" => Self::GreaterThanOrEqual,
+            "lessThan" => Self::LessThan,
+            "lessThanOrEqual" => Self::LessThanOrEqual,
+            "notBetween" => Self::NotBetween,
+            "notEqual" => Self::NotEqual,
+            _ => return Err(()),
+        })
+    }
+}


### PR DESCRIPTION
I noticed that `operator` support wasn't implemented (and I need it).  I went off of these docs but it was really hard to find anything concrete so please let me know if I'm missing anything: https://learn.microsoft.com/en-my/dotnet/api/documentformat.openxml.spreadsheet.datavalidationoperatorvalues?view=openxml-2.8.1