### PR TITLE
Fix drawing error

### DIFF
--- a/src/structs/drawing/spreadsheet/worksheet_drawing.rs
+++ b/src/structs/drawing/spreadsheet/worksheet_drawing.rs
@@ -346,13 +346,16 @@ impl WorksheetDrawing {
                         }
                     }
                     b"xdr:twoCellAnchor" => {
-                        if is_alternate_content {
-                            ole_objects.get_ole_object_mut()[ole_index]
+                        let os = ole_objects.get_ole_object_mut();
+                        if is_alternate_content && !os.is_empty() {
+                            os[ole_index]
                                 .get_two_cell_anchor_mut()
                                 .set_is_alternate_content(true);
-                            ole_objects.get_ole_object_mut()[ole_index]
-                                .get_two_cell_anchor_mut()
-                                .set_attributes(reader, e, drawing_relationships);
+                            os[ole_index].get_two_cell_anchor_mut().set_attributes(
+                                reader,
+                                e,
+                                drawing_relationships,
+                            );
                             ole_index += 1;
                             continue;
                         }

--- a/src/structs/int16_value.rs
+++ b/src/structs/int16_value.rs
@@ -1,5 +1,6 @@
 #[derive(Clone, Default, Debug)]
 pub struct Int16Value {
+    #[allow(dead_code)]
     value: Option<i16>,
 }
 impl Int16Value {
@@ -24,10 +25,7 @@ impl Int16Value {
     }
 
     pub(crate) fn _has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 
     pub(crate) fn _get_hash_string(&self) -> String {

--- a/src/structs/raw/raw_file.rs
+++ b/src/structs/raw/raw_file.rs
@@ -13,7 +13,7 @@ pub(crate) struct RawFile {
 impl RawFile {
     pub(crate) fn get_file_name(&self) -> String {
         let v: Vec<&str> = self.get_file_target().split('/').collect();
-        let object_name = v.last().unwrap().clone();
+        let object_name = v.last().unwrap();
         object_name.to_string()
     }
 
@@ -30,7 +30,7 @@ impl RawFile {
     pub(crate) fn get_extension(&self) -> String {
         let file_name = self.get_file_name();
         let v: Vec<&str> = file_name.split('.').collect();
-        let extension = v.last().unwrap().clone();
+        let extension = v.last().unwrap();
 
         extension.to_lowercase()
     }

--- a/src/structs/raw/raw_relationships.rs
+++ b/src/structs/raw/raw_relationships.rs
@@ -19,7 +19,7 @@ pub(crate) struct RawRelationships {
 impl RawRelationships {
     pub(crate) fn _get_file_name(&self) -> String {
         let v: Vec<&str> = self.get_file_target().split('/').collect();
-        let object_name = v.last().unwrap().clone();
+        let object_name = v.last().unwrap();
         object_name.to_string()
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1112,8 +1112,8 @@ fn issue_110() {
 }
 
 #[test]
+#[ignore]
 fn issue_114() {
-    return;
     let path = std::path::Path::new("./tests/test_files/test1.xlsx");
     let mut book = umya_spreadsheet::reader::xlsx::read(path).unwrap();
 


### PR DESCRIPTION
Hi, it's me again - I was running into this error on a spreadsheet that was written by Excel:

```
thread 'main' panicked at /Users/patrick/umya-spreadsheet/src/structs/drawing/spreadsheet/worksheet_drawing.rs:350:61:
index out of bounds: the len is 0 but the index is 0
```

I'm not sure why it doesn't have (or wasn't able to parse) the expected OLE Objects data structures, but when I debug there it was an empty vector.  So I just made the code handle it better but I'm assuming that the drawing gets stripped out of the final sheet.

I also fixed some clippy warnings in the first 3 commits.

