### PR TITLE
Fix swapped attributes

### DIFF
--- a/src/structs/cell_style.rs
+++ b/src/structs/cell_style.rs
@@ -55,13 +55,13 @@ impl CellStyle {
         }
         match get_attribute(e, b"xfId") {
             Some(v) => {
-                self.builtin_id.set_value_string(v);
+                self.format_id.set_value_string(v);
             }
             None => {}
         }
         match get_attribute(e, b"builtinId") {
             Some(v) => {
-                self.format_id.set_value_string(v);
+                self.builtin_id.set_value_string(v);
             }
             None => {}
         }

--- a/src/structs/drawing/spreadsheet/transform.rs
+++ b/src/structs/drawing/spreadsheet/transform.rs
@@ -85,14 +85,14 @@ impl Transform {
 
         match get_attribute(e, b"flipH") {
             Some(v) => {
-                self.vertical_flip.set_value_string(v);
+                self.horizontal_flip.set_value_string(v);
             }
             None => {}
         }
 
         match get_attribute(e, b"flipV") {
             Some(v) => {
-                self.horizontal_flip.set_value_string(v);
+                self.vertical_flip.set_value_string(v);
             }
             None => {}
         }


### PR DESCRIPTION
I was working on something else and noticed the code here has these two swapped. Reading the docs it seems like `xfId` should map to `format_id` and `builtinId` to `builtin_id`.  I also found a second place where the vertical/horizontal attrs are flipped