### PR TITLE
Use Clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,32 @@
+name: umya-spreadsheet
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust
+      run: rustup component add rustfmt clippy
+
+    - name: Build
+      run: cargo build
+
+    - name: Lint (clippy)
+      run: cargo clippy -- -D warnings
+
+    - name: Lint (rustfmt)
+      run: cargo fmt --all -- --check
+
+    - name: Tests
+      run: cargo test

--- a/src/helper/address.rs
+++ b/src/helper/address.rs
@@ -38,32 +38,32 @@ pub fn is_address<S: AsRef<str>>(input: S) -> bool {
 
 #[test]
 fn is_address_test() {
-    assert_eq!(is_address("A1"), true);
-    assert_eq!(is_address("$A1"), true);
-    assert_eq!(is_address("A$1"), true);
-    assert_eq!(is_address("$A$1"), true);
+    assert!(is_address("A1"));
+    assert!(is_address("$A1"));
+    assert!(is_address("A$1"));
+    assert!(is_address("$A$1"));
 
-    assert_eq!(is_address("A1:B2"), true);
-    assert_eq!(is_address("$A1:B2"), true);
-    assert_eq!(is_address("$A$1:B2"), true);
-    assert_eq!(is_address("$A$1:$B2"), true);
-    assert_eq!(is_address("$A$1:$B$2"), true);
+    assert!(is_address("A1:B2"));
+    assert!(is_address("$A1:B2"));
+    assert!(is_address("$A$1:B2"));
+    assert!(is_address("$A$1:$B2"));
+    assert!(is_address("$A$1:$B$2"));
 
-    assert_eq!(is_address("Sheet1!A1"), true);
-    assert_eq!(is_address("Sheet1!$A1"), true);
-    assert_eq!(is_address("Sheet1!A$1"), true);
-    assert_eq!(is_address("Sheet1!A$1"), true);
+    assert!(is_address("Sheet1!A1"));
+    assert!(is_address("Sheet1!$A1"));
+    assert!(is_address("Sheet1!A$1"));
+    assert!(is_address("Sheet1!A$1"));
 
-    assert_eq!(is_address("Sheet1!A1:B2"), true);
-    assert_eq!(is_address("Sheet1!$A1:B2"), true);
-    assert_eq!(is_address("Sheet1!$A$1:B2"), true);
-    assert_eq!(is_address("Sheet1!$A$1:$B2"), true);
-    assert_eq!(is_address("Sheet1!$A$1:$B$2"), true);
-    assert_eq!(is_address("New Sheet!$H$7:$H$10"), true);
+    assert!(is_address("Sheet1!A1:B2"));
+    assert!(is_address("Sheet1!$A1:B2"));
+    assert!(is_address("Sheet1!$A$1:B2"));
+    assert!(is_address("Sheet1!$A$1:$B2"));
+    assert!(is_address("Sheet1!$A$1:$B$2"));
+    assert!(is_address("New Sheet!$H$7:$H$10"));
 
-    assert_eq!(is_address("(Sheet1!A1:B2)"), false);
-    assert_eq!(is_address("Sheet1!A1:"), false);
-    assert_eq!(is_address("Sheet1!A1:B"), false);
-    assert_eq!(is_address("Sheet1!A:B2"), false);
-    assert_eq!(is_address("Sheet1"), false);
+    assert!(!is_address("(Sheet1!A1:B2)"));
+    assert!(!is_address("Sheet1!A1:"));
+    assert!(!is_address("Sheet1!A1:B"));
+    assert!(!is_address("Sheet1!A:B2"));
+    assert!(!is_address("Sheet1"));
 }

--- a/src/helper/coordinate.rs
+++ b/src/helper/coordinate.rs
@@ -33,7 +33,6 @@ where
     alpha
         .as_ref()
         .chars()
-        .into_iter()
         .rev()
         .enumerate()
         .map(|(index, v)| {

--- a/src/helper/date.rs
+++ b/src/helper/date.rs
@@ -16,16 +16,11 @@ pub fn excel_to_date_time_object(
         // Unix timestamp base date
         NaiveDateTime::parse_from_str("1970-01-01 00:00:00", "%Y-%m-%d %T").unwrap()
     } else {
-        // MS Excel calendar base dates
-        if CALENDAR_WINDOWS_1900 == CALENDAR_WINDOWS_1900 {
-            // Allow adjustment for 1900 Leap Year in MS Excel
-            if excel_timestamp < &60f64 {
-                NaiveDateTime::parse_from_str("1899-12-31 00:00:00", "%Y-%m-%d %T").unwrap()
-            } else {
-                NaiveDateTime::parse_from_str("1899-12-30 00:00:00", "%Y-%m-%d %T").unwrap()
-            }
+        // Allow adjustment for 1900 Leap Year in MS Excel
+        if excel_timestamp < &60f64 {
+            NaiveDateTime::parse_from_str("1899-12-31 00:00:00", "%Y-%m-%d %T").unwrap()
         } else {
-            NaiveDateTime::parse_from_str("1904-01-01 00:00:00", "%Y-%m-%d %T").unwrap()
+            NaiveDateTime::parse_from_str("1899-12-30 00:00:00", "%Y-%m-%d %T").unwrap()
         }
     };
 

--- a/src/helper/formula.rs
+++ b/src/helper/formula.rs
@@ -10,7 +10,7 @@ pub fn adjustment_insert_formula_coordinate(
     worksheet_name: &str,
     self_worksheet_name: &str,
 ) -> String {
-    let re = Regex::new(r#"[^\(]*!*[A-Z]+[0-9]+\:[A-Z]+[0-9]+"#).unwrap();
+    let re = Regex::new(r"[^\(]*!*[A-Z]+[0-9]+\:[A-Z]+[0-9]+").unwrap();
     let result = re.replace_all(formula, |caps: &Captures| {
         let caps_string = caps.get(0).unwrap().as_str().to_string();
         let split_str: Vec<&str> = caps_string.split('!').collect();
@@ -28,7 +28,7 @@ pub fn adjustment_insert_formula_coordinate(
             range = split_str.first().unwrap().to_string();
         }
 
-        if &wksheet != &worksheet_name {
+        if wksheet != worksheet_name {
             return caps_string;
         }
 
@@ -77,7 +77,7 @@ pub fn adjustment_remove_formula_coordinate(
     worksheet_name: &str,
     self_worksheet_name: &str,
 ) -> String {
-    let re = Regex::new(r#"[^\(]*!*[A-Z]+[0-9]+\:[A-Z]+[0-9]+"#).unwrap();
+    let re = Regex::new(r"[^\(]*!*[A-Z]+[0-9]+\:[A-Z]+[0-9]+").unwrap();
     let result = re.replace_all(formula, |caps: &Captures| {
         let caps_string = caps.get(0).unwrap().as_str().to_string();
         let split_str: Vec<&str> = caps_string.split('!').collect();
@@ -95,7 +95,7 @@ pub fn adjustment_remove_formula_coordinate(
             range = split_str.first().unwrap().to_string();
         }
 
-        if &wksheet != &worksheet_name {
+        if wksheet != worksheet_name {
             return caps_string;
         }
 

--- a/src/helper/number_format.rs
+++ b/src/helper/number_format.rs
@@ -3,7 +3,6 @@ use std::borrow::Cow;
 use fancy_regex::Captures;
 use fancy_regex::Matches;
 use fancy_regex::Regex;
-//use fancy_regex::Regex;
 use helper::date::*;
 use structs::Color;
 use structs::NumberingFormat;
@@ -13,6 +12,7 @@ pub struct Split<'r, 't> {
     finder: Matches<'r, 't>,
     last: usize,
 }
+
 pub fn split<'r, 't>(regex: &'r Regex, text: &'t str) -> Split<'r, 't> {
     Split {
         finder: regex.find_iter(text),
@@ -123,7 +123,7 @@ pub fn to_formatted_string<S: AsRef<str>, P: AsRef<str>>(value: S, format: P) ->
 
     // Convert any other escaped characters to quoted strings, e.g. (\T to "T")
 
-    let mut format = ESCAPE_REGEX.replace_all(&format, r#""$0""#).to_owned();
+    let mut format = ESCAPE_REGEX.replace_all(&format, r#""$0""#);
 
     // Get the sections, there can be up to four sections, separated with a semi-colon (but only if not a quoted literal)
 
@@ -187,7 +187,7 @@ fn split_format(sections: Vec<&str>, value: &f64) -> (String, String, String) {
     //   4 sections:  [POSITIVE] [NEGATIVE] [ZERO] [TEXT]
     let cnt: usize = sections.len();
     let color_regex: String = format!("{}{}{}", "\\[(", Color::NAMED_COLORS.join("|"), ")\\]");
-    let cond_regex = r#"\[(>|>=|<|<=|=|<>)([+-]?\d+([.]\d+)?)\]"#;
+    let cond_regex = r"\[(>|>=|<|<=|=|<>)([+-]?\d+([.]\d+)?)\]";
     let color_re = Regex::new(&color_regex).unwrap();
     let cond_re = Regex::new(cond_regex).unwrap();
 
@@ -284,14 +284,13 @@ fn split_format_compare(value: &f64, cond: &str, val: &f64, dfcond: &str, dfval:
 }
 
 fn format_as_date<'input>(value: &f64, format: &'input str) -> Cow<'input, str> {
-    let value = value;
     let format = Cow::Borrowed(format);
 
     // strip off first part containing e.g. [$-F800] or [$USD-409]
     // general syntax: [$<Currency string>-<language info>]
     // language info is in hexadecimal
     // strip off chinese part like [DBNum1][$-804]
-    let re = Regex::new(r#"^(\[[0-9A-Za-z]*\])*(\[\$[A-Z]*-[0-9A-F]*\])"#).unwrap();
+    let re = Regex::new(r"^(\[[0-9A-Za-z]*\])*(\[\$[A-Z]*-[0-9A-F]*\])").unwrap();
     let format = re.replace_all(&format, r#""#);
 
     // OpenOffice.org uses upper-case number formats, e.g. 'YYYY', convert to lower-case;
@@ -351,9 +350,9 @@ fn format_as_number<'input>(value: &f64, format: &'input str) -> Cow<'input, str
         static ref THOUSANDS_SEP_REGEX: Regex = Regex::new(r#"(#,#|0,0)"#).unwrap();
         static ref SCALE_REGEX: Regex = Regex::new(r#"(#|0)(,+)"#).unwrap();
         static ref TRAILING_COMMA_REGEX: Regex = Regex::new("(#|0),+").unwrap();
-        static ref FRACTION_REGEX: Regex = Regex::new(r#"#?.*\?{1,2}\/\?{1,2}"#).unwrap();
-        static ref SQUARE_BRACKET_REGEX: Regex = Regex::new(r#"\[[^\]]+\]"#).unwrap();
-        static ref NUMBER_REGEX: Regex = Regex::new(r#"(0+)(\.?)(0*)"#).unwrap();
+        static ref FRACTION_REGEX: Regex = Regex::new(r"#?.*\?{1,2}\/\?{1,2}").unwrap();
+        static ref SQUARE_BRACKET_REGEX: Regex = Regex::new(r"\[[^\]]+\]").unwrap();
+        static ref NUMBER_REGEX: Regex = Regex::new(r"(0+)(\.?)(0*)").unwrap();
     }
 
     let mut value = value.to_string();
@@ -427,12 +426,12 @@ fn format_as_number<'input>(value: &f64, format: &'input str) -> Cow<'input, str
                 &format,
                 &item,
                 &use_thousands,
-                r#"(0+)(\.?)(0*)"#,
+                r"(0+)(\.?)(0*)",
             );
         }
     }
 
-    let re = Regex::new(r#"\$[^0-9]*"#).unwrap();
+    let re = Regex::new(r"\$[^0-9]*").unwrap();
     if re.find(&format).ok().flatten().is_some() {
         let mut item: Vec<String> = Vec::new();
         for ite in re.captures(&format).ok().flatten().unwrap().iter() {
@@ -545,8 +544,7 @@ fn format_straight_numeric_value(
             let pow = 10i32.pow(right.len() as u32);
             right_value = format!("{}", right_value.parse::<i32>().unwrap() * pow);
         } else {
-            let mut right_value_conv: String =
-                right_value.chars().skip(0).take(right.len()).collect();
+            let mut right_value_conv: String = right_value.chars().take(right.len()).collect();
             let ajst_str: String = right_value.chars().skip(right.len()).take(1).collect();
             let ajst_int = ajst_str.parse::<i32>().unwrap();
             if ajst_int > 4 {

--- a/src/helper/range.rs
+++ b/src/helper/range.rs
@@ -74,5 +74,5 @@ pub fn get_start_and_end_point(range_str: &str) -> (u32, u32, u32, u32) {
             }
         }
     }
-    return (row_start, row_end, col_start, col_end);
+    (row_start, row_end, col_start, col_end)
 }

--- a/src/reader/xlsx/comment.rs
+++ b/src/reader/xlsx/comment.rs
@@ -1,4 +1,5 @@
 use super::XlsxError;
+use crate::xml_read_loop;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use std::result;
@@ -13,40 +14,33 @@ pub(crate) fn read(
     let data = std::io::Cursor::new(drawing_file.get_file_data());
     let mut reader = Reader::from_reader(data);
     reader.trim_text(false);
-    let mut buf = Vec::new();
 
     let mut authors: Vec<String> = Vec::new();
     let mut value: String = String::from("");
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                b"author" => {
-                    authors.push(String::from(""));
-                }
-                _ => (),
-            },
-            Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                b"comment" => {
-                    let mut obj = Comment::default();
-                    obj.set_attributes(&mut reader, e, &authors);
-                    worksheet.add_comments(obj);
-                }
-                _ => (),
-            },
-            Ok(Event::Text(e)) => {
-                value = e.unescape().unwrap().to_string();
+    xml_read_loop!(
+        reader,
+        Event::Empty(ref e) => {
+            if e.name().into_inner() == b"author" {
+                authors.push(String::from(""));
             }
-            Ok(Event::End(ref e)) => match e.name().into_inner() {
-                b"author" => {
-                    authors.push(value.clone());
-                }
-                _ => (),
-            },
-            Ok(Event::Eof) => break,
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-            _ => (),
-        }
-        buf.clear();
-    }
+        },
+        Event::Start(ref e) => {
+            if e.name().into_inner() ==  b"comment" {
+                let mut obj = Comment::default();
+                obj.set_attributes(&mut reader, e, &authors);
+                worksheet.add_comments(obj);
+            }
+        },
+        Event::Text(e) => {
+            value = e.unescape().unwrap().to_string();
+        },
+        Event::End(ref e) => {
+            if e.name().into_inner() == b"author" {
+                authors.push(value.clone());
+            }
+        },
+        Event::Eof => break,
+    );
+
     Ok(())
 }

--- a/src/reader/xlsx/content_types.rs
+++ b/src/reader/xlsx/content_types.rs
@@ -14,24 +14,20 @@ pub(crate) fn read<R: io::Read + io::Seek>(
     let r = io::BufReader::new(arv.by_name(FILE_PATH)?);
     let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
-    let mut buf = Vec::new();
     let mut list: Vec<(String, String)> = Vec::new();
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                b"Override" => {
-                    let part_name = get_attribute(e, b"PartName").unwrap();
-                    let content_type = get_attribute(e, b"ContentType").unwrap();
-                    list.push((part_name, content_type));
-                }
-                _ => (),
-            },
-            Ok(Event::Eof) => break,
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-            _ => (),
-        }
-        buf.clear();
-    }
+
+    xml_read_loop!(
+        reader,
+        Event::Empty(ref e) => {
+            if e.name().into_inner() == b"Override" {
+                let part_name = get_attribute(e, b"PartName").unwrap();
+                let content_type = get_attribute(e, b"ContentType").unwrap();
+                list.push((part_name, content_type));
+            }
+        },
+        Event::Eof => break,
+    );
+
     spreadsheet.set_backup_context_types(list);
     Ok(())
 }

--- a/src/reader/xlsx/drawing.rs
+++ b/src/reader/xlsx/drawing.rs
@@ -1,6 +1,7 @@
 use super::XlsxError;
 use quick_xml::events::Event;
 use quick_xml::Reader;
+use reader::driver::xml_read_loop;
 use std::result;
 use structs::drawing::spreadsheet::WorksheetDrawing;
 use structs::raw::RawFile;
@@ -15,29 +16,23 @@ pub(crate) fn read(
     let data = std::io::Cursor::new(drawing_file.get_file_data());
     let mut reader = Reader::from_reader(data);
     reader.trim_text(true);
-    let mut buf = Vec::new();
 
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                b"xdr:wsDr" => {
-                    let mut obj = WorksheetDrawing::default();
-                    obj.set_attributes(
-                        &mut reader,
-                        e,
-                        drawing_relationships,
-                        worksheet.get_ole_objects_mut(),
-                    );
-                    worksheet.set_worksheet_drawing(obj);
-                }
-                _ => (),
-            },
-            Ok(Event::Eof) => break,
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-            _ => (),
-        }
-        buf.clear();
-    }
+    xml_read_loop!(
+        reader,
+        Event::Start(ref e) => {
+            if e.name().into_inner() == b"xdr:wsDr" {
+                let mut obj = WorksheetDrawing::default();
+                obj.set_attributes(
+                    &mut reader,
+                    e,
+                    drawing_relationships,
+                    worksheet.get_ole_objects_mut(),
+                );
+                worksheet.set_worksheet_drawing(obj);
+            }
+        },
+        Event::Eof => break
+    );
 
     Ok(())
 }

--- a/src/reader/xlsx/styles.rs
+++ b/src/reader/xlsx/styles.rs
@@ -1,3 +1,5 @@
+use crate::xml_read_loop;
+
 use super::XlsxError;
 use quick_xml::events::Event;
 use quick_xml::Reader;
@@ -14,75 +16,60 @@ pub fn read<R: io::Read + io::Seek>(
     let r = io::BufReader::new(arv.by_name(FILE_PATH)?);
     let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
-    let mut buf = Vec::new();
 
     let theme = spreadsheet.get_theme().clone();
 
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(ref e)) => {
-                match e.name().into_inner() {
-                    b"styleSheet" => {
-                        let mut obj = Stylesheet::default();
-                        obj.set_attributes(&mut reader, e);
+    xml_read_loop!(
+        reader,
+        Event::Start(ref e) => {
+            if e.name().into_inner() == b"styleSheet" {
+                let mut obj = Stylesheet::default();
+                obj.set_attributes(&mut reader, e);
 
-                        // set ThemeColor
-                        for font in obj.get_fonts_mut().get_font_mut() {
-                            let color = font.get_color_mut();
-                            color.set_argb_by_theme(&theme);
-                        }
-                        for fill in obj.get_fills_mut().get_fill_mut() {
-                            match fill.get_pattern_fill() {
-                                Some(_) => {
-                                    match fill.get_pattern_fill_mut().get_foreground_color() {
-                                        Some(_) => {
-                                            fill.get_pattern_fill_mut()
-                                                .get_foreground_color_mut()
-                                                .set_argb_by_theme(&theme);
-                                        }
-                                        None => {}
-                                    }
-                                    match fill.get_pattern_fill_mut().get_background_color() {
-                                        Some(_) => {
-                                            fill.get_pattern_fill_mut()
-                                                .get_background_color_mut()
-                                                .set_argb_by_theme(&theme);
-                                        }
-                                        None => {}
-                                    }
-                                }
-                                None => {}
-                            }
-                        }
-                        for border in obj.get_borders_mut().get_borders_mut() {
-                            let color = border.get_left_border_mut().get_color_mut();
-                            color.set_argb_by_theme(&theme);
-                            let color = border.get_right_border_mut().get_color_mut();
-                            color.set_argb_by_theme(&theme);
-                            let color = border.get_top_border_mut().get_color_mut();
-                            color.set_argb_by_theme(&theme);
-                            let color = border.get_bottom_border_mut().get_color_mut();
-                            color.set_argb_by_theme(&theme);
-                            let color = border.get_diagonal_border_mut().get_color_mut();
-                            color.set_argb_by_theme(&theme);
-                            let color = border.get_vertical_border_mut().get_color_mut();
-                            color.set_argb_by_theme(&theme);
-                            let color = border.get_horizontal_border_mut().get_color_mut();
-                            color.set_argb_by_theme(&theme);
-                        }
-
-                        obj.make_style();
-                        spreadsheet.set_stylesheet(obj);
-                    }
-                    _ => (),
+                // set ThemeColor
+                for font in obj.get_fonts_mut().get_font_mut() {
+                    let color = font.get_color_mut();
+                    color.set_argb_by_theme(&theme);
                 }
+
+                for fill in obj.get_fills_mut().get_fill_mut() {
+                    if fill.get_pattern_fill().is_some() {
+                        if fill.get_pattern_fill_mut().get_foreground_color().is_some() {
+                            fill.get_pattern_fill_mut()
+                                .get_foreground_color_mut()
+                                .set_argb_by_theme(&theme);
+                        }
+                        if fill.get_pattern_fill_mut().get_background_color().is_some() {
+                            fill.get_pattern_fill_mut()
+                                .get_background_color_mut()
+                                .set_argb_by_theme(&theme);
+                        }
+                    }
+                }
+
+                for border in obj.get_borders_mut().get_borders_mut() {
+                    let color = border.get_left_border_mut().get_color_mut();
+                    color.set_argb_by_theme(&theme);
+                    let color = border.get_right_border_mut().get_color_mut();
+                    color.set_argb_by_theme(&theme);
+                    let color = border.get_top_border_mut().get_color_mut();
+                    color.set_argb_by_theme(&theme);
+                    let color = border.get_bottom_border_mut().get_color_mut();
+                    color.set_argb_by_theme(&theme);
+                    let color = border.get_diagonal_border_mut().get_color_mut();
+                    color.set_argb_by_theme(&theme);
+                    let color = border.get_vertical_border_mut().get_color_mut();
+                    color.set_argb_by_theme(&theme);
+                    let color = border.get_horizontal_border_mut().get_color_mut();
+                    color.set_argb_by_theme(&theme);
+                }
+
+                obj.make_style();
+                spreadsheet.set_stylesheet(obj);
             }
-            Ok(Event::Eof) => break,
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-            _ => (),
-        }
-        buf.clear();
-    }
+        },
+        Event::Eof => break
+    );
 
     Ok(())
 }

--- a/src/reader/xlsx/theme.rs
+++ b/src/reader/xlsx/theme.rs
@@ -1,8 +1,8 @@
 use super::XlsxError;
+use crate::xml_read_loop;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use std::{io, result};
-
 use structs::drawing::Theme;
 
 pub fn read<R: io::Read + io::Seek>(
@@ -12,23 +12,18 @@ pub fn read<R: io::Read + io::Seek>(
     let r = io::BufReader::new(arv.by_name(&format!("xl/{}", target))?);
     let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
-    let mut buf = Vec::new();
 
     let mut theme: Theme = Theme::default();
 
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                b"a:theme" => {
-                    theme.set_attributes(&mut reader, e);
-                }
-                _ => (),
-            },
-            Ok(Event::Eof) => break,
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-            _ => (),
-        }
-        buf.clear();
-    }
+    xml_read_loop!(
+        reader,
+        Event::Start(ref e) => {
+            if e.name().into_inner() == b"a:theme" {
+                theme.set_attributes(&mut reader, e);
+            }
+        },
+        Event::Eof => break,
+    );
+
     Ok(theme)
 }

--- a/src/reader/xlsx/workbook_rels.rs
+++ b/src/reader/xlsx/workbook_rels.rs
@@ -14,34 +14,29 @@ pub(crate) fn read<R: io::Read + io::Seek>(
     let r = io::BufReader::new(arv.by_name(FILE_PATH)?);
     let mut reader = Reader::from_reader(r);
     reader.trim_text(true);
-    let mut buf = Vec::new();
 
     let mut result: Vec<(String, String, String)> = Vec::new();
 
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                b"Relationship" => {
-                    let id_value = get_attribute(e, b"Id").unwrap();
-                    let type_value = get_attribute(e, b"Type").unwrap();
-                    let target_value = get_attribute(e, b"Target").unwrap();
-                    let target_value = target_value
-                        .strip_prefix("/xl/")
-                        .map(|t| t.to_owned())
-                        .unwrap_or(target_value);
-                    if type_value == "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" {
-                        spreadsheet.update_pivot_caches(id_value, target_value);
-                    } else {
-                        result.push((id_value, type_value, target_value));
-                    }
+    xml_read_loop!(
+        reader,
+        Event::Empty(ref e) => {
+            if e.name().into_inner() == b"Relationship" {
+                let id_value = get_attribute(e, b"Id").unwrap();
+                let type_value = get_attribute(e, b"Type").unwrap();
+                let target_value = get_attribute(e, b"Target").unwrap();
+                let target_value = target_value
+                    .strip_prefix("/xl/")
+                    .map(|t| t.to_owned())
+                    .unwrap_or(target_value);
+                if type_value == "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" {
+                    spreadsheet.update_pivot_caches(id_value, target_value);
+                } else {
+                    result.push((id_value, type_value, target_value));
                 }
-                _ => (),
-            },
-            Ok(Event::Eof) => break,
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-            _ => (),
-        }
-        buf.clear();
-    }
+            }
+        },
+        Event::Eof => break,
+    );
+
     Ok(result)
 }

--- a/src/reader/xlsx/worksheet.rs
+++ b/src/reader/xlsx/worksheet.rs
@@ -26,182 +26,177 @@ pub(crate) fn read(
     let data = std::io::Cursor::new(raw_data_of_worksheet.get_worksheet_file().get_file_data());
     let mut reader = Reader::from_reader(data);
     reader.trim_text(true);
-    let mut buf = Vec::new();
 
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                b"sheetPr" => {
-                    for a in e.attributes().with_checks(false) {
-                        match a {
-                            Ok(ref attr) if attr.key.0 == b"codeName" => {
-                                worksheet.set_code_name(get_attribute_value(attr)?);
-                            }
-                            Ok(_) => {}
-                            Err(_) => {}
+    xml_read_loop!(
+        reader,
+        Event::Start(ref e) => match e.name().into_inner() {
+            b"sheetPr" => {
+                for a in e.attributes().with_checks(false) {
+                    match a {
+                        Ok(ref attr) if attr.key.0 == b"codeName" => {
+                            worksheet.set_code_name(get_attribute_value(attr)?);
                         }
+                        Ok(_) => {}
+                        Err(_) => {}
                     }
                 }
-                b"sheetViews" => {
-                    worksheet
-                        .get_sheet_views_mut()
-                        .set_attributes(&mut reader, e);
-                }
-                b"sheetFormatPr" => {
-                    worksheet
-                        .get_sheet_format_properties_mut()
-                        .set_attributes(&mut reader, e);
-                }
-                b"selection" => {
-                    for a in e.attributes().with_checks(false) {
-                        match a {
-                            Ok(ref attr) if attr.key.0 == b"activeCell" => {
-                                worksheet.set_active_cell(get_attribute_value(attr)?);
-                            }
-                            Ok(_) => {}
-                            Err(_) => {}
+            }
+            b"sheetViews" => {
+                worksheet
+                    .get_sheet_views_mut()
+                    .set_attributes(&mut reader, e);
+            }
+            b"sheetFormatPr" => {
+                worksheet
+                    .get_sheet_format_properties_mut()
+                    .set_attributes(&mut reader, e);
+            }
+            b"selection" => {
+                for a in e.attributes().with_checks(false) {
+                    match a {
+                        Ok(ref attr) if attr.key.0 == b"activeCell" => {
+                            worksheet.set_active_cell(get_attribute_value(attr)?);
                         }
+                        Ok(_) => {}
+                        Err(_) => {}
                     }
                 }
-                b"row" => {
-                    let mut obj = Row::default();
-                    obj.set_attributes(
-                        &mut reader,
-                        e,
-                        worksheet.get_cell_collection_crate_mut(),
-                        shared_string_table,
-                        stylesheet,
-                        false,
-                    );
-                    worksheet.set_row_dimension(obj);
-                }
-                b"autoFilter" => {
-                    worksheet.set_auto_filter(get_attribute(e, b"ref").unwrap());
-                }
-                b"cols" => {
-                    let mut obj = Columns::default();
-                    obj.set_attributes(&mut reader, e, stylesheet);
-                    worksheet.set_column_dimensions_crate(obj);
-                }
-                b"mergeCells" => {
-                    worksheet
-                        .get_merge_cells_crate_mut()
-                        .set_attributes(&mut reader, e);
-                }
-                b"conditionalFormatting" => {
-                    let mut obj = ConditionalFormatting::default();
-                    obj.set_attributes(&mut reader, e, stylesheet.get_differential_formats());
-                    worksheet.add_conditional_formatting_collection(obj);
-                }
-                b"dataValidations" => {
-                    let mut obj = DataValidations::default();
-                    obj.set_attributes(&mut reader, e);
-                    worksheet.set_data_validations(obj);
-                }
-                b"oleObjects" => {
-                    let mut obj = OleObjects::default();
-                    obj.set_attributes(
-                        &mut reader,
-                        e,
-                        raw_data_of_worksheet.get_worksheet_relationships().unwrap(),
-                    );
-                    worksheet.set_ole_objects(obj);
-                }
-                b"headerFooter" => {
-                    worksheet
-                        .get_header_footer_mut()
-                        .set_attributes(&mut reader, e);
-                }
-                b"rowBreaks" => {
-                    worksheet
-                        .get_row_breaks_mut()
-                        .set_attributes(&mut reader, e);
-                }
-                b"colBreaks" => {
-                    worksheet
-                        .get_column_breaks_mut()
-                        .set_attributes(&mut reader, e);
-                }
-                _ => (),
-            },
-            Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                b"sheetPr" => {
-                    for a in e.attributes().with_checks(false) {
-                        match a {
-                            Ok(ref attr) if attr.key.0 == b"codeName" => {
-                                worksheet.set_code_name(get_attribute_value(attr)?);
-                            }
-                            Ok(_) => {}
-                            Err(_) => {}
-                        }
-                    }
-                }
-                b"tabColor" => {
-                    worksheet
-                        .get_tab_color_mut()
-                        .set_attributes(&mut reader, e, true);
-                    worksheet.get_tab_color_mut().set_argb_by_theme(theme);
-                }
-                b"sheetFormatPr" => {
-                    worksheet
-                        .get_sheet_format_properties_mut()
-                        .set_attributes(&mut reader, e);
-                }
-                b"selection" => {
-                    for a in e.attributes().with_checks(false) {
-                        match a {
-                            Ok(ref attr) if attr.key.0 == b"activeCell" => {
-                                worksheet.set_active_cell(get_attribute_value(attr)?);
-                            }
-                            Ok(_) => {}
-                            Err(_) => {}
-                        }
-                    }
-                }
-                b"row" => {
-                    let mut obj = Row::default();
-                    obj.set_attributes(
-                        &mut reader,
-                        e,
-                        worksheet.get_cell_collection_crate_mut(),
-                        shared_string_table,
-                        stylesheet,
-                        true,
-                    );
-                    worksheet.set_row_dimension(obj);
-                }
-                b"autoFilter" => {
-                    worksheet.set_auto_filter(get_attribute(e, b"ref").unwrap());
-                }
-                b"pageMargins" => {
-                    worksheet
-                        .get_page_margins_mut()
-                        .set_attributes(&mut reader, e);
-                }
-                b"hyperlink" => {
-                    let (coor, _rid, hyperlink) = get_hyperlink(e);
-                    let _ = worksheet.get_cell_mut(coor).set_hyperlink(hyperlink);
-                }
-                b"printOptions" => {
-                    worksheet
-                        .get_print_options_mut()
-                        .set_attributes(&mut reader, e);
-                }
-                b"pageSetup" => {
-                    worksheet.get_page_setup_mut().set_attributes(
-                        &mut reader,
-                        e,
-                        raw_data_of_worksheet.get_worksheet_relationships(),
-                    );
-                }
-                _ => (),
-            },
-            Ok(Event::Eof) => break,
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+            }
+            b"row" => {
+                let mut obj = Row::default();
+                obj.set_attributes(
+                    &mut reader,
+                    e,
+                    worksheet.get_cell_collection_crate_mut(),
+                    shared_string_table,
+                    stylesheet,
+                    false,
+                );
+                worksheet.set_row_dimension(obj);
+            }
+            b"autoFilter" => {
+                worksheet.set_auto_filter(get_attribute(e, b"ref").unwrap());
+            }
+            b"cols" => {
+                let mut obj = Columns::default();
+                obj.set_attributes(&mut reader, e, stylesheet);
+                worksheet.set_column_dimensions_crate(obj);
+            }
+            b"mergeCells" => {
+                worksheet
+                    .get_merge_cells_crate_mut()
+                    .set_attributes(&mut reader, e);
+            }
+            b"conditionalFormatting" => {
+                let mut obj = ConditionalFormatting::default();
+                obj.set_attributes(&mut reader, e, stylesheet.get_differential_formats());
+                worksheet.add_conditional_formatting_collection(obj);
+            }
+            b"dataValidations" => {
+                let mut obj = DataValidations::default();
+                obj.set_attributes(&mut reader, e);
+                worksheet.set_data_validations(obj);
+            }
+            b"oleObjects" => {
+                let mut obj = OleObjects::default();
+                obj.set_attributes(
+                    &mut reader,
+                    e,
+                    raw_data_of_worksheet.get_worksheet_relationships().unwrap(),
+                );
+                worksheet.set_ole_objects(obj);
+            }
+            b"headerFooter" => {
+                worksheet
+                    .get_header_footer_mut()
+                    .set_attributes(&mut reader, e);
+            }
+            b"rowBreaks" => {
+                worksheet
+                    .get_row_breaks_mut()
+                    .set_attributes(&mut reader, e);
+            }
+            b"colBreaks" => {
+                worksheet
+                    .get_column_breaks_mut()
+                    .set_attributes(&mut reader, e);
+            }
             _ => (),
-        }
-        buf.clear();
-    }
+        },
+        Event::Empty(ref e) => match e.name().into_inner() {
+            b"sheetPr" => {
+                for a in e.attributes().with_checks(false) {
+                    match a {
+                        Ok(ref attr) if attr.key.0 == b"codeName" => {
+                            worksheet.set_code_name(get_attribute_value(attr)?);
+                        }
+                        Ok(_) => {}
+                        Err(_) => {}
+                    }
+                }
+            }
+            b"tabColor" => {
+                worksheet
+                    .get_tab_color_mut()
+                    .set_attributes(&mut reader, e, true);
+                worksheet.get_tab_color_mut().set_argb_by_theme(theme);
+            }
+            b"sheetFormatPr" => {
+                worksheet
+                    .get_sheet_format_properties_mut()
+                    .set_attributes(&mut reader, e);
+            }
+            b"selection" => {
+                for a in e.attributes().with_checks(false) {
+                    match a {
+                        Ok(ref attr) if attr.key.0 == b"activeCell" => {
+                            worksheet.set_active_cell(get_attribute_value(attr)?);
+                        }
+                        Ok(_) => {}
+                        Err(_) => {}
+                    }
+                }
+            }
+            b"row" => {
+                let mut obj = Row::default();
+                obj.set_attributes(
+                    &mut reader,
+                    e,
+                    worksheet.get_cell_collection_crate_mut(),
+                    shared_string_table,
+                    stylesheet,
+                    true,
+                );
+                worksheet.set_row_dimension(obj);
+            }
+            b"autoFilter" => {
+                worksheet.set_auto_filter(get_attribute(e, b"ref").unwrap());
+            }
+            b"pageMargins" => {
+                worksheet
+                    .get_page_margins_mut()
+                    .set_attributes(&mut reader, e);
+            }
+            b"hyperlink" => {
+                let (coor, _rid, hyperlink) = get_hyperlink(e);
+                let _ = worksheet.get_cell_mut(coor).set_hyperlink(hyperlink);
+            }
+            b"printOptions" => {
+                worksheet
+                    .get_print_options_mut()
+                    .set_attributes(&mut reader, e);
+            }
+            b"pageSetup" => {
+                worksheet.get_page_setup_mut().set_attributes(
+                    &mut reader,
+                    e,
+                    raw_data_of_worksheet.get_worksheet_relationships(),
+                );
+            }
+            _ => (),
+        },
+        Event::Eof => break,
+    );
 
     Ok(())
 }
@@ -214,46 +209,39 @@ pub(crate) fn read_lite(
     let data = std::io::Cursor::new(raw_data_of_worksheet.get_worksheet_file().get_file_data());
     let mut reader = Reader::from_reader(data);
     reader.trim_text(true);
-    let mut buf = Vec::new();
 
     let mut cells = Cells::default();
 
-    loop {
-        match reader.read_event_into(&mut buf) {
-            Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                b"row" => {
-                    let mut obj = Row::default();
-                    obj.set_attributes(
-                        &mut reader,
-                        e,
-                        &mut cells,
-                        shared_string_table,
-                        stylesheet,
-                        false,
-                    );
-                }
-                _ => (),
-            },
-            Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                b"row" => {
-                    let mut obj = Row::default();
-                    obj.set_attributes(
-                        &mut reader,
-                        e,
-                        &mut cells,
-                        shared_string_table,
-                        stylesheet,
-                        true,
-                    );
-                }
-                _ => (),
-            },
-            Ok(Event::Eof) => break,
-            Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-            _ => (),
-        }
-        buf.clear();
-    }
+    xml_read_loop!(
+        reader,
+        Event::Start(ref e) => {
+            if e.name().into_inner() == b"row" {
+                let mut obj = Row::default();
+                obj.set_attributes(
+                    &mut reader,
+                    e,
+                    &mut cells,
+                    shared_string_table,
+                    stylesheet,
+                    false,
+                );
+            }
+        },
+        Event::Empty(ref e) => {
+            if e.name().into_inner() == b"row" {
+                let mut obj = Row::default();
+                obj.set_attributes(
+                    &mut reader,
+                    e,
+                    &mut cells,
+                    shared_string_table,
+                    stylesheet,
+                    true,
+                );
+            }
+        },
+        Event::Eof => break,
+    );
 
     Ok(cells)
 }

--- a/src/structs/address.rs
+++ b/src/structs/address.rs
@@ -5,6 +5,7 @@ pub struct Address {
     sheet_name: String,
     range: Range,
 }
+
 impl Address {
     pub fn get_sheet_name(&self) -> &str {
         &self.sheet_name
@@ -49,11 +50,8 @@ impl Address {
             return range;
         }
         let mut with_space_char = String::from("");
-        match self.get_sheet_name().find(char::is_whitespace) {
-            Some(_) => {
-                with_space_char = String::from("'");
-            }
-            None => {}
+        if self.get_sheet_name().contains(char::is_whitespace) {
+            with_space_char = String::from("'");
         }
         format!(
             "{}{}{}!{}",
@@ -72,7 +70,7 @@ impl Address {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        if &self.sheet_name == sheet_name {
+        if self.sheet_name == sheet_name {
             self.range.adjustment_insert_coordinate(
                 root_col_num,
                 offset_col_num,
@@ -90,7 +88,7 @@ impl Address {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        if &self.sheet_name == sheet_name {
+        if self.sheet_name == sheet_name {
             self.range.adjustment_remove_coordinate(
                 root_col_num,
                 offset_col_num,
@@ -108,7 +106,7 @@ impl Address {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) -> bool {
-        if &self.sheet_name == sheet_name {
+        if self.sheet_name == sheet_name {
             return self.range.is_remove(
                 root_col_num,
                 offset_col_num,

--- a/src/structs/alignment.rs
+++ b/src/structs/alignment.rs
@@ -19,6 +19,7 @@ pub struct Alignment {
     wrap_text: BooleanValue,
     text_rotation: UInt32Value,
 }
+
 impl Alignment {
     pub fn get_horizontal(&self) -> &HorizontalAlignmentValues {
         self.horizontal.get_value()
@@ -70,30 +71,10 @@ impl Alignment {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"horizontal") {
-            Some(v) => {
-                self.horizontal.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"vertical") {
-            Some(v) => {
-                self.vertical.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"wrapText") {
-            Some(v) => {
-                self.wrap_text.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"textRotation") {
-            Some(v) => {
-                self.text_rotation.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, horizontal, "horizontal");
+        set_string_from_xml!(self, e, vertical, "vertical");
+        set_string_from_xml!(self, e, wrap_text, "wrapText");
+        set_string_from_xml!(self, e, text_rotation, "textRotation");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/anchor.rs
+++ b/src/structs/anchor.rs
@@ -9,6 +9,7 @@ pub struct Anchor {
     bottom_row: u32,
     bottom_offset: u32,
 }
+
 impl Anchor {
     pub fn get_left_column(&self) -> &u32 {
         &self.left_column

--- a/src/structs/auto_filter.rs
+++ b/src/structs/auto_filter.rs
@@ -4,6 +4,7 @@ use super::Range;
 pub struct AutoFilter {
     range: Range,
 }
+
 impl AutoFilter {
     pub fn get_range(&self) -> &Range {
         &self.range

--- a/src/structs/bold.rs
+++ b/src/structs/bold.rs
@@ -11,6 +11,7 @@ use writer::driver::*;
 pub struct Bold {
     pub(crate) val: BooleanValue,
 }
+
 impl Bold {
     pub fn get_val(&self) -> &bool {
         self.val.get_value()
@@ -27,12 +28,7 @@ impl Bold {
         e: &BytesStart,
     ) {
         self.val.set_value(true);
-        match get_attribute(e, b"val") {
-            Some(v) => {
-                self.val.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, val, "val");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/boolean_value.rs
+++ b/src/structs/boolean_value.rs
@@ -2,6 +2,7 @@
 pub struct BooleanValue {
     value: Option<bool>,
 }
+
 impl BooleanValue {
     pub(crate) fn get_value(&self) -> &bool {
         match &self.value {
@@ -11,10 +12,10 @@ impl BooleanValue {
     }
 
     pub(crate) fn get_value_string(&self) -> &str {
-        if self.get_value() == &false {
-            "0"
-        } else {
+        if *self.get_value() {
             "1"
+        } else {
+            "0"
         }
     }
 
@@ -24,19 +25,11 @@ impl BooleanValue {
     }
 
     pub(crate) fn set_value_string<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        let v = match value.into().as_str() {
-            "true" => true,
-            "1" => true,
-            _ => false,
-        };
-        self.set_value(v)
+        self.set_value(matches!(value.into().as_str(), "true" | "1"))
     }
 
     pub(crate) fn has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 
     pub(crate) fn get_hash_string(&self) -> &str {

--- a/src/structs/break.rs
+++ b/src/structs/break.rs
@@ -15,6 +15,7 @@ pub struct Break {
     min: UInt32Value,
     manual_page_break: BooleanValue,
 }
+
 impl Break {
     pub fn get_id(&self) -> &u32 {
         self.id.get_value()
@@ -48,33 +49,10 @@ impl Break {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"id") {
-            Some(v) => {
-                self.id.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"max") {
-            Some(v) => {
-                self.max.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"min") {
-            Some(v) => {
-                self.min.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"man") {
-            Some(v) => {
-                self.manual_page_break.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, id, "id");
+        set_string_from_xml!(self, e, max, "max");
+        set_string_from_xml!(self, e, min, "min");
+        set_string_from_xml!(self, e, manual_page_break, "man");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/byte_value.rs
+++ b/src/structs/byte_value.rs
@@ -24,9 +24,6 @@ impl ByteValue {
     }
 
     pub(crate) fn has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 }

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -248,26 +248,17 @@ impl Cell {
     ) {
         let mut type_value: String = String::from("");
 
-        match get_attribute(e, b"r") {
-            Some(v) => {
-                self.coordinate.set_coordinate(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"r") {
+            self.coordinate.set_coordinate(v);
         }
 
-        match get_attribute(e, b"s") {
-            Some(v) => {
-                let style = stylesheet.get_style(v.parse::<usize>().unwrap());
-                self.set_style(style);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"s") {
+            let style = stylesheet.get_style(v.parse::<usize>().unwrap());
+            self.set_style(style);
         }
 
-        match get_attribute(e, b"t") {
-            Some(v) => {
-                type_value = v;
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"t") {
+            type_value = v;
         }
 
         if empty_flag {

--- a/src/structs/cell_formats.rs
+++ b/src/structs/cell_formats.rs
@@ -3,6 +3,7 @@ use super::CellFormat;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub(crate) struct CellFormats {
     cell_format: Vec<CellFormat>,
 }
+
 impl CellFormats {
     pub(crate) fn get_cell_format(&self) -> &Vec<CellFormat> {
         &self.cell_format
@@ -29,35 +31,29 @@ impl CellFormats {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"xf" => {
-                        let mut obj = CellFormat::default();
-                        obj.set_attributes(reader, e, true);
-                        self.set_cell_format(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"xf" => {
-                        let mut obj = CellFormat::default();
-                        obj.set_attributes(reader, e, false);
-                        self.set_cell_format(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"cellXfs" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "cellXfs"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"xf" {
+                    let mut obj = CellFormat::default();
+                    obj.set_attributes(reader, e, true);
+                    self.set_cell_format(obj);
+                }
+            },
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"xf" {
+                    let mut obj = CellFormat::default();
+                    obj.set_attributes(reader, e, false);
+                    self.set_cell_format(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"cellXfs" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "cellXfs")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/cell_style.rs
+++ b/src/structs/cell_style.rs
@@ -14,6 +14,7 @@ pub struct CellStyle {
     builtin_id: UInt32Value,
     format_id: UInt32Value,
 }
+
 impl CellStyle {
     pub fn get_name(&self) -> &str {
         self.name.get_value()
@@ -47,24 +48,9 @@ impl CellStyle {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"name") {
-            Some(v) => {
-                self.name.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"xfId") {
-            Some(v) => {
-                self.builtin_id.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"builtinId") {
-            Some(v) => {
-                self.format_id.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, name, "name");
+        set_string_from_xml!(self, e, builtin_id, "builtinId");
+        set_string_from_xml!(self, e, format_id, "xfId");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/cell_style_formats.rs
+++ b/src/structs/cell_style_formats.rs
@@ -3,6 +3,7 @@ use super::CellFormat;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub(crate) struct CellStyleFormats {
     cell_format: Vec<CellFormat>,
 }
+
 impl CellStyleFormats {
     pub(crate) fn get_cell_format(&self) -> &Vec<CellFormat> {
         &self.cell_format
@@ -29,35 +31,29 @@ impl CellStyleFormats {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"xf" => {
-                        let mut obj = CellFormat::default();
-                        obj.set_attributes(reader, e, true);
-                        self.set_cell_format(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"xf" => {
-                        let mut obj = CellFormat::default();
-                        obj.set_attributes(reader, e, false);
-                        self.set_cell_format(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"cellStyleXfs" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "cellStyleXfs"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"xf" {
+                    let mut obj = CellFormat::default();
+                    obj.set_attributes(reader, e, true);
+                    self.set_cell_format(obj);
+                }
+            },
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"xf" {
+                    let mut obj = CellFormat::default();
+                    obj.set_attributes(reader, e, false);
+                    self.set_cell_format(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"cellStyleXfs" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "cellStyleXfs")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/cell_value.rs
+++ b/src/structs/cell_value.rs
@@ -44,11 +44,8 @@ impl CellValue {
     }
 
     pub fn get_value_lazy(&mut self) -> Cow<'static, str> {
-        match &self.raw_value {
-            CellRawValue::Lazy(v) => {
-                self.raw_value = Self::guess_typed_data(v);
-            }
-            _ => {}
+        if let CellRawValue::Lazy(v) = &self.raw_value {
+            self.raw_value = Self::guess_typed_data(v);
         }
         self.remove_formula();
         self.raw_value.to_string().into()

--- a/src/structs/chart.rs
+++ b/src/structs/chart.rs
@@ -158,18 +158,16 @@ impl Chart {
         let title = self.make_title(value);
         let plot_area = self.get_plot_area_mut();
         match plot_area.get_value_axis_mut().len() {
-            1 => match plot_area.get_value_axis_mut().get_mut(0) {
-                Some(v) => {
+            1 => {
+                if let Some(v) = plot_area.get_value_axis_mut().get_mut(0) {
                     v.set_title(title);
                 }
-                None => {}
-            },
-            2 => match plot_area.get_value_axis_mut().get_mut(1) {
-                Some(v) => {
+            }
+            2 => {
+                if let Some(v) = plot_area.get_value_axis_mut().get_mut(1) {
                     v.set_title(title);
                 }
-                None => {}
-            },
+            }
             _ => {}
         }
         self
@@ -179,18 +177,16 @@ impl Chart {
         let title = self.make_title(value);
         let plot_area = self.get_plot_area_mut();
         match plot_area.get_value_axis_mut().len() {
-            1 => match plot_area.get_category_axis_mut().get_mut(0) {
-                Some(v) => {
+            1 => {
+                if let Some(v) = plot_area.get_category_axis_mut().get_mut(0) {
                     v.set_title(title);
                 }
-                None => {}
-            },
-            2 => match plot_area.get_value_axis_mut().get_mut(0) {
-                Some(v) => {
+            }
+            2 => {
+                if let Some(v) = plot_area.get_value_axis_mut().get_mut(0) {
                     v.set_title(title);
                 }
-                None => {}
-            },
+            }
             _ => {}
         }
         self
@@ -207,13 +203,10 @@ impl Chart {
             .get_area_chart_series_mut()
         {
             let value_raw = value_iter.next();
-            match value_raw {
-                Some(v) => {
-                    let mut series_text = SeriesText::default();
-                    series_text.set_value(v.clone());
-                    series.set_series_text(series_text);
-                }
-                None => {}
+            if let Some(v) = value_raw {
+                let mut series_text = SeriesText::default();
+                series_text.set_value(v.clone());
+                series.set_series_text(series_text);
             }
         }
         self

--- a/src/structs/color_scale.rs
+++ b/src/structs/color_scale.rs
@@ -4,6 +4,7 @@ use quick_xml::events::BytesStart;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -12,6 +13,7 @@ pub struct ColorScale {
     cfvo_collection: Vec<ConditionalFormatValueObject>,
     color_collection: Vec<Color>,
 }
+
 impl ColorScale {
     pub fn get_cfvo_collection(&self) -> &Vec<ConditionalFormatValueObject> {
         &self.cfvo_collection
@@ -46,10 +48,10 @@ impl ColorScale {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
                     b"cfvo" => {
                         let mut obj = ConditionalFormatValueObject::default();
                         obj.set_attributes(reader, e, true);
@@ -61,8 +63,10 @@ impl ColorScale {
                         self.color_collection.push(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
+                }
+            },
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
                     b"cfvo" => {
                         let mut obj = ConditionalFormatValueObject::default();
                         obj.set_attributes(reader, e, false);
@@ -74,17 +78,15 @@ impl ColorScale {
                         self.color_collection.push(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"colorScale" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "colorScale"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"colorScale" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "colorScale")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/colors.rs
+++ b/src/structs/colors.rs
@@ -3,6 +3,7 @@ use super::MruColors;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub(crate) struct Colors {
     mru_colors: MruColors,
 }
+
 impl Colors {
     pub(crate) fn _get_mru_colors(&self) -> &MruColors {
         &self.mru_colors
@@ -29,25 +31,20 @@ impl Colors {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"mruColors" => {
-                        self.mru_colors.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"colors" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "colors"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"mruColors" {
+                    self.mru_colors.set_attributes(reader, e);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"colors" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "colors")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/column.rs
+++ b/src/structs/column.rs
@@ -33,6 +33,7 @@ pub struct Column {
     style: Style,
     auto_width: BooleanValue,
 }
+
 impl Default for Column {
     fn default() -> Self {
         let mut width = DoubleValue::default();
@@ -47,6 +48,7 @@ impl Default for Column {
         }
     }
 }
+
 impl Column {
     pub fn get_col_num(&self) -> &u32 {
         self.col_num.get_value()
@@ -182,33 +184,13 @@ impl Column {
         e: &BytesStart,
         stylesheet: &Stylesheet,
     ) {
-        match get_attribute(e, b"width") {
-            Some(v) => {
-                self.width.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, width, "width");
+        set_string_from_xml!(self, e, hidden, "hidden");
+        set_string_from_xml!(self, e, best_fit, "bestFit");
 
-        match get_attribute(e, b"hidden") {
-            Some(v) => {
-                self.hidden.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"bestFit") {
-            Some(v) => {
-                self.best_fit.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"style") {
-            Some(v) => {
-                let style = stylesheet.get_style(v.parse::<usize>().unwrap());
-                self.set_style(style);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"style") {
+            let style = stylesheet.get_style(v.parse::<usize>().unwrap());
+            self.set_style(style);
         }
     }
 }

--- a/src/structs/column_breaks.rs
+++ b/src/structs/column_breaks.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Break;
 use writer::driver::*;
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub struct ColumnBreaks {
     break_list: Vec<Break>,
 }
+
 impl ColumnBreaks {
     pub fn get_break_list(&self) -> &Vec<Break> {
         &self.break_list
@@ -36,27 +38,22 @@ impl ColumnBreaks {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"brk" => {
-                        let mut obj = Break::default();
-                        obj.set_attributes(reader, e);
-                        self.add_break_list(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"colBreaks" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "colBreaks"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"brk" {
+                    let mut obj = Break::default();
+                    obj.set_attributes(reader, e);
+                    self.add_break_list(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"colBreaks" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "colBreaks")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/column_reference.rs
+++ b/src/structs/column_reference.rs
@@ -26,11 +26,11 @@ impl ColumnReference {
     }
 
     pub(crate) fn offset_num(&mut self, value: i32) -> &mut Self {
-        if &value > &0 {
+        if value > 0 {
             self.plus_num(value as u32);
         }
-        if &value < &0 {
-            self.minus_num((value * -1) as u32);
+        if value < 0 {
+            self.minus_num(-value as u32);
         }
         self
     }
@@ -62,7 +62,7 @@ impl ColumnReference {
     pub(crate) fn get_coordinate(&self) -> String {
         format!(
             "{}{}",
-            if &self.is_lock == &true { "$" } else { "" },
+            if self.is_lock { "$" } else { "" },
             string_from_column_index(&self.num),
         )
     }
@@ -85,9 +85,7 @@ impl ColumnReference {
 
     pub(crate) fn is_remove(&self, root_col_num: &u32, offset_col_num: &u32) -> bool {
         if root_col_num > &0 {
-            let col_result =
-                &self.num >= root_col_num && &self.num < &(root_col_num + offset_col_num);
-            return col_result;
+            return &self.num >= root_col_num && self.num < (root_col_num + offset_col_num);
         }
         false
     }

--- a/src/structs/data_bar.rs
+++ b/src/structs/data_bar.rs
@@ -4,6 +4,7 @@ use quick_xml::events::BytesStart;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -12,6 +13,7 @@ pub struct DataBar {
     cfvo_collection: Vec<ConditionalFormatValueObject>,
     color_collection: Vec<Color>,
 }
+
 impl DataBar {
     pub fn get_cfvo_collection(&self) -> &Vec<ConditionalFormatValueObject> {
         &self.cfvo_collection
@@ -46,10 +48,10 @@ impl DataBar {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
                     b"cfvo" => {
                         let mut obj = ConditionalFormatValueObject::default();
                         obj.set_attributes(reader, e, true);
@@ -61,17 +63,15 @@ impl DataBar {
                         self.color_collection.push(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"dataBar" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "dataBar"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"dataBar" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "dataBar")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/data_validations.rs
+++ b/src/structs/data_validations.rs
@@ -3,6 +3,7 @@ use super::DataValidation;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub struct DataValidations {
     data_validation_list: Vec<DataValidation>,
 }
+
 impl DataValidations {
     pub fn get_data_validation_list(&self) -> &Vec<DataValidation> {
         &self.data_validation_list
@@ -34,35 +36,29 @@ impl DataValidations {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"dataValidation" => {
-                        let mut obj = DataValidation::default();
-                        obj.set_attributes(reader, e, true);
-                        self.add_data_validation_list(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"dataValidation" => {
-                        let mut obj = DataValidation::default();
-                        obj.set_attributes(reader, e, false);
-                        self.add_data_validation_list(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"dataValidations" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "dataValidations"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"dataValidation" {
+                    let mut obj = DataValidation::default();
+                    obj.set_attributes(reader, e, true);
+                    self.add_data_validation_list(obj);
+                }
+            },
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"dataValidation" {
+                    let mut obj = DataValidation::default();
+                    obj.set_attributes(reader, e, false);
+                    self.add_data_validation_list(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"dataValidations" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "dataValidations")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/double_value.rs
+++ b/src/structs/double_value.rs
@@ -24,10 +24,7 @@ impl DoubleValue {
     }
 
     pub(crate) fn has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 
     pub(crate) fn get_hash_string(&self) -> String {

--- a/src/structs/drawing/bevel_bottom.rs
+++ b/src/structs/drawing/bevel_bottom.rs
@@ -15,6 +15,7 @@ pub struct BevelBottom {
     height: Int64Value,
     preset: EnumValue<BevelPresetValues>,
 }
+
 impl BevelBottom {
     pub fn get_width(&self) -> &i64 {
         self.width.get_value()
@@ -48,38 +49,23 @@ impl BevelBottom {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"w") {
-            Some(v) => {
-                self.width.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"h") {
-            Some(v) => {
-                self.height.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"prst") {
-            Some(v) => {
-                self.preset.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, width, "w");
+        set_string_from_xml!(self, e, height, "h");
+        set_string_from_xml!(self, e, preset, "prst");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:bevelB
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         let width = self.width.get_value_string();
-        if &self.width.has_value() == &true {
+        if self.width.has_value() {
             attributes.push(("w", &width));
         }
         let height = self.height.get_value_string();
-        if &self.height.has_value() == &true {
+        if self.height.has_value() {
             attributes.push(("h", &height));
         }
-        if &self.preset.has_value() == &true {
+        if self.preset.has_value() {
             attributes.push(("prst", self.preset.get_value_string()));
         }
 

--- a/src/structs/drawing/bevel_top.rs
+++ b/src/structs/drawing/bevel_top.rs
@@ -15,6 +15,7 @@ pub struct BevelTop {
     height: Int64Value,
     preset: EnumValue<BevelPresetValues>,
 }
+
 impl BevelTop {
     pub fn get_width(&self) -> &i64 {
         self.width.get_value()
@@ -48,38 +49,23 @@ impl BevelTop {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"w") {
-            Some(v) => {
-                self.width.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"h") {
-            Some(v) => {
-                self.height.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"prst") {
-            Some(v) => {
-                self.preset.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, width, "w");
+        set_string_from_xml!(self, e, height, "h");
+        set_string_from_xml!(self, e, preset, "prst");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:bevelT
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         let width = self.width.get_value_string();
-        if &self.width.has_value() == &true {
+        if self.width.has_value() {
             attributes.push(("w", &width));
         }
         let height = self.height.get_value_string();
-        if &self.height.has_value() == &true {
+        if self.height.has_value() {
             attributes.push(("h", &height));
         }
-        if &self.preset.has_value() == &true {
+        if self.preset.has_value() {
             attributes.push(("prst", self.preset.get_value_string()));
         }
 

--- a/src/structs/drawing/blip.rs
+++ b/src/structs/drawing/blip.rs
@@ -13,6 +13,7 @@ pub struct Blip {
     image: MediaObject,
     cstate: String,
 }
+
 impl Blip {
     pub fn get_image(&self) -> &MediaObject {
         &self.image
@@ -42,11 +43,8 @@ impl Blip {
         e: &BytesStart,
         drawing_relationships: &RawRelationships,
     ) {
-        match get_attribute(e, b"cstate") {
-            Some(v) => {
-                self.set_cstate(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"cstate") {
+            self.set_cstate(v);
         }
 
         let picture_id = get_attribute(e, b"r:embed").unwrap();

--- a/src/structs/drawing/charts/area_chart.rs
+++ b/src/structs/drawing/charts/area_chart.rs
@@ -8,6 +8,7 @@ use super::VaryColors;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -20,6 +21,7 @@ pub struct AreaChart {
     data_labels: DataLabels,
     axis_id: Vec<AxisId>,
 }
+
 impl AreaChart {
     pub fn get_grouping(&self) -> &Grouping {
         &self.grouping
@@ -96,22 +98,24 @@ impl AreaChart {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
                     b"c:ser" => {
                         let mut obj = AreaChartSeries::default();
                         obj.set_attributes(reader, e);
                         self.get_area_chart_series_list_mut()
                             .add_area_chart_series(obj);
-                    }
+                        }
                     b"c:dLbls" => {
                         self.data_labels.set_attributes(reader, e);
                     }
                     _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+                }
+            },
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
                     b"c:grouping" => {
                         self.grouping.set_attributes(reader, e);
                     }
@@ -124,17 +128,15 @@ impl AreaChart {
                         self.add_axis_id(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:areaChart" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:areaChart"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:areaChart" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:areaChart")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/back_wall.rs
+++ b/src/structs/drawing/charts/back_wall.rs
@@ -4,6 +4,7 @@ use super::Thickness;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -12,6 +13,7 @@ pub struct BackWall {
     thickness: Option<Thickness>,
     shape_properties: Option<ShapeProperties>,
 }
+
 impl BackWall {
     pub fn get_thickness(&self) -> &Option<Thickness> {
         &self.thickness
@@ -44,35 +46,29 @@ impl BackWall {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"c:thickness" => {
-                        let mut obj = Thickness::default();
-                        obj.set_attributes(reader, e);
-                        self.set_thickness(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"c:spPr" => {
-                        let mut obj = ShapeProperties::default();
-                        obj.set_attributes(reader, e);
-                        self.set_shape_properties(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:backWall" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:backWall"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"c:thickness" {
+                    let mut obj = Thickness::default();
+                    obj.set_attributes(reader, e);
+                    self.set_thickness(obj);
+                }
+            },
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"c:spPr" {
+                    let mut obj = ShapeProperties::default();
+                    obj.set_attributes(reader, e);
+                    self.set_shape_properties(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:backWall" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:backWall")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
@@ -80,19 +76,13 @@ impl BackWall {
         write_start_tag(writer, "c:backWall", vec![], false);
 
         // c:thickness
-        match &self.thickness {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.thickness {
+            v.write_to(writer);
         }
 
         // c:spPr
-        match &self.shape_properties {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.shape_properties {
+            v.write_to(writer);
         }
 
         write_end_tag(writer, "c:backWall");

--- a/src/structs/drawing/charts/bar_3d_chart.rs
+++ b/src/structs/drawing/charts/bar_3d_chart.rs
@@ -11,6 +11,7 @@ use super::VaryColors;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -26,6 +27,7 @@ pub struct Bar3DChart {
     shape: Shape,
     axis_id: Vec<AxisId>,
 }
+
 impl Bar3DChart {
     pub fn get_bar_direction(&self) -> &BarDirection {
         &self.bar_direction
@@ -141,22 +143,24 @@ impl Bar3DChart {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
                     b"c:ser" => {
                         let mut obj = AreaChartSeries::default();
                         obj.set_attributes(reader, e);
                         self.get_area_chart_series_list_mut()
                             .add_area_chart_series(obj);
-                    }
+                        }
                     b"c:dLbls" => {
                         self.data_labels.set_attributes(reader, e);
                     }
                     _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+                }
+            },
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
                     b"c:barDir" => {
                         self.bar_direction.set_attributes(reader, e);
                     }
@@ -178,17 +182,15 @@ impl Bar3DChart {
                         self.add_axis_id(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:bar3DChart" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:bar3DChart"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:bar3DChart" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:bar3DChart")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/bar_chart.rs
+++ b/src/structs/drawing/charts/bar_chart.rs
@@ -11,6 +11,7 @@ use super::VaryColors;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -26,6 +27,7 @@ pub struct BarChart {
     overlap: Overlap,
     axis_id: Vec<AxisId>,
 }
+
 impl BarChart {
     pub fn get_bar_direction(&self) -> &BarDirection {
         &self.bar_direction
@@ -141,22 +143,24 @@ impl BarChart {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
                     b"c:ser" => {
                         let mut obj = AreaChartSeries::default();
                         obj.set_attributes(reader, e);
                         self.get_area_chart_series_list_mut()
                             .add_area_chart_series(obj);
-                    }
+                        }
                     b"c:dLbls" => {
                         self.data_labels.set_attributes(reader, e);
                     }
                     _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+                }
+            },
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
                     b"c:barDir" => {
                         self.bar_direction.set_attributes(reader, e);
                     }
@@ -178,17 +182,15 @@ impl BarChart {
                         self.add_axis_id(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:barChart" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:barChart"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:barChart" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:barChart")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/bubble_chart.rs
+++ b/src/structs/drawing/charts/bubble_chart.rs
@@ -9,6 +9,7 @@ use super::VaryColors;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -22,6 +23,7 @@ pub struct BubbleChart {
     show_negative_bubbles: ShowNegativeBubbles,
     axis_id: Vec<AxisId>,
 }
+
 impl BubbleChart {
     pub fn get_vary_colors(&self) -> &VaryColors {
         &self.vary_colors
@@ -111,22 +113,24 @@ impl BubbleChart {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
                     b"c:ser" => {
                         let mut obj = AreaChartSeries::default();
                         obj.set_attributes(reader, e);
                         self.get_area_chart_series_list_mut()
                             .add_area_chart_series(obj);
-                    }
+                        }
                     b"c:dLbls" => {
                         self.data_labels.set_attributes(reader, e);
                     }
                     _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+                }
+            },
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
                     b"c:varyColors" => {
                         self.vary_colors.set_attributes(reader, e);
                     }
@@ -142,17 +146,15 @@ impl BubbleChart {
                         self.add_axis_id(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:bubbleChart" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:bubbleChart"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:bubbleChart" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:bubbleChart")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/bubble_size.rs
+++ b/src/structs/drawing/charts/bubble_size.rs
@@ -3,6 +3,7 @@ use super::NumberReference;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -11,6 +12,7 @@ use writer::driver::*;
 pub struct BubbleSize {
     number_reference: NumberReference,
 }
+
 impl BubbleSize {
     pub fn get_number_reference(&self) -> &NumberReference {
         &self.number_reference
@@ -30,25 +32,20 @@ impl BubbleSize {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"c:numRef" => {
-                        self.number_reference.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:bubbleSize" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:bubbleSize"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"c:numRef" {
+                    self.number_reference.set_attributes(reader, e);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:bubbleSize" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:bubbleSize")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/category_axis.rs
+++ b/src/structs/drawing/charts/category_axis.rs
@@ -1,3 +1,5 @@
+use crate::xml_read_loop;
+
 // c:catAx
 use super::AutoLabeled;
 use super::AxisId;
@@ -42,6 +44,7 @@ pub struct CategoryAxis {
     shape_properties: Option<ShapeProperties>,
     text_properties: Option<TextProperties>,
 }
+
 impl CategoryAxis {
     pub fn get_axis_id(&self) -> &AxisId {
         &self.axis_id
@@ -269,89 +272,85 @@ impl CategoryAxis {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"c:title" => {
-                        let mut obj = Title::default();
-                        obj.set_attributes(reader, e);
-                        self.set_title(obj);
-                    }
-                    b"c:scaling" => {
-                        self.scaling.set_attributes(reader, e);
-                    }
-                    b"c:spPr" => {
-                        let mut obj = ShapeProperties::default();
-                        obj.set_attributes(reader, e);
-                        self.set_shape_properties(obj);
-                    }
-                    b"c:txPr" => {
-                        let mut obj = TextProperties::default();
-                        obj.set_attributes(reader, e);
-                        self.set_text_properties(obj);
-                    }
-                    b"c:majorGridlines" => {
-                        let mut obj = MajorGridlines::default();
-                        obj.set_attributes(reader, e, false);
-                        self.set_major_gridlines(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"c:axId" => {
-                        self.axis_id.set_attributes(reader, e);
-                    }
-                    b"c:delete" => {
-                        self.delete.set_attributes(reader, e);
-                    }
-                    b"c:axPos" => {
-                        self.axis_position.set_attributes(reader, e);
-                    }
-                    b"c:majorGridlines" => {
-                        let mut obj = MajorGridlines::default();
-                        obj.set_attributes(reader, e, true);
-                        self.set_major_gridlines(obj);
-                    }
-                    b"c:majorTickMark" => {
-                        self.major_tick_mark.set_attributes(reader, e);
-                    }
-                    b"c:minorTickMark" => {
-                        self.minor_tick_mark.set_attributes(reader, e);
-                    }
-                    b"c:tickLblPos" => {
-                        self.tick_label_position.set_attributes(reader, e);
-                    }
-                    b"c:crossAx" => {
-                        self.crossing_axis.set_attributes(reader, e);
-                    }
-                    b"c:crosses" => {
-                        self.crosses.set_attributes(reader, e);
-                    }
-                    b"c:auto" => {
-                        self.auto_labeled.set_attributes(reader, e);
-                    }
-                    b"c:lblAlgn" => {
-                        self.label_alignment.set_attributes(reader, e);
-                    }
-                    b"c:lblOffset" => {
-                        self.label_offset.set_attributes(reader, e);
-                    }
-                    b"c:noMultiLvlLbl" => {
-                        self.no_multi_level_labels.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:catAx" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:catAx"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => match e.name().into_inner() {
+                b"c:title" => {
+                    let mut obj = Title::default();
+                    obj.set_attributes(reader, e);
+                    self.set_title(obj);
+                }
+                b"c:scaling" => {
+                    self.scaling.set_attributes(reader, e);
+                }
+                b"c:spPr" => {
+                    let mut obj = ShapeProperties::default();
+                    obj.set_attributes(reader, e);
+                    self.set_shape_properties(obj);
+                }
+                b"c:txPr" => {
+                    let mut obj = TextProperties::default();
+                    obj.set_attributes(reader, e);
+                    self.set_text_properties(obj);
+                }
+                b"c:majorGridlines" => {
+                    let mut obj = MajorGridlines::default();
+                    obj.set_attributes(reader, e, false);
+                    self.set_major_gridlines(obj);
+                }
                 _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Empty(ref e) => match e.name().into_inner() {
+                b"c:axId" => {
+                    self.axis_id.set_attributes(reader, e);
+                }
+                b"c:delete" => {
+                    self.delete.set_attributes(reader, e);
+                }
+                b"c:axPos" => {
+                    self.axis_position.set_attributes(reader, e);
+                }
+                b"c:majorGridlines" => {
+                    let mut obj = MajorGridlines::default();
+                    obj.set_attributes(reader, e, true);
+                    self.set_major_gridlines(obj);
+                }
+                b"c:majorTickMark" => {
+                    self.major_tick_mark.set_attributes(reader, e);
+                }
+                b"c:minorTickMark" => {
+                    self.minor_tick_mark.set_attributes(reader, e);
+                }
+                b"c:tickLblPos" => {
+                    self.tick_label_position.set_attributes(reader, e);
+                }
+                b"c:crossAx" => {
+                    self.crossing_axis.set_attributes(reader, e);
+                }
+                b"c:crosses" => {
+                    self.crosses.set_attributes(reader, e);
+                }
+                b"c:auto" => {
+                    self.auto_labeled.set_attributes(reader, e);
+                }
+                b"c:lblAlgn" => {
+                    self.label_alignment.set_attributes(reader, e);
+                }
+                b"c:lblOffset" => {
+                    self.label_offset.set_attributes(reader, e);
+                }
+                b"c:noMultiLvlLbl" => {
+                    self.no_multi_level_labels.set_attributes(reader, e);
+                }
+                _ => (),
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:catAx" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:catAx"),
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
@@ -371,19 +370,13 @@ impl CategoryAxis {
         self.axis_position.write_to(writer);
 
         // c:title
-        match &self.title {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.title {
+            v.write_to(writer);
         }
 
         // c:majorGridlines
-        match &self.major_gridlines {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.major_gridlines {
+            v.write_to(writer);
         }
 
         // c:majorTickMark
@@ -396,19 +389,13 @@ impl CategoryAxis {
         self.tick_label_position.write_to(writer);
 
         // c:spPr
-        match &self.shape_properties {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.shape_properties {
+            v.write_to(writer);
         }
 
         // c:txPr
-        match &self.text_properties {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.text_properties {
+            v.write_to(writer);
         }
 
         // c:crossAx

--- a/src/structs/drawing/charts/chart_text.rs
+++ b/src/structs/drawing/charts/chart_text.rs
@@ -1,5 +1,6 @@
 // c:tx
 use super::RichText;
+use crate::xml_read_loop;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub struct ChartText {
     rich_text: RichText,
 }
+
 impl ChartText {
     pub fn get_rich_text(&self) -> &RichText {
         &self.rich_text
@@ -29,25 +31,20 @@ impl ChartText {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"c:rich" => {
-                        self.rich_text.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:tx" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:tx"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"c:rich" {
+                    self.rich_text.set_attributes(reader, e);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:tx" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:tx"),
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/charts/doughnut_chart.rs
+++ b/src/structs/drawing/charts/doughnut_chart.rs
@@ -8,6 +8,7 @@ use super::VaryColors;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -20,6 +21,7 @@ pub struct DoughnutChart {
     first_slice_angle: FirstSliceAngle,
     hole_size: HoleSize,
 }
+
 impl DoughnutChart {
     pub fn get_vary_colors(&self) -> &VaryColors {
         &self.vary_colors
@@ -91,43 +93,39 @@ impl DoughnutChart {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"c:ser" => {
-                        let mut obj = AreaChartSeries::default();
-                        obj.set_attributes(reader, e);
-                        self.get_area_chart_series_list_mut()
-                            .add_area_chart_series(obj);
-                    }
-                    b"c:dLbls" => {
-                        self.data_labels.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"c:varyColors" => {
-                        self.vary_colors.set_attributes(reader, e);
-                    }
-                    b"c:firstSliceAng" => {
-                        self.first_slice_angle.set_attributes(reader, e);
-                    }
-                    b"c:holeSize" => {
-                        self.hole_size.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:doughnutChart" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:doughnutChart"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => match e.name().into_inner() {
+                b"c:ser" => {
+                    let mut obj = AreaChartSeries::default();
+                    obj.set_attributes(reader, e);
+                    self.get_area_chart_series_list_mut()
+                        .add_area_chart_series(obj);
+                }
+                b"c:dLbls" => {
+                    self.data_labels.set_attributes(reader, e);
+                }
                 _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Empty(ref e) => match e.name().into_inner() {
+                b"c:varyColors" => {
+                    self.vary_colors.set_attributes(reader, e);
+                }
+                b"c:firstSliceAng" => {
+                    self.first_slice_angle.set_attributes(reader, e);
+                }
+                b"c:holeSize" => {
+                    self.hole_size.set_attributes(reader, e);
+                }
+                _ => (),
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:doughnutChart" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:doughnutChart")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/floor.rs
+++ b/src/structs/drawing/charts/floor.rs
@@ -4,6 +4,7 @@ use super::Thickness;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -12,6 +13,7 @@ pub struct Floor {
     thickness: Option<Thickness>,
     shape_properties: Option<ShapeProperties>,
 }
+
 impl Floor {
     pub fn get_thickness(&self) -> &Option<Thickness> {
         &self.thickness
@@ -44,35 +46,29 @@ impl Floor {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"c:thickness" => {
-                        let mut obj = Thickness::default();
-                        obj.set_attributes(reader, e);
-                        self.set_thickness(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"c:spPr" => {
-                        let mut obj = ShapeProperties::default();
-                        obj.set_attributes(reader, e);
-                        self.set_shape_properties(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:floor" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:floor"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"c:thickness" {
+                    let mut obj = Thickness::default();
+                    obj.set_attributes(reader, e);
+                    self.set_thickness(obj);
+                }
+            },
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"c:spPr" {
+                    let mut obj = ShapeProperties::default();
+                    obj.set_attributes(reader, e);
+                    self.set_shape_properties(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:floor" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:floor")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
@@ -80,19 +76,13 @@ impl Floor {
         write_start_tag(writer, "c:floor", vec![], false);
 
         // c:thickness
-        match &self.thickness {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.thickness {
+            v.write_to(writer);
         }
 
         // c:spPr
-        match &self.shape_properties {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.shape_properties {
+            v.write_to(writer);
         }
 
         write_end_tag(writer, "c:floor");

--- a/src/structs/drawing/charts/layout.rs
+++ b/src/structs/drawing/charts/layout.rs
@@ -1,5 +1,6 @@
 // c:layout
 use super::ManualLayout;
+use crate::xml_read_loop;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub struct Layout {
     manual_layout: Option<ManualLayout>,
 }
+
 impl Layout {
     pub fn get_manual_layout(&self) -> &Option<ManualLayout> {
         &self.manual_layout
@@ -38,27 +40,22 @@ impl Layout {
             return;
         }
 
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"c:manualLayout" => {
-                        let mut obj = ManualLayout::default();
-                        obj.set_attributes(reader, e);
-                        self.set_manual_layout(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:layout" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:layout"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"c:manualLayout" {
+                    let mut obj = ManualLayout::default();
+                    obj.set_attributes(reader, e);
+                    self.set_manual_layout(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:layout" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:layout"),
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
@@ -70,11 +67,8 @@ impl Layout {
             write_start_tag(writer, "c:layout", vec![], false);
 
             // c:manualLayout
-            match &self.manual_layout {
-                Some(v) => {
-                    v.write_to(writer);
-                }
-                None => {}
+            if let Some(v) = &self.manual_layout {
+                v.write_to(writer);
             }
 
             write_end_tag(writer, "c:layout");

--- a/src/structs/drawing/charts/line_3d_chart.rs
+++ b/src/structs/drawing/charts/line_3d_chart.rs
@@ -8,6 +8,7 @@ use super::VaryColors;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -20,6 +21,7 @@ pub struct Line3DChart {
     data_labels: DataLabels,
     axis_id: Vec<AxisId>,
 }
+
 impl Line3DChart {
     pub fn get_grouping(&self) -> &Grouping {
         &self.grouping
@@ -96,22 +98,24 @@ impl Line3DChart {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
                     b"c:ser" => {
                         let mut obj = AreaChartSeries::default();
                         obj.set_attributes(reader, e);
                         self.get_area_chart_series_list_mut()
                             .add_area_chart_series(obj);
-                    }
+                        }
                     b"c:dLbls" => {
                         self.data_labels.set_attributes(reader, e);
                     }
                     _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+                }
+            },
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
                     b"c:grouping" => {
                         self.grouping.set_attributes(reader, e);
                     }
@@ -124,17 +128,15 @@ impl Line3DChart {
                         self.add_axis_id(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"c:line3DChart" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:line3DChart"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"c:line3DChart" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:line3DChart")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/manual_layout.rs
+++ b/src/structs/drawing/charts/manual_layout.rs
@@ -8,7 +8,7 @@ use super::Top;
 use super::TopMode;
 use super::Width;
 use super::WidthMode;
-
+use crate::xml_read_loop;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -27,6 +27,7 @@ pub struct ManualLayout {
     width: Option<Width>,
     width_mode: Option<WidthMode>,
 }
+
 impl ManualLayout {
     pub fn get_height(&self) -> &Option<Height> {
         &self.height
@@ -167,67 +168,63 @@ impl ManualLayout {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().0 {
-                    b"c:h" => {
-                        let mut obj = Height::default();
-                        obj.set_attributes(reader, e);
-                        self.set_height(obj);
-                    }
-                    b"c:hMode" => {
-                        let mut obj = HeightMode::default();
-                        obj.set_attributes(reader, e);
-                        self.set_height_mode(obj);
-                    }
-                    b"c:layoutTarget" => {
-                        let mut obj = LayoutTarget::default();
-                        obj.set_attributes(reader, e);
-                        self.set_layout_target(obj);
-                    }
-                    b"c:x" => {
-                        let mut obj = Left::default();
-                        obj.set_attributes(reader, e);
-                        self.set_left(obj);
-                    }
-                    b"c:xMode" => {
-                        let mut obj = LeftMode::default();
-                        obj.set_attributes(reader, e);
-                        self.set_left_mode(obj);
-                    }
-                    b"c:y" => {
-                        let mut obj = Top::default();
-                        obj.set_attributes(reader, e);
-                        self.set_top(obj);
-                    }
-                    b"c:yMode" => {
-                        let mut obj = TopMode::default();
-                        obj.set_attributes(reader, e);
-                        self.set_top_mode(obj);
-                    }
-                    b"c:w" => {
-                        let mut obj = Width::default();
-                        obj.set_attributes(reader, e);
-                        self.set_width(obj);
-                    }
-                    b"c:wMode" => {
-                        let mut obj = WidthMode::default();
-                        obj.set_attributes(reader, e);
-                        self.set_width_mode(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:manualLayout" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:manualLayout"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => match e.name().0 {
+                b"c:h" => {
+                    let mut obj = Height::default();
+                    obj.set_attributes(reader, e);
+                    self.set_height(obj);
+                }
+                b"c:hMode" => {
+                    let mut obj = HeightMode::default();
+                    obj.set_attributes(reader, e);
+                    self.set_height_mode(obj);
+                }
+                b"c:layoutTarget" => {
+                    let mut obj = LayoutTarget::default();
+                    obj.set_attributes(reader, e);
+                    self.set_layout_target(obj);
+                }
+                b"c:x" => {
+                    let mut obj = Left::default();
+                    obj.set_attributes(reader, e);
+                    self.set_left(obj);
+                }
+                b"c:xMode" => {
+                    let mut obj = LeftMode::default();
+                    obj.set_attributes(reader, e);
+                    self.set_left_mode(obj);
+                }
+                b"c:y" => {
+                    let mut obj = Top::default();
+                    obj.set_attributes(reader, e);
+                    self.set_top(obj);
+                }
+                b"c:yMode" => {
+                    let mut obj = TopMode::default();
+                    obj.set_attributes(reader, e);
+                    self.set_top_mode(obj);
+                }
+                b"c:w" => {
+                    let mut obj = Width::default();
+                    obj.set_attributes(reader, e);
+                    self.set_width(obj);
+                }
+                b"c:wMode" => {
+                    let mut obj = WidthMode::default();
+                    obj.set_attributes(reader, e);
+                    self.set_width_mode(obj);
+                }
                 _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:manualLayout" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:manualLayout"),
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
@@ -235,75 +232,48 @@ impl ManualLayout {
         write_start_tag(writer, "c:manualLayout", vec![], false);
 
         // c:hMode
-        match &self.height_mode {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.height_mode {
+            v.write_to(writer);
         }
 
         // c:xMode
-        match &self.left_mode {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.left_mode {
+            v.write_to(writer);
         }
 
         // c:yMode
-        match &self.top_mode {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.top_mode {
+            v.write_to(writer);
         }
 
         // c:wMode
-        match &self.width_mode {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.width_mode {
+            v.write_to(writer);
         }
 
         // c:h
-        match &self.height {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.height {
+            v.write_to(writer);
         }
 
         // c:x
-        match &self.left {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.left {
+            v.write_to(writer);
         }
 
         // c:y
-        match &self.top {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.top {
+            v.write_to(writer);
         }
 
         // c:w
-        match &self.width {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.width {
+            v.write_to(writer);
         }
 
         // c:layoutTarget
-        match &self.layout_target {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.layout_target {
+            v.write_to(writer);
         }
 
         write_end_tag(writer, "c:manualLayout");

--- a/src/structs/drawing/charts/numeric_value.rs
+++ b/src/structs/drawing/charts/numeric_value.rs
@@ -1,4 +1,5 @@
 // c:v
+use crate::xml_read_loop;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -9,6 +10,7 @@ use writer::driver::*;
 pub struct NumericValue {
     text: String,
 }
+
 impl NumericValue {
     pub fn get_text(&self) -> &str {
         &self.text
@@ -24,22 +26,18 @@ impl NumericValue {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => {
-                    self.set_text(e.unescape().unwrap());
+        xml_read_loop!(
+            reader,
+            Event::Text(e) => {
+                self.set_text(e.unescape().unwrap());
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:v" {
+                    return;
                 }
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:v" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:v"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:v"),
+        );
     }
 
     pub(crate) fn _write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/charts/pie_3d_chart.rs
+++ b/src/structs/drawing/charts/pie_3d_chart.rs
@@ -6,6 +6,7 @@ use super::VaryColors;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -16,6 +17,7 @@ pub struct Pie3DChart {
     area_chart_series_list: AreaChartSeriesList,
     data_labels: DataLabels,
 }
+
 impl Pie3DChart {
     pub fn get_vary_colors(&self) -> &VaryColors {
         &self.vary_colors
@@ -61,37 +63,34 @@ impl Pie3DChart {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().0 {
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().0 {
                     b"c:ser" => {
                         let mut obj = AreaChartSeries::default();
                         obj.set_attributes(reader, e);
                         self.get_area_chart_series_list_mut()
                             .add_area_chart_series(obj);
-                    }
+                        }
                     b"c:dLbls" => {
                         self.data_labels.set_attributes(reader, e);
                     }
                     _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().0 {
-                    b"c:varyColors" => {
-                        self.vary_colors.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:pie3DChart" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:pie3DChart"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::Empty(ref e) => {
+                if e.name().0 == b"c:varyColors" {
+                    self.vary_colors.set_attributes(reader, e);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:pie3DChart" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:pie3DChart")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/pie_chart.rs
+++ b/src/structs/drawing/charts/pie_chart.rs
@@ -7,6 +7,7 @@ use super::VaryColors;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -18,6 +19,7 @@ pub struct PieChart {
     data_labels: DataLabels,
     first_slice_angle: FirstSliceAngle,
 }
+
 impl PieChart {
     pub fn get_vary_colors(&self) -> &VaryColors {
         &self.vary_colors
@@ -76,22 +78,24 @@ impl PieChart {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().0 {
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().0 {
                     b"c:ser" => {
                         let mut obj = AreaChartSeries::default();
                         obj.set_attributes(reader, e);
                         self.get_area_chart_series_list_mut()
                             .add_area_chart_series(obj);
-                    }
+                        }
                     b"c:dLbls" => {
                         self.data_labels.set_attributes(reader, e);
                     }
                     _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().0 {
+                }
+            },
+            Event::Empty(ref e) => {
+                match e.name().0 {
                     b"c:varyColors" => {
                         self.vary_colors.set_attributes(reader, e);
                     }
@@ -99,17 +103,15 @@ impl PieChart {
                         self.first_slice_angle.set_attributes(reader, e);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:pieChart" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:pieChart"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:pieChart" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:pieChart")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/plot_area.rs
+++ b/src/structs/drawing/charts/plot_area.rs
@@ -20,6 +20,7 @@ use super::ScatterChart;
 use super::SeriesAxis;
 use super::ShapeProperties;
 use super::ValueAxis;
+use crate::xml_read_loop;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -48,6 +49,7 @@ pub struct PlotArea {
     series_axis: Vec<SeriesAxis>,
     shape_properties: Option<ShapeProperties>,
 }
+
 impl PlotArea {
     pub fn get_layout(&self) -> &Layout {
         &self.layout
@@ -299,385 +301,250 @@ impl PlotArea {
     }
 
     pub fn set_grouping(&mut self, value: GroupingValues) -> &mut Self {
-        match &mut self.line_chart {
-            Some(chart) => {
-                chart.get_grouping_mut().set_val(value);
-                return self;
-            }
-            None => {}
+        if let Some(chart) = &mut self.line_chart {
+            chart.get_grouping_mut().set_val(value);
+            return self;
         }
-        match &mut self.line_3d_chart {
-            Some(chart) => {
-                chart.get_grouping_mut().set_val(value);
-                return self;
-            }
-            None => {}
+        if let Some(chart) = &mut self.line_3d_chart {
+            chart.get_grouping_mut().set_val(value);
+            return self;
         }
-        match &mut self.bar_chart {
-            Some(chart) => {
-                chart.get_grouping_mut().set_val(value);
-                return self;
-            }
-            None => {}
+        if let Some(chart) = &mut self.bar_chart {
+            chart.get_grouping_mut().set_val(value);
+            return self;
         }
-        match &mut self.bar_3d_chart {
-            Some(chart) => {
-                chart.get_grouping_mut().set_val(value);
-                return self;
-            }
-            None => {}
+        if let Some(chart) = &mut self.bar_3d_chart {
+            chart.get_grouping_mut().set_val(value);
+            return self;
         }
-        match &mut self.area_chart {
-            Some(chart) => {
-                chart.get_grouping_mut().set_val(value);
-                return self;
-            }
-            None => {}
+        if let Some(chart) = &mut self.area_chart {
+            chart.get_grouping_mut().set_val(value);
+            return self;
         }
-        match &mut self.area_3d_chart {
-            Some(chart) => {
-                chart.get_grouping_mut().set_val(value);
-                return self;
-            }
-            None => {}
+        if let Some(chart) = &mut self.area_3d_chart {
+            chart.get_grouping_mut().set_val(value);
+            return self;
         }
         panic! {"Non-Grouping."};
     }
 
     pub fn get_area_chart_series_list_mut(&mut self) -> &mut AreaChartSeriesList {
-        match &mut self.line_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.line_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.line_3d_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.line_3d_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.pie_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.pie_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.pie_3d_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.pie_3d_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.doughnut_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.doughnut_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.scatter_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.scatter_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.bar_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.bar_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.bar_3d_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.bar_3d_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.radar_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.radar_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.bubble_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.bubble_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.area_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.area_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.area_3d_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.area_3d_chart {
+            return chart.get_area_chart_series_list_mut();
         }
-        match &mut self.of_pie_chart {
-            Some(chart) => {
-                return chart.get_area_chart_series_list_mut();
-            }
-            None => {}
+        if let Some(chart) = &mut self.of_pie_chart {
+            return chart.get_area_chart_series_list_mut();
         }
         panic! {"Non-ChartSeriesList."};
     }
 
     pub fn get_formula_mut(&mut self) -> Vec<&mut Formula> {
         let mut result: Vec<&mut Formula> = Vec::default();
-        match &mut self.line_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.line_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.line_3d_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.line_3d_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.pie_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.pie_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.pie_3d_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.pie_3d_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.doughnut_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.doughnut_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.scatter_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.scatter_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.bar_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.bar_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.bar_3d_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.bar_3d_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.radar_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.radar_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.bubble_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.bubble_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.area_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.area_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.area_3d_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.area_3d_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
-        match &mut self.of_pie_chart {
-            Some(v) => {
-                for ser in v
-                    .get_area_chart_series_list_mut()
-                    .get_area_chart_series_mut()
-                {
-                    for formula in ser.get_formula_mut() {
-                        result.push(formula);
-                    }
+        if let Some(v) = &mut self.of_pie_chart {
+            for ser in v
+                .get_area_chart_series_list_mut()
+                .get_area_chart_series_mut()
+            {
+                for formula in ser.get_formula_mut() {
+                    result.push(formula);
                 }
             }
-            None => {}
         }
         result
     }
 
     pub(crate) fn is_support(&self) -> bool {
-        match &self.line_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.line_chart.is_some() {
+            return true;
         }
-        match &self.line_3d_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.line_3d_chart.is_some() {
+            return true;
         }
-        match &self.pie_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.pie_chart.is_some() {
+            return true;
         }
-        match &self.pie_3d_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.pie_3d_chart.is_some() {
+            return true;
         }
-        match &self.doughnut_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.doughnut_chart.is_some() {
+            return true;
         }
-        match &self.scatter_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.scatter_chart.is_some() {
+            return true;
         }
-        match &self.bar_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.bar_chart.is_some() {
+            return true;
         }
-        match &self.bar_3d_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.bar_3d_chart.is_some() {
+            return true;
         }
-        match &self.radar_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.radar_chart.is_some() {
+            return true;
         }
-        match &self.bubble_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.bubble_chart.is_some() {
+            return true;
         }
-        match &self.area_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.area_chart.is_some() {
+            return true;
         }
-        match &self.area_3d_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.area_3d_chart.is_some() {
+            return true;
         }
-        match &self.of_pie_chart {
-            Some(_) => {
-                return true;
-            }
-            None => {}
+        if self.of_pie_chart.is_some() {
+            return true;
         }
         false
     }
@@ -687,110 +554,106 @@ impl PlotArea {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().0 {
-                    b"c:layout" => {
-                        self.layout.set_attributes(reader, e, false);
-                    }
-                    b"c:lineChart" => {
-                        let mut obj = LineChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_line_chart(obj);
-                    }
-                    b"c:line3DChart" => {
-                        let mut obj = Line3DChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_line_3d_chart(obj);
-                    }
-                    b"c:pieChart" => {
-                        let mut obj = PieChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_pie_chart(obj);
-                    }
-                    b"c:pie3DChart" => {
-                        let mut obj = Pie3DChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_pie_3d_chart(obj);
-                    }
-                    b"c:doughnutChart" => {
-                        let mut obj = DoughnutChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_doughnut_chart(obj);
-                    }
-                    b"c:scatterChart" => {
-                        let mut obj = ScatterChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_scatter_chart(obj);
-                    }
-                    b"c:barChart" => {
-                        let mut obj = BarChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_bar_chart(obj);
-                    }
-                    b"c:bar3DChart" => {
-                        let mut obj = Bar3DChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_bar_3d_chart(obj);
-                    }
-                    b"c:radarChart" => {
-                        let mut obj = RadarChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_radar_chart(obj);
-                    }
-                    b"c:bubbleChart" => {
-                        let mut obj = BubbleChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_bubble_chart(obj);
-                    }
-                    b"c:areaChart" => {
-                        let mut obj = AreaChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_area_chart(obj);
-                    }
-                    b"c:area3DChart" => {
-                        let mut obj = Area3DChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_area_3d_chart(obj);
-                    }
-                    b"c:ofPieChart" => {
-                        let mut obj = OfPieChart::default();
-                        obj.set_attributes(reader, e);
-                        self.set_of_pie_chart(obj);
-                    }
-                    b"c:catAx" => {
-                        let mut obj = CategoryAxis::default();
-                        obj.set_attributes(reader, e);
-                        self.add_category_axis(obj);
-                    }
-                    b"c:valAx" => {
-                        let mut obj = ValueAxis::default();
-                        obj.set_attributes(reader, e);
-                        self.add_value_axis(obj);
-                    }
-                    b"c:serAx" => {
-                        let mut obj = SeriesAxis::default();
-                        obj.set_attributes(reader, e);
-                        self.add_series_axis(obj);
-                    }
-                    b"c:spPr" => {
-                        let mut obj = ShapeProperties::default();
-                        obj.set_attributes(reader, e);
-                        self.set_shape_properties(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:plotArea" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:plotArea"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => match e.name().0 {
+                b"c:layout" => {
+                    self.layout.set_attributes(reader, e, false);
+                }
+                b"c:lineChart" => {
+                    let mut obj = LineChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_line_chart(obj);
+                }
+                b"c:line3DChart" => {
+                    let mut obj = Line3DChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_line_3d_chart(obj);
+                }
+                b"c:pieChart" => {
+                    let mut obj = PieChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_pie_chart(obj);
+                }
+                b"c:pie3DChart" => {
+                    let mut obj = Pie3DChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_pie_3d_chart(obj);
+                }
+                b"c:doughnutChart" => {
+                    let mut obj = DoughnutChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_doughnut_chart(obj);
+                }
+                b"c:scatterChart" => {
+                    let mut obj = ScatterChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_scatter_chart(obj);
+                }
+                b"c:barChart" => {
+                    let mut obj = BarChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_bar_chart(obj);
+                }
+                b"c:bar3DChart" => {
+                    let mut obj = Bar3DChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_bar_3d_chart(obj);
+                }
+                b"c:radarChart" => {
+                    let mut obj = RadarChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_radar_chart(obj);
+                }
+                b"c:bubbleChart" => {
+                    let mut obj = BubbleChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_bubble_chart(obj);
+                }
+                b"c:areaChart" => {
+                    let mut obj = AreaChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_area_chart(obj);
+                }
+                b"c:area3DChart" => {
+                    let mut obj = Area3DChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_area_3d_chart(obj);
+                }
+                b"c:ofPieChart" => {
+                    let mut obj = OfPieChart::default();
+                    obj.set_attributes(reader, e);
+                    self.set_of_pie_chart(obj);
+                }
+                b"c:catAx" => {
+                    let mut obj = CategoryAxis::default();
+                    obj.set_attributes(reader, e);
+                    self.add_category_axis(obj);
+                }
+                b"c:valAx" => {
+                    let mut obj = ValueAxis::default();
+                    obj.set_attributes(reader, e);
+                    self.add_value_axis(obj);
+                }
+                b"c:serAx" => {
+                    let mut obj = SeriesAxis::default();
+                    obj.set_attributes(reader, e);
+                    self.add_series_axis(obj);
+                }
+                b"c:spPr" => {
+                    let mut obj = ShapeProperties::default();
+                    obj.set_attributes(reader, e);
+                    self.set_shape_properties(obj);
+                }
                 _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:plotArea" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:plotArea"),
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {
@@ -801,107 +664,68 @@ impl PlotArea {
         self.layout.write_to(writer);
 
         // c:lineChart
-        match &self.line_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.line_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:line3DChart
-        match &self.line_3d_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.line_3d_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:pieChart
-        match &self.pie_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.pie_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:pie3DChart
-        match &self.pie_3d_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.pie_3d_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:doughnutChart
-        match &self.doughnut_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.doughnut_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:scatterChart
-        match &self.scatter_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.scatter_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:barChart
-        match &self.bar_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.bar_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:bar3DChart
-        match &self.bar_3d_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.bar_3d_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:radarChart
-        match &self.radar_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.radar_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:bubbleChart
-        match &self.bubble_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.bubble_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:areaChart
-        match &self.area_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.area_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:area3DChart
-        match &self.area_3d_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.area_3d_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:ofPieChart
-        match &self.of_pie_chart {
-            Some(v) => {
-                v.write_to(writer, spreadsheet);
-            }
-            None => {}
+        if let Some(v) = &self.of_pie_chart {
+            v.write_to(writer, spreadsheet);
         }
 
         // c:catAx
@@ -920,11 +744,8 @@ impl PlotArea {
         }
 
         // c:spPr
-        match &self.shape_properties {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.shape_properties {
+            v.write_to(writer);
         }
 
         write_end_tag(writer, "c:plotArea");

--- a/src/structs/drawing/charts/radar_chart.rs
+++ b/src/structs/drawing/charts/radar_chart.rs
@@ -8,6 +8,7 @@ use super::VaryColors;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -20,6 +21,7 @@ pub struct RadarChart {
     data_labels: DataLabels,
     axis_id: Vec<AxisId>,
 }
+
 impl RadarChart {
     pub fn get_radar_style(&self) -> &RadarStyle {
         &self.radar_style
@@ -96,22 +98,24 @@ impl RadarChart {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().0 {
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().0 {
                     b"c:ser" => {
                         let mut obj = AreaChartSeries::default();
                         obj.set_attributes(reader, e);
                         self.get_area_chart_series_list_mut()
                             .add_area_chart_series(obj);
-                    }
+                        }
                     b"c:dLbls" => {
                         self.data_labels.set_attributes(reader, e);
                     }
                     _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().0 {
+                }
+            },
+            Event::Empty(ref e) => {
+                match e.name().0 {
                     b"c:radarStyle" => {
                         self.radar_style.set_attributes(reader, e);
                     }
@@ -124,17 +128,15 @@ impl RadarChart {
                         self.add_axis_id(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:radarChart" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:radarChart"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:radarChart" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:radarChart")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/rich_text.rs
+++ b/src/structs/drawing/charts/rich_text.rs
@@ -2,6 +2,7 @@
 use super::super::BodyProperties;
 use super::super::ListStyle;
 use super::super::Paragraph;
+use crate::xml_read_loop;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -14,6 +15,7 @@ pub struct RichText {
     list_style: ListStyle,
     paragraph: Vec<Paragraph>,
 }
+
 impl RichText {
     pub fn get_body_properties(&self) -> &BodyProperties {
         &self.body_properties
@@ -56,40 +58,35 @@ impl RichText {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().0 {
-                    b"a:p" => {
-                        let mut paragraph = Paragraph::default();
-                        paragraph.set_attributes(reader, e);
-                        self.add_paragraph(paragraph);
-                    }
-                    b"a:bodyPr" => {
-                        let mut body_properties = BodyProperties::default();
-                        body_properties.set_attributes(reader, e, false);
-                        self.set_body_properties(body_properties);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().0 {
-                    b"a:bodyPr" => {
-                        let mut body_properties = BodyProperties::default();
-                        body_properties.set_attributes(reader, e, true);
-                        self.set_body_properties(body_properties);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:rich" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:rich"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => match e.name().0 {
+                b"a:p" => {
+                    let mut paragraph = Paragraph::default();
+                    paragraph.set_attributes(reader, e);
+                    self.add_paragraph(paragraph);
+                }
+                b"a:bodyPr" => {
+                    let mut body_properties = BodyProperties::default();
+                    body_properties.set_attributes(reader, e, false);
+                    self.set_body_properties(body_properties);
+                }
                 _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Empty(ref e) => {
+                if e.name().0 == b"a:bodyPr" {
+                    let mut body_properties = BodyProperties::default();
+                    body_properties.set_attributes(reader, e, true);
+                    self.set_body_properties(body_properties);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:rich" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:rich"),
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/charts/scatter_chart.rs
+++ b/src/structs/drawing/charts/scatter_chart.rs
@@ -8,6 +8,7 @@ use super::VaryColors;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -20,6 +21,7 @@ pub struct ScatterChart {
     data_labels: DataLabels,
     axis_id: Vec<AxisId>,
 }
+
 impl ScatterChart {
     pub fn get_scatter_style(&self) -> &ScatterStyle {
         &self.scatter_style
@@ -96,45 +98,45 @@ impl ScatterChart {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().0 {
-                    b"c:ser" => {
-                        let mut obj = AreaChartSeries::default();
-                        obj.set_attributes(reader, e);
-                        self.get_area_chart_series_list_mut()
-                            .add_area_chart_series(obj);
-                    }
-                    b"c:dLbls" => {
-                        self.data_labels.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().0 {
-                    b"c:scatterStyle" => {
-                        self.scatter_style.set_attributes(reader, e);
-                    }
-                    b"c:varyColors" => {
-                        self.vary_colors.set_attributes(reader, e);
-                    }
-                    b"c:axId" => {
-                        let mut obj = AxisId::default();
-                        obj.set_attributes(reader, e);
-                        self.add_axis_id(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:scatterChart" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:scatterChart"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().0 {
+                b"c:ser" => {
+                    let mut obj = AreaChartSeries::default();
+                    obj.set_attributes(reader, e);
+                    self.get_area_chart_series_list_mut()
+                        .add_area_chart_series(obj);
+                }
+                b"c:dLbls" => {
+                    self.data_labels.set_attributes(reader, e);
+                }
                 _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::Empty(ref e) => {
+                match e.name().0 {
+                b"c:scatterStyle" => {
+                    self.scatter_style.set_attributes(reader, e);
+                }
+                b"c:varyColors" => {
+                    self.vary_colors.set_attributes(reader, e);
+                }
+                b"c:axId" => {
+                    let mut obj = AxisId::default();
+                    obj.set_attributes(reader, e);
+                    self.add_axis_id(obj);
+                }
+                _ => (),
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:scatterChart" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:scatterChart")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/string_reference.rs
+++ b/src/structs/drawing/charts/string_reference.rs
@@ -1,3 +1,5 @@
+use crate::xml_read_loop;
+
 // c:strRef
 use super::Formula;
 use super::StringCache;
@@ -13,6 +15,7 @@ pub struct StringReference {
     formula: Formula,
     string_cache: StringCache,
 }
+
 impl StringReference {
     pub fn get_formula(&self) -> &Formula {
         &self.formula
@@ -45,28 +48,24 @@ impl StringReference {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().0 {
-                    b"c:f" => {
-                        self.formula.set_attributes(reader, e);
-                    }
-                    b"c:strCache" => {
-                        self.string_cache.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:strRef" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:strRef"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => match e.name().0 {
+                b"c:f" => {
+                    self.formula.set_attributes(reader, e);
+                }
+                b"c:strCache" => {
+                    self.string_cache.set_attributes(reader, e);
+                }
                 _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:strRef" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:strRef"),
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/style.rs
+++ b/src/structs/drawing/charts/style.rs
@@ -11,6 +11,7 @@ use writer::driver::*;
 pub struct Style {
     val: ByteValue,
 }
+
 impl Style {
     pub fn get_val(&self) -> &u8 {
         self.val.get_value()

--- a/src/structs/drawing/charts/tick_mark_values.rs
+++ b/src/structs/drawing/charts/tick_mark_values.rs
@@ -1,7 +1,6 @@
 use super::super::super::EnumTrait;
 use std::str::FromStr;
-#[derive(Clone, Debug)]
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub enum TickMarkValues {
     #[default]
     Cross,

--- a/src/structs/drawing/charts/tick_mark_values.rs
+++ b/src/structs/drawing/charts/tick_mark_values.rs
@@ -1,17 +1,15 @@
 use super::super::super::EnumTrait;
 use std::str::FromStr;
 #[derive(Clone, Debug)]
+#[derive(Default)]
 pub enum TickMarkValues {
+    #[default]
     Cross,
     Inside,
     None,
     Outside,
 }
-impl Default for TickMarkValues {
-    fn default() -> Self {
-        TickMarkValues::Cross
-    }
-}
+
 impl EnumTrait for TickMarkValues {
     fn get_value_string(&self) -> &str {
         match &self {

--- a/src/structs/drawing/charts/values.rs
+++ b/src/structs/drawing/charts/values.rs
@@ -1,3 +1,5 @@
+use crate::xml_read_loop;
+
 // c:val
 use super::NumberReference;
 use quick_xml::events::{BytesStart, Event};
@@ -11,6 +13,7 @@ use writer::driver::*;
 pub struct Values {
     number_reference: NumberReference,
 }
+
 impl Values {
     pub fn get_number_reference(&self) -> &NumberReference {
         &self.number_reference
@@ -30,25 +33,20 @@ impl Values {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().0 {
-                    b"c:numRef" => {
-                        self.number_reference.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:val" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:val"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().0 == b"c:numRef" {
+                    self.number_reference.set_attributes(reader, e);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:val" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:val"),
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/x_values.rs
+++ b/src/structs/drawing/charts/x_values.rs
@@ -3,6 +3,7 @@ use super::NumberReference;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -11,6 +12,7 @@ use writer::driver::*;
 pub struct XValues {
     number_reference: NumberReference,
 }
+
 impl XValues {
     pub fn get_number_reference(&self) -> &NumberReference {
         &self.number_reference
@@ -30,25 +32,20 @@ impl XValues {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().0 {
-                    b"c:numRef" => {
-                        self.number_reference.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:xVal" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:xVal"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().0 == b"c:numRef" {
+                    self.number_reference.set_attributes(reader, e);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:xVal" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:xVal")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/charts/y_values.rs
+++ b/src/structs/drawing/charts/y_values.rs
@@ -3,6 +3,7 @@ use super::NumberReference;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
 use writer::driver::*;
@@ -11,6 +12,7 @@ use writer::driver::*;
 pub struct YValues {
     number_reference: NumberReference,
 }
+
 impl YValues {
     pub fn get_number_reference(&self) -> &NumberReference {
         &self.number_reference
@@ -30,25 +32,20 @@ impl YValues {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().0 {
-                    b"c:numRef" => {
-                        self.number_reference.set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"c:yVal" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "c:yVal"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().0 == b"c:numRef" {
+                    self.number_reference.set_attributes(reader, e);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"c:yVal" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "c:yVal")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, spreadsheet: &Spreadsheet) {

--- a/src/structs/drawing/effect_style_list.rs
+++ b/src/structs/drawing/effect_style_list.rs
@@ -2,6 +2,7 @@ use super::EffectStyle;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -9,6 +10,7 @@ use writer::driver::*;
 pub struct EffectStyleList {
     effect_style_collection: Vec<EffectStyle>,
 }
+
 impl EffectStyleList {
     pub fn get_effect_style_collection(&self) -> &Vec<EffectStyle> {
         &self.effect_style_collection
@@ -33,27 +35,22 @@ impl EffectStyleList {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"a:effectStyle" => {
-                        let mut obj = EffectStyle::default();
-                        obj.set_attributes(reader, e);
-                        self.effect_style_collection.push(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:effectStyleLst" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "a:effectStyleLst"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"a:effectStyle" {
+                    let mut obj = EffectStyle::default();
+                    obj.set_attributes(reader, e);
+                    self.effect_style_collection.push(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"a:effectStyleLst" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "a:effectStyleLst")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/fill_style_list.rs
+++ b/src/structs/drawing/fill_style_list.rs
@@ -3,6 +3,7 @@ use super::SolidFill;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -11,6 +12,7 @@ pub struct FillStyleList {
     solid_fill: Option<SolidFill>,
     gradient_fill_collection: Vec<GradientFill>,
 }
+
 impl FillStyleList {
     pub fn get_solid_fill(&self) -> &Option<SolidFill> {
         &self.solid_fill
@@ -48,10 +50,10 @@ impl FillStyleList {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
                     b"a:solidFill" => {
                         let mut obj = SolidFill::default();
                         obj.set_attributes(reader, e);
@@ -63,17 +65,15 @@ impl FillStyleList {
                         self.gradient_fill_collection.push(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:fillStyleLst" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "fillStyleLst"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"a:fillStyleLst" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "fillStyleLst")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
@@ -81,9 +81,8 @@ impl FillStyleList {
         write_start_tag(writer, "a:fillStyleLst", vec![], false);
 
         // a:solidFill
-        match &self.solid_fill {
-            Some(v) => v.write_to(writer),
-            _ => {}
+        if let Some(v) = &self.solid_fill {
+            v.write_to(writer);
         }
 
         // a:gradFill

--- a/src/structs/drawing/foreground_color.rs
+++ b/src/structs/drawing/foreground_color.rs
@@ -3,6 +3,7 @@ use super::SchemeColor;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub struct ForegroundColor {
     scheme_color: SchemeColor,
 }
+
 impl ForegroundColor {
     pub fn get_scheme_color(&self) -> &SchemeColor {
         &self.scheme_color
@@ -29,31 +31,25 @@ impl ForegroundColor {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"a:schemeClr" => {
-                        self.scheme_color.set_attributes(reader, e, false);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"a:schemeClr" => {
-                        self.scheme_color.set_attributes(reader, e, true);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:fgClr" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "a:fgClr"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"a:schemeClr" {
+                    self.scheme_color.set_attributes(reader, e, false);
+                }
+            },
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"a:schemeClr" {
+                    self.scheme_color.set_attributes(reader, e, true);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"a:fgClr" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "a:fgClr")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/graphic.rs
+++ b/src/structs/drawing/graphic.rs
@@ -3,6 +3,7 @@ use super::GraphicData;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::raw::RawRelationships;
 use writer::driver::*;
@@ -11,6 +12,7 @@ use writer::driver::*;
 pub struct Graphic {
     graphic_data: GraphicData,
 }
+
 impl Graphic {
     pub fn get_graphic_data(&self) -> &GraphicData {
         &self.graphic_data
@@ -31,27 +33,21 @@ impl Graphic {
         _e: &BytesStart,
         drawing_relationships: Option<&RawRelationships>,
     ) {
-        let mut buf = Vec::new();
-
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"a:graphicData" => {
-                        self.graphic_data
-                            .set_attributes(reader, e, drawing_relationships);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:graphic" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "a:graphic"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"a:graphicData" {
+                    self.graphic_data
+                        .set_attributes(reader, e, drawing_relationships);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"a:graphic" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "a:graphic")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, r_id: &i32) {

--- a/src/structs/drawing/line_spacing.rs
+++ b/src/structs/drawing/line_spacing.rs
@@ -3,6 +3,7 @@ use super::SpacingPercent;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub struct LineSpacing {
     spacing_percent: Option<SpacingPercent>,
 }
+
 impl LineSpacing {
     pub fn get_spacing_percent(&self) -> &Option<SpacingPercent> {
         &self.spacing_percent
@@ -33,27 +35,22 @@ impl LineSpacing {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"a:spcPct" => {
-                        let mut obj = SpacingPercent::default();
-                        obj.set_attributes(reader, e);
-                        self.set_spacing_percent(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:lnSpc" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "a:lnSpc"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"a:spcPct" {
+                    let mut obj = SpacingPercent::default();
+                    obj.set_attributes(reader, e);
+                    self.set_spacing_percent(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"a:lnSpc" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "a:lnSpc")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
@@ -61,9 +58,8 @@ impl LineSpacing {
         write_start_tag(writer, "a:lnSpc", vec![], false);
 
         // a:spcPct
-        match &self.spacing_percent {
-            Some(v) => v.write_to(writer),
-            None => {}
+        if let Some(v) = &self.spacing_percent {
+            v.write_to(writer);
         }
 
         write_end_tag(writer, "a:lnSpc");

--- a/src/structs/drawing/line_style_list.rs
+++ b/src/structs/drawing/line_style_list.rs
@@ -2,6 +2,7 @@ use super::Outline;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -9,6 +10,7 @@ use writer::driver::*;
 pub struct LineStyleList {
     outline_collection: Vec<Outline>,
 }
+
 impl LineStyleList {
     pub fn get_outline_collection(&self) -> &Vec<Outline> {
         &self.outline_collection
@@ -33,27 +35,22 @@ impl LineStyleList {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"a:ln" => {
-                        let mut obj = Outline::default();
-                        obj.set_attributes(reader, e);
-                        self.outline_collection.push(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:lnStyleLst" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "lnStyleLst"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"a:ln" {
+                    let mut obj = Outline::default();
+                    obj.set_attributes(reader, e);
+                    self.outline_collection.push(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"a:lnStyleLst" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "lnStyleLst")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/linear_gradient_fill.rs
+++ b/src/structs/drawing/linear_gradient_fill.rs
@@ -13,6 +13,7 @@ pub struct LinearGradientFill {
     angle: Int32Value,
     scaled: BooleanValue,
 }
+
 impl LinearGradientFill {
     pub fn get_angle(&self) -> &i32 {
         self.angle.get_value()
@@ -37,28 +38,18 @@ impl LinearGradientFill {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"ang") {
-            Some(v) => {
-                self.angle.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"scaled") {
-            Some(v) => {
-                self.scaled.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, angle, "ang");
+        set_string_from_xml!(self, e, scaled, "scaled");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:lin
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         let ang = self.angle.get_value_string();
-        if &self.angle.has_value() == &true {
+        if self.angle.has_value() {
             attributes.push(("ang", &ang));
         }
-        if &self.scaled.has_value() == &true {
+        if self.scaled.has_value() {
             attributes.push(("scaled", self.scaled.get_value_string()));
         }
         write_start_tag(writer, "a:lin", attributes, true);

--- a/src/structs/drawing/list_style.rs
+++ b/src/structs/drawing/list_style.rs
@@ -3,6 +3,7 @@ use super::EffectList;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub struct ListStyle {
     effect_list: Option<EffectList>,
 }
+
 impl ListStyle {
     pub fn get_effect_list(&self) -> &Option<EffectList> {
         &self.effect_list
@@ -28,26 +30,21 @@ impl ListStyle {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"a:effectLst" => {
-                        let obj = EffectList::default();
-                        self.set_effect_list(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:lstStyle" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "a:lstStyle"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"a:effectLst" {
+                    let obj = EffectList::default();
+                    self.set_effect_list(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"a:lstStyle" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "a:lstStyle")
+        );
     }
 
     pub(crate) fn _write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/miter.rs
+++ b/src/structs/drawing/miter.rs
@@ -1,5 +1,5 @@
 // a:miter
-use super::super::super::Int32Value;
+use crate::Int32Value;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -11,6 +11,7 @@ use writer::driver::*;
 pub struct Miter {
     limit: Int32Value,
 }
+
 impl Miter {
     pub fn get_limit(&self) -> &i32 {
         self.limit.get_value()
@@ -26,19 +27,14 @@ impl Miter {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"lim") {
-            Some(v) => {
-                self.limit.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, limit, "lim");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:miter
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         let lim = self.limit.get_value_string();
-        if &self.limit.has_value() == &true {
+        if self.limit.has_value() {
             attributes.push(("lim", &lim));
         }
         write_start_tag(writer, "a:miter", attributes, true);

--- a/src/structs/drawing/outer_shadow.rs
+++ b/src/structs/drawing/outer_shadow.rs
@@ -22,6 +22,7 @@ pub struct OuterShadow {
     scheme_color: Option<SchemeColor>,
     rgb_color_model_hex: Option<RgbColorModelHex>,
 }
+
 impl OuterShadow {
     pub fn get_blur_radius(&self) -> &Option<String> {
         &self.blur_radius
@@ -130,53 +131,32 @@ impl OuterShadow {
         reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"blurRad") {
-            Some(v) => {
-                self.set_blur_radius(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"blurRad") {
+            self.set_blur_radius(v);
         }
-        match get_attribute(e, b"dist") {
-            Some(v) => {
-                self.set_distance(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"dist") {
+            self.set_distance(v);
         }
-        match get_attribute(e, b"dir") {
-            Some(v) => {
-                self.set_direction(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"dir") {
+            self.set_direction(v);
         }
-        match get_attribute(e, b"sx") {
-            Some(v) => {
-                self.set_horizontal_ratio(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"sx") {
+            self.set_horizontal_ratio(v);
         }
-        match get_attribute(e, b"sy") {
-            Some(v) => {
-                self.set_vertical_ratio(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"sy") {
+            self.set_vertical_ratio(v);
         }
-        match get_attribute(e, b"algn") {
-            Some(v) => {
-                self.set_alignment(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"algn") {
+            self.set_alignment(v);
         }
-        match get_attribute(e, b"rotWithShape") {
-            Some(v) => {
-                self.set_rotate_with_shape(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"rotWithShape") {
+            self.set_rotate_with_shape(v);
         }
 
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
                     b"a:schemeClr" => {
                         let mut obj = SchemeColor::default();
                         obj.set_attributes(reader, e, true);
@@ -188,8 +168,10 @@ impl OuterShadow {
                         self.set_rgb_color_model_hex(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
+                }
+            },
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
                     b"a:prstClr" => {
                         let mut obj = PresetColor::default();
                         obj.set_attributes(reader, e);
@@ -206,17 +188,15 @@ impl OuterShadow {
                         self.set_rgb_color_model_hex(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:outerShdw" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "a:outerShdw"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"a:outerShdw" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "a:outerShdw")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/percentage_type.rs
+++ b/src/structs/drawing/percentage_type.rs
@@ -10,6 +10,7 @@ use writer::driver::*;
 pub struct PercentageType {
     val: Int32Value,
 }
+
 impl PercentageType {
     pub fn get_val(&self) -> &i32 {
         self.val.get_value()
@@ -25,12 +26,7 @@ impl PercentageType {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"val") {
-            Some(v) => {
-                self.val.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, val, "val");
     }
 
     pub(crate) fn write_to_lum(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/picture_locks.rs
+++ b/src/structs/drawing/picture_locks.rs
@@ -10,6 +10,7 @@ use writer::driver::*;
 pub struct PictureLocks {
     no_change_aspect: bool,
 }
+
 impl PictureLocks {
     pub fn get_no_change_aspect(&self) -> &bool {
         &self.no_change_aspect
@@ -24,26 +25,16 @@ impl PictureLocks {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"noChangeAspect") {
-            Some(v) => {
-                match &*v {
-                    "1" => {
-                        self.set_no_change_aspect(true);
-                    }
-                    _ => {}
-                };
+        if let Some(v) = get_attribute(e, b"noChangeAspect") {
+            if v == "1" {
+                self.set_no_change_aspect(true);
             }
-            None => {}
         }
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:picLocks
-        let no_change_aspect = if &self.no_change_aspect == &true {
-            "1"
-        } else {
-            "2"
-        };
+        let no_change_aspect = if self.no_change_aspect { "1" } else { "2" };
         write_start_tag(
             writer,
             "a:picLocks",

--- a/src/structs/drawing/positive_fixed_percentage_type.rs
+++ b/src/structs/drawing/positive_fixed_percentage_type.rs
@@ -10,6 +10,7 @@ use writer::driver::*;
 pub struct PositiveFixedPercentageType {
     val: Int32Value,
 }
+
 impl PositiveFixedPercentageType {
     pub fn get_val(&self) -> &i32 {
         self.val.get_value()
@@ -25,12 +26,7 @@ impl PositiveFixedPercentageType {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"val") {
-            Some(v) => {
-                self.val.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, val, "val");
     }
 
     pub(crate) fn write_to_shade(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/rgb_color_model_hex.rs
+++ b/src/structs/drawing/rgb_color_model_hex.rs
@@ -22,6 +22,7 @@ pub struct RgbColorModelHex {
     alpha: Option<PositiveFixedPercentageType>,
     tint: Option<PositiveFixedPercentageType>,
 }
+
 impl RgbColorModelHex {
     pub fn get_val(&self) -> &str {
         self.val.get_value()
@@ -151,10 +152,10 @@ impl RgbColorModelHex {
             return;
         }
 
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
                     b"a:lum" => {
                         let mut obj = PercentageType::default();
                         obj.set_attributes(reader, e);
@@ -196,17 +197,15 @@ impl RgbColorModelHex {
                         self.tint = Some(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:srgbClr" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "a:srgbClr"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"a:srgbClr" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "a:srgbClr")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
@@ -220,67 +219,43 @@ impl RgbColorModelHex {
             );
 
             // a:luminance
-            match &self.luminance {
-                Some(v) => {
-                    v.write_to_lum(writer);
-                }
-                None => {}
+            if let Some(v) = &self.luminance {
+                v.write_to_lum(writer);
             }
 
             // a:lumMod
-            match &self.luminance_modulation {
-                Some(v) => {
-                    v.write_to_lum_mod(writer);
-                }
-                None => {}
+            if let Some(v) = &self.luminance_modulation {
+                v.write_to_lum_mod(writer);
             }
 
             // a:lumOff
-            match &self.luminance_offset {
-                Some(v) => {
-                    v.write_to_lum_off(writer);
-                }
-                None => {}
+            if let Some(v) = &self.luminance_offset {
+                v.write_to_lum_off(writer);
             }
 
             // a:sat
-            match &self.saturation {
-                Some(v) => {
-                    v.write_to_sat(writer);
-                }
-                None => {}
+            if let Some(v) = &self.saturation {
+                v.write_to_sat(writer);
             }
 
             // a:satMod
-            match &self.saturation_modulation {
-                Some(v) => {
-                    v.write_to_sat_mod(writer);
-                }
-                None => {}
+            if let Some(v) = &self.saturation_modulation {
+                v.write_to_sat_mod(writer);
             }
 
             // a:shade
-            match &self.shade {
-                Some(v) => {
-                    v.write_to_shade(writer);
-                }
-                None => {}
+            if let Some(v) = &self.shade {
+                v.write_to_shade(writer);
             }
 
             // a:alpha
-            match &self.alpha {
-                Some(v) => {
-                    v.write_to_alpha(writer);
-                }
-                None => {}
+            if let Some(v) = &self.alpha {
+                v.write_to_alpha(writer);
             }
 
             // a:tint
-            match &self.tint {
-                Some(v) => {
-                    v.write_to_tint(writer);
-                }
-                None => {}
+            if let Some(v) = &self.tint {
+                v.write_to_tint(writer);
             }
 
             write_end_tag(writer, "a:srgbClr");

--- a/src/structs/drawing/rotation.rs
+++ b/src/structs/drawing/rotation.rs
@@ -13,6 +13,7 @@ pub struct Rotation {
     longitude: Int32Value,
     revolution: Int32Value,
 }
+
 impl Rotation {
     pub fn get_latitude(&self) -> &i32 {
         self.latitude.get_value()
@@ -46,26 +47,9 @@ impl Rotation {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"lat") {
-            Some(v) => {
-                self.latitude.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"lon") {
-            Some(v) => {
-                self.longitude.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"rev") {
-            Some(v) => {
-                self.revolution.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, latitude, "lat");
+        set_string_from_xml!(self, e, longitude, "lon");
+        set_string_from_xml!(self, e, revolution, "rev");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/run.rs
+++ b/src/structs/drawing/run.rs
@@ -2,6 +2,7 @@ use super::run_properties::RunProperties;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -10,6 +11,7 @@ pub struct Run {
     text: String,
     run_properties: RunProperties,
 }
+
 impl Run {
     pub fn get_text(&self) -> &str {
         &self.text
@@ -36,34 +38,28 @@ impl Run {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().0 {
-                    b"a:rPr" => {
-                        self.run_properties.set_attributes(reader, e, false);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().0 {
-                    b"a:rPr" => {
-                        self.run_properties.set_attributes(reader, e, true);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Text(e)) => {
-                    self.set_text(e.unescape().unwrap());
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().0 == b"a:rPr" {
+                    self.run_properties.set_attributes(reader, e, false);
                 }
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"a:r" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "a:r"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Empty(ref e) => {
+                if e.name().0 == b"a:rPr" {
+                    self.run_properties.set_attributes(reader, e, true);
+                }
+            },
+            Event::Text(e) => {
+                self.set_text(e.unescape().unwrap());
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"a:r" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "a:r")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/run_properties.rs
+++ b/src/structs/drawing/run_properties.rs
@@ -35,6 +35,7 @@ pub struct RunProperties {
     no_fill: Option<NoFill>,
     effect_list: Option<EffectList>,
 }
+
 impl RunProperties {
     pub fn get_text(&self) -> &str {
         &self.text
@@ -223,129 +224,103 @@ impl RunProperties {
         e: &BytesStart,
         empty_flag: bool,
     ) {
-        match get_attribute(e, b"kumimoji") {
-            Some(v) => {
-                self.set_kumimoji(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"kumimoji") {
+            self.set_kumimoji(v);
         }
-        match get_attribute(e, b"lang") {
-            Some(v) => {
-                self.set_language(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"lang") {
+            self.set_language(v);
         }
-        match get_attribute(e, b"altLang") {
-            Some(v) => {
-                self.set_alternative_language(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"altLang") {
+            self.set_alternative_language(v);
         }
-        match get_attribute(e, b"b") {
-            Some(v) => {
-                self.set_bold(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"b") {
+            self.set_bold(v);
         }
-        match get_attribute(e, b"sz") {
-            Some(v) => {
-                self.set_sz(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"sz") {
+            self.set_sz(v);
         }
-        match get_attribute(e, b"strike") {
-            Some(v) => {
-                self.set_strike(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"strike") {
+            self.set_strike(v);
         }
-        match get_attribute(e, b"i") {
-            Some(v) => {
-                self.set_italic(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"i") {
+            self.set_italic(v);
         }
-        match get_attribute(e, b"cap") {
-            Some(v) => {
-                self.capital.set_value_string(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"cap") {
+            self.capital.set_value_string(v);
         }
-        match get_attribute(e, b"spc") {
-            Some(v) => {
-                self.spacing.set_value_string(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"spc") {
+            self.spacing.set_value_string(v);
         }
 
         if empty_flag {
             return;
         }
 
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"a:solidFill" => {
-                        let mut obj = SolidFill::default();
-                        obj.set_attributes(reader, e);
-                        self.set_solid_fill(obj);
-                    }
-                    b"a:ln" => {
-                        let mut obj = Outline::default();
-                        obj.set_attributes(reader, e);
-                        self.set_outline(obj);
-                    }
-                    b"a:gradFill" => {
-                        let mut obj = GradientFill::default();
-                        obj.set_attributes(reader, e);
-                        self.set_gradient_fill(obj);
-                    }
-                    b"a:effectLst" => {
-                        let mut effect_list = EffectList::default();
-                        effect_list.set_attributes(reader, e, false);
-                        self.set_effect_list(effect_list);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"a:latin" => {
-                        let mut obj = TextFontType::default();
-                        obj.set_attributes(reader, e);
-                        self.set_latin_font(obj);
-                    }
-                    b"a:ea" => {
-                        let mut obj = TextFontType::default();
-                        obj.set_attributes(reader, e);
-                        self.set_east_asian_font(obj);
-                    }
-                    b"a:noFill" => {
-                        let mut obj = NoFill::default();
-                        obj.set_attributes(reader, e);
-                        self.set_no_fill(obj);
-                    }
-                    b"a:effectLst" => {
-                        let mut obj = EffectList::default();
-                        obj.set_attributes(reader, e, true);
-                        self.set_effect_list(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:rPr" => return,
-                    b"a:endParaRPr" => return,
-                    b"a:defRPr" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!(
-                    "Error not find {} end element",
-                    "a:rPr, a:endParaRPr, a:defRPr"
-                ),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
+                b"a:solidFill" => {
+                    let mut obj = SolidFill::default();
+                    obj.set_attributes(reader, e);
+                    self.set_solid_fill(obj);
+                }
+                b"a:ln" => {
+                    let mut obj = Outline::default();
+                    obj.set_attributes(reader, e);
+                    self.set_outline(obj);
+                }
+                b"a:gradFill" => {
+                    let mut obj = GradientFill::default();
+                    obj.set_attributes(reader, e);
+                    self.set_gradient_fill(obj);
+                }
+                b"a:effectLst" => {
+                    let mut effect_list = EffectList::default();
+                    effect_list.set_attributes(reader, e, false);
+                    self.set_effect_list(effect_list);
+                }
                 _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
+                b"a:latin" => {
+                    let mut obj = TextFontType::default();
+                    obj.set_attributes(reader, e);
+                    self.set_latin_font(obj);
+                }
+                b"a:ea" => {
+                    let mut obj = TextFontType::default();
+                    obj.set_attributes(reader, e);
+                    self.set_east_asian_font(obj);
+                }
+                b"a:noFill" => {
+                    let mut obj = NoFill::default();
+                    obj.set_attributes(reader, e);
+                    self.set_no_fill(obj);
+                }
+                b"a:effectLst" => {
+                    let mut obj = EffectList::default();
+                    obj.set_attributes(reader, e, true);
+                    self.set_effect_list(obj);
+                }
+                _ => (),
+                }
+            },
+            Event::End(ref e) => {
+                match e.name().into_inner() {
+                b"a:rPr" => return,
+                b"a:endParaRPr" => return,
+                b"a:defRPr" => return,
+                _ => (),
+                }
+            },
+            Event::Eof => panic!(
+                "Error not find {} end element",
+                "a:rPr, a:endParaRPr, a:defRPr"
+            )
+        );
     }
 
     pub(crate) fn write_to_rpr(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/scheme_color.rs
+++ b/src/structs/drawing/scheme_color.rs
@@ -22,6 +22,7 @@ pub struct SchemeColor {
     alpha: Option<PositiveFixedPercentageType>,
     tint: Option<PositiveFixedPercentageType>,
 }
+
 impl SchemeColor {
     pub fn get_val(&self) -> &SchemeColorValues {
         self.val.get_value()
@@ -151,10 +152,10 @@ impl SchemeColor {
             return;
         }
 
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
                     b"a:lum" => {
                         let mut obj = PercentageType::default();
                         obj.set_attributes(reader, e);
@@ -196,17 +197,15 @@ impl SchemeColor {
                         self.tint = Some(obj);
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:schemeClr" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "a:schemeClr"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"a:schemeClr" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "a:schemeClr")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
@@ -220,67 +219,43 @@ impl SchemeColor {
             );
 
             // a:luminance
-            match &self.luminance {
-                Some(v) => {
-                    v.write_to_lum(writer);
-                }
-                None => {}
+            if let Some(v) = &self.luminance {
+                v.write_to_lum(writer);
             }
 
             // a:lumMod
-            match &self.luminance_modulation {
-                Some(v) => {
-                    v.write_to_lum_mod(writer);
-                }
-                None => {}
+            if let Some(v) = &self.luminance_modulation {
+                v.write_to_lum_mod(writer);
             }
 
             // a:lumOff
-            match &self.luminance_offset {
-                Some(v) => {
-                    v.write_to_lum_off(writer);
-                }
-                None => {}
+            if let Some(v) = &self.luminance_offset {
+                v.write_to_lum_off(writer);
             }
 
             // a:sat
-            match &self.saturation {
-                Some(v) => {
-                    v.write_to_sat(writer);
-                }
-                None => {}
+            if let Some(v) = &self.saturation {
+                v.write_to_sat(writer);
             }
 
             // a:satMod
-            match &self.saturation_modulation {
-                Some(v) => {
-                    v.write_to_sat_mod(writer);
-                }
-                None => {}
+            if let Some(v) = &self.saturation_modulation {
+                v.write_to_sat_mod(writer);
             }
 
             // a:shade
-            match &self.shade {
-                Some(v) => {
-                    v.write_to_shade(writer);
-                }
-                None => {}
+            if let Some(v) = &self.shade {
+                v.write_to_shade(writer);
             }
 
             // a:alpha
-            match &self.alpha {
-                Some(v) => {
-                    v.write_to_alpha(writer);
-                }
-                None => {}
+            if let Some(v) = &self.alpha {
+                v.write_to_alpha(writer);
             }
 
             // a:tint
-            match &self.tint {
-                Some(v) => {
-                    v.write_to_tint(writer);
-                }
-                None => {}
+            if let Some(v) = &self.tint {
+                v.write_to_tint(writer);
             }
 
             write_end_tag(writer, "a:schemeClr");

--- a/src/structs/drawing/spreadsheet/extent.rs
+++ b/src/structs/drawing/spreadsheet/extent.rs
@@ -12,6 +12,7 @@ pub struct Extent {
     cx: Int64Value,
     cy: Int64Value,
 }
+
 impl Extent {
     pub fn get_cx(&self) -> &i64 {
         self.cx.get_value()
@@ -36,18 +37,8 @@ impl Extent {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"cx") {
-            Some(v) => {
-                self.cx.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"cy") {
-            Some(v) => {
-                self.cy.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, cx, "cx");
+        set_string_from_xml!(self, e, cy, "cy");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/spreadsheet/graphic_frame.rs
+++ b/src/structs/drawing/spreadsheet/graphic_frame.rs
@@ -19,6 +19,7 @@ pub struct GraphicFrame {
     transform: Transform,
     graphic: Graphic,
 }
+
 impl GraphicFrame {
     pub fn get_macro(&self) -> &str {
         self.r#macro.get_value()
@@ -79,41 +80,33 @@ impl GraphicFrame {
         e: &BytesStart,
         drawing_relationships: Option<&RawRelationships>,
     ) {
-        match get_attribute(e, b"macro") {
-            Some(v) => {
-                self.r#macro.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, r#macro, "macro");
 
-        let mut buf = Vec::new();
-
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
                     b"xdr:nvGraphicFramePr" => {
                         self.non_visual_graphic_frame_properties
                             .set_attributes(reader, e);
-                    }
+                        }
                     b"xdr:xfrm" => {
                         self.transform.set_attributes(reader, e);
                     }
                     b"a:graphic" => {
                         self.graphic
                             .set_attributes(reader, e, drawing_relationships);
-                    }
+                        }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"xdr:graphicFrame" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "xdr:graphicFrame"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::End(ref e) => {
+                if  e.name().into_inner() == b"xdr:graphicFrame" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "xdr:graphicFrame")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, r_id: &i32) {

--- a/src/structs/drawing/spreadsheet/non_visual_connection_shape_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_connection_shape_properties.rs
@@ -4,6 +4,7 @@ use super::NonVisualDrawingProperties;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -12,6 +13,7 @@ pub struct NonVisualConnectionShapeProperties {
     non_visual_drawing_properties: NonVisualDrawingProperties,
     non_visual_connector_shape_drawing_properties: NonVisualConnectorShapeDrawingProperties,
 }
+
 impl NonVisualConnectionShapeProperties {
     pub fn get_non_visual_drawing_properties(&self) -> &NonVisualDrawingProperties {
         &self.non_visual_drawing_properties
@@ -54,33 +56,27 @@ impl NonVisualConnectionShapeProperties {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"xdr:cNvCxnSpPr" => {
-                        self.non_visual_connector_shape_drawing_properties
-                            .set_attributes(reader, e);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"xdr:cNvPr" => {
-                        self.non_visual_drawing_properties
-                            .set_attributes(reader, e, true);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"xdr:nvCxnSpPr" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "xdr:nvCxnSpPr"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"xdr:cNvCxnSpPr" {
+                    self.non_visual_connector_shape_drawing_properties
+                        .set_attributes(reader, e);
+                }
+            },
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"xdr:cNvPr" {
+                    self.non_visual_drawing_properties
+                        .set_attributes(reader, e, true);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"xdr:nvCxnSpPr" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "xdr:nvCxnSpPr")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/spreadsheet/worksheet_drawing.rs
+++ b/src/structs/drawing/spreadsheet/worksheet_drawing.rs
@@ -8,6 +8,7 @@ use super::TwoCellAnchor;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::raw::RawRelationships;
 use structs::Chart;
@@ -22,6 +23,7 @@ pub struct WorksheetDrawing {
     one_cell_anchor_collection: Vec<OneCellAnchor>,
     two_cell_anchor_collection: Vec<TwoCellAnchor>,
 }
+
 impl WorksheetDrawing {
     pub fn get_image_collection(&self) -> &Vec<Image> {
         &self.image_collection
@@ -43,12 +45,9 @@ impl WorksheetDrawing {
     }
 
     pub fn get_image_mut(&mut self, col: &u32, row: &u32) -> Option<&mut Image> {
-        for image in &mut self.image_collection {
-            if image.get_col() == &(col - 1) && image.get_row() == &(row - 1) {
-                return Some(image);
-            }
-        }
-        None
+        self.image_collection
+            .iter_mut()
+            .find(|image| image.get_col() == &(col - 1) && image.get_row() == &(row - 1))
     }
 
     pub fn get_images(&self, col: &u32, row: &u32) -> Vec<&Image> {
@@ -91,12 +90,9 @@ impl WorksheetDrawing {
     }
 
     pub fn get_chart_mut(&mut self, col: &u32, row: &u32) -> Option<&mut Chart> {
-        for chart in &mut self.chart_collection {
-            if chart.get_col() == &(col - 1) && chart.get_row() == &(row - 1) {
-                return Some(chart);
-            }
-        }
-        None
+        self.chart_collection
+            .iter_mut()
+            .find(|chart| chart.get_col() == &(col - 1) && chart.get_row() == &(row - 1))
     }
 
     pub fn get_charts(&self, col: &u32, row: &u32) -> Vec<&Chart> {
@@ -155,11 +151,8 @@ impl WorksheetDrawing {
     pub fn get_graphic_frame_collection(&self) -> Vec<&GraphicFrame> {
         let mut result: Vec<&GraphicFrame> = Vec::new();
         for two_cell_anchor in &self.two_cell_anchor_collection {
-            match two_cell_anchor.get_graphic_frame() {
-                Some(v) => {
-                    result.push(v);
-                }
-                None => {}
+            if let Some(v) = two_cell_anchor.get_graphic_frame() {
+                result.push(v);
             }
         }
         result
@@ -168,11 +161,8 @@ impl WorksheetDrawing {
     pub fn get_graphic_frame_collection_mut(&mut self) -> Vec<&mut GraphicFrame> {
         let mut result: Vec<&mut GraphicFrame> = Vec::new();
         for two_cell_anchor in &mut self.two_cell_anchor_collection {
-            match two_cell_anchor.get_graphic_frame_mut() {
-                Some(v) => {
-                    result.push(v);
-                }
-                None => {}
+            if let Some(v) = two_cell_anchor.get_graphic_frame_mut() {
+                result.push(v);
             }
         }
         result
@@ -181,11 +171,8 @@ impl WorksheetDrawing {
     pub fn get_shape_collection(&self) -> Vec<&Shape> {
         let mut result: Vec<&Shape> = Vec::new();
         for two_cell_anchor in &self.two_cell_anchor_collection {
-            match two_cell_anchor.get_shape() {
-                Some(v) => {
-                    result.push(v);
-                }
-                None => {}
+            if let Some(v) = two_cell_anchor.get_shape() {
+                result.push(v);
             }
         }
         result
@@ -194,11 +181,8 @@ impl WorksheetDrawing {
     pub fn get_shape_collection_mut(&mut self) -> Vec<&mut Shape> {
         let mut result: Vec<&mut Shape> = Vec::new();
         for two_cell_anchor in &mut self.two_cell_anchor_collection {
-            match two_cell_anchor.get_shape_mut() {
-                Some(v) => {
-                    result.push(v);
-                }
-                None => {}
+            if let Some(v) = two_cell_anchor.get_shape_mut() {
+                result.push(v);
             }
         }
         result
@@ -207,11 +191,8 @@ impl WorksheetDrawing {
     pub fn get_connection_shape_collection(&self) -> Vec<&ConnectionShape> {
         let mut result: Vec<&ConnectionShape> = Vec::new();
         for two_cell_anchor in &self.two_cell_anchor_collection {
-            match two_cell_anchor.get_connection_shape() {
-                Some(v) => {
-                    result.push(v);
-                }
-                None => {}
+            if let Some(v) = two_cell_anchor.get_connection_shape() {
+                result.push(v);
             }
         }
         result
@@ -220,11 +201,8 @@ impl WorksheetDrawing {
     pub fn get_connection_shape_collection_mut(&mut self) -> Vec<&mut ConnectionShape> {
         let mut result: Vec<&mut ConnectionShape> = Vec::new();
         for two_cell_anchor in &mut self.two_cell_anchor_collection {
-            match two_cell_anchor.get_connection_shape_mut() {
-                Some(v) => {
-                    result.push(v);
-                }
-                None => {}
+            if let Some(v) = two_cell_anchor.get_connection_shape_mut() {
+                result.push(v);
             }
         }
         result
@@ -233,11 +211,8 @@ impl WorksheetDrawing {
     pub fn get_picture_collection(&self) -> Vec<&Picture> {
         let mut result: Vec<&Picture> = Vec::new();
         for two_cell_anchor in &self.two_cell_anchor_collection {
-            match two_cell_anchor.get_picture() {
-                Some(v) => {
-                    result.push(v);
-                }
-                None => {}
+            if let Some(v) = two_cell_anchor.get_picture() {
+                result.push(v);
             }
         }
         result
@@ -246,11 +221,8 @@ impl WorksheetDrawing {
     pub fn get_picture_collection_mut(&mut self) -> Vec<&mut Picture> {
         let mut result: Vec<&mut Picture> = Vec::new();
         for two_cell_anchor in &mut self.two_cell_anchor_collection {
-            match two_cell_anchor.get_picture_mut() {
-                Some(v) => {
-                    result.push(v);
-                }
-                None => {}
+            if let Some(v) = two_cell_anchor.get_picture_mut() {
+                result.push(v);
             }
         }
         result
@@ -324,10 +296,11 @@ impl WorksheetDrawing {
     ) {
         let mut ole_index = 0;
         let mut is_alternate_content = false;
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
+
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
                     b"mc:AlternateContent" => {
                         is_alternate_content = true;
                     }
@@ -376,20 +349,21 @@ impl WorksheetDrawing {
                         }
                     }
                     _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
+                }
+            },
+
+            Event::End(ref e) => {
+                match e.name().into_inner() {
                     b"mc:AlternateContent" => {
                         is_alternate_content = false;
                     }
                     b"xdr:wsDr" => return,
                     _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "xdr:wsDr"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+
+            Event::Eof => panic!("Error not find {} end element", "xdr:wsDr")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, ole_objects: &OleObjects) {

--- a/src/structs/drawing/stretch.rs
+++ b/src/structs/drawing/stretch.rs
@@ -3,6 +3,7 @@ use super::fill_rectangle::FillRectangle;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub struct Stretch {
     fill_rectangle: Option<FillRectangle>,
 }
+
 impl Stretch {
     pub fn get_fill_rectangle(&self) -> &Option<FillRectangle> {
         &self.fill_rectangle
@@ -28,27 +30,22 @@ impl Stretch {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"a:fillRect" => {
-                        let mut fill_rectangle = FillRectangle::default();
-                        fill_rectangle.set_attributes(reader, e);
-                        self.set_fill_rectangle(fill_rectangle);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"a:stretch" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "a:stretch"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"a:fillRect" {
+                    let mut fill_rectangle = FillRectangle::default();
+                    fill_rectangle.set_attributes(reader, e);
+                    self.set_fill_rectangle(fill_rectangle);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"a:stretch" {
+                    return;
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "a:stretch")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/style_matrix_reference_type.rs
+++ b/src/structs/drawing/style_matrix_reference_type.rs
@@ -12,6 +12,7 @@ pub struct StyleMatrixReferenceType {
     index: String,
     scheme_color: Option<SchemeColor>,
 }
+
 impl StyleMatrixReferenceType {
     pub fn get_index(&self) -> &str {
         &self.index
@@ -41,26 +42,24 @@ impl StyleMatrixReferenceType {
             return;
         }
 
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"a:schemeClr" => {
-                        let mut scheme_color = SchemeColor::default();
-                        scheme_color.set_attributes(reader, e, false);
-                        self.set_scheme_color(scheme_color);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"a:schemeClr" => {
-                        let mut scheme_color = SchemeColor::default();
-                        scheme_color.set_attributes(reader, e, true);
-                        self.set_scheme_color(scheme_color);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
+        xml_read_loop!(
+            reader,
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"a:schemeClr" {
+                    let mut scheme_color = SchemeColor::default();
+                    scheme_color.set_attributes(reader, e, false);
+                    self.set_scheme_color(scheme_color);
+                }
+            },
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"a:schemeClr" {
+                    let mut scheme_color = SchemeColor::default();
+                    scheme_color.set_attributes(reader, e, true);
+                    self.set_scheme_color(scheme_color);
+                }
+            },
+            Event::End(ref e) => {
+                match e.name().into_inner() {
                     b"a:lnRef" => {
                         return;
                     }
@@ -74,26 +73,20 @@ impl StyleMatrixReferenceType {
                         return;
                     }
                     _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "a:lnRef"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "a:lnRef")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, tag_name: &str) {
-        match &self.scheme_color {
-            Some(color) => {
-                write_start_tag(writer, tag_name, vec![("idx", &self.index)], false);
-                // a:schemeClr
-                color.write_to(writer);
-                write_end_tag(writer, tag_name);
-            }
-            None => {
-                write_start_tag(writer, tag_name, vec![("idx", &self.index)], true);
-            }
+        if let Some(color) = &self.scheme_color {
+            write_start_tag(writer, tag_name, vec![("idx", &self.index)], false);
+            // a:schemeClr
+            color.write_to(writer);
+            write_end_tag(writer, tag_name);
+        } else {
+            write_start_tag(writer, tag_name, vec![("idx", &self.index)], true);
         }
     }
 }

--- a/src/structs/drawing/supplemental_font.rs
+++ b/src/structs/drawing/supplemental_font.rs
@@ -12,6 +12,7 @@ pub struct SupplementalFont {
     script: StringValue,
     typeface: StringValue,
 }
+
 impl SupplementalFont {
     pub fn get_script(&self) -> &str {
         self.script.get_value()
@@ -36,18 +37,8 @@ impl SupplementalFont {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"script") {
-            Some(v) => {
-                self.script.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"typeface") {
-            Some(v) => {
-                self.typeface.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, script, "script");
+        set_string_from_xml!(self, e, typeface, "typeface");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/system_color.rs
+++ b/src/structs/drawing/system_color.rs
@@ -14,6 +14,7 @@ pub struct SystemColor {
     val: EnumValue<SystemColorValues>,
     last_color: StringValue,
 }
+
 impl SystemColor {
     pub fn get_val(&self) -> &SystemColorValues {
         self.val.get_value()
@@ -37,18 +38,8 @@ impl SystemColor {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"val") {
-            Some(v) => {
-                self.val.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"lastClr") {
-            Some(v) => {
-                self.last_color.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, val, "val");
+        set_string_from_xml!(self, e, last_color, "lastClr");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/tail_end.rs
+++ b/src/structs/drawing/tail_end.rs
@@ -13,6 +13,7 @@ pub struct TailEnd {
     width: StringValue,
     length: StringValue,
 }
+
 impl TailEnd {
     pub fn get_type(&self) -> &str {
         self.t_type.get_value()
@@ -43,25 +44,16 @@ impl TailEnd {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"type") {
-            Some(v) => {
-                self.set_type(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"type") {
+            self.set_type(v);
         }
 
-        match get_attribute(e, b"w") {
-            Some(v) => {
-                self.set_width(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"w") {
+            self.set_width(v);
         }
 
-        match get_attribute(e, b"len") {
-            Some(v) => {
-                self.set_length(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"len") {
+            self.set_length(v);
         }
     }
 

--- a/src/structs/drawing/text_font_type.rs
+++ b/src/structs/drawing/text_font_type.rs
@@ -13,6 +13,7 @@ pub struct TextFontType {
     charset: StringValue,
     panose: StringValue,
 }
+
 impl TextFontType {
     pub fn get_typeface(&self) -> &str {
         self.typeface.get_value()
@@ -55,29 +56,17 @@ impl TextFontType {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"typeface") {
-            Some(v) => {
-                self.set_typeface(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"typeface") {
+            self.set_typeface(v);
         }
-        match get_attribute(e, b"pitchFamily") {
-            Some(v) => {
-                self.set_pitch_family(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"pitchFamily") {
+            self.set_pitch_family(v);
         }
-        match get_attribute(e, b"charset") {
-            Some(v) => {
-                self.set_charset(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"charset") {
+            self.set_charset(v);
         }
-        match get_attribute(e, b"panose") {
-            Some(v) => {
-                self.set_panose(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"panose") {
+            self.set_panose(v);
         }
     }
 

--- a/src/structs/enum_value.rs
+++ b/src/structs/enum_value.rs
@@ -1,10 +1,12 @@
 use super::EnumTrait;
 use std::str::FromStr;
+
 #[derive(Clone, Default, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct EnumValue<T: EnumTrait + FromStr> {
     value: Option<T>,
     value_default: T,
 }
+
 impl<T: EnumTrait + FromStr> EnumValue<T> {
     pub(crate) fn get_value(&self) -> &T {
         match &self.value {
@@ -23,20 +25,14 @@ impl<T: EnumTrait + FromStr> EnumValue<T> {
     }
 
     pub(crate) fn set_value_string<S: Into<String>>(&mut self, value: S) -> &mut EnumValue<T> {
-        match T::from_str(value.into().as_str()) {
-            Ok(v) => {
-                self.set_value(v);
-            }
-            Err(_) => {}
+        if let Ok(v) = T::from_str(value.into().as_str()) {
+            self.set_value(v);
         }
         self
     }
 
     pub(crate) fn has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 
     pub(crate) fn get_hash_string(&self) -> &str {

--- a/src/structs/font_char_set.rs
+++ b/src/structs/font_char_set.rs
@@ -11,6 +11,7 @@ use writer::driver::*;
 pub struct FontCharSet {
     pub(crate) val: Int32Value,
 }
+
 impl FontCharSet {
     pub fn get_val(&self) -> &i32 {
         self.val.get_value()
@@ -26,17 +27,12 @@ impl FontCharSet {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"val") {
-            Some(v) => {
-                self.val.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, val, "val");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // charset
-        if &self.val.has_value() == &true {
+        if self.val.has_value() {
             let mut attributes: Vec<(&str, &str)> = Vec::new();
             let val = self.val.get_value_string();
             attributes.push(("val", &val));

--- a/src/structs/font_family_numbering.rs
+++ b/src/structs/font_family_numbering.rs
@@ -11,6 +11,7 @@ use writer::driver::*;
 pub struct FontFamilyNumbering {
     pub(crate) val: Int32Value,
 }
+
 impl FontFamilyNumbering {
     pub fn get_val(&self) -> &i32 {
         self.val.get_value()
@@ -26,17 +27,12 @@ impl FontFamilyNumbering {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"val") {
-            Some(v) => {
-                self.val.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, val, "val");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // family
-        if &self.val.has_value() == &true {
+        if self.val.has_value() {
             write_start_tag(
                 writer,
                 "family",

--- a/src/structs/font_name.rs
+++ b/src/structs/font_name.rs
@@ -11,6 +11,7 @@ use writer::driver::*;
 pub struct FontName {
     pub(crate) val: StringValue,
 }
+
 impl FontName {
     pub fn get_val(&self) -> &str {
         self.val.get_value()
@@ -31,7 +32,7 @@ impl FontName {
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, tag_name: &str) {
         // name, rFont
-        if &self.val.has_value() == &true {
+        if self.val.has_value() {
             write_start_tag(
                 writer,
                 tag_name,

--- a/src/structs/font_scheme.rs
+++ b/src/structs/font_scheme.rs
@@ -12,6 +12,7 @@ use writer::driver::*;
 pub struct FontScheme {
     pub(crate) val: EnumValue<FontSchemeValues>,
 }
+
 impl FontScheme {
     pub fn get_val(&self) -> &FontSchemeValues {
         self.val.get_value()
@@ -33,8 +34,7 @@ impl FontScheme {
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // scheme
         if self.val.has_value() {
-            let mut attributes: Vec<(&str, &str)> = Vec::new();
-            attributes.push(("val", self.val.get_value_string()));
+            let attributes = vec![("val", self.val.get_value_string())];
             write_start_tag(writer, "scheme", attributes, true);
         }
     }

--- a/src/structs/font_scheme_values.rs
+++ b/src/structs/font_scheme_values.rs
@@ -1,16 +1,19 @@
 use super::EnumTrait;
 use std::str::FromStr;
+
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum FontSchemeValues {
     Major,
     Minor,
     None,
 }
+
 impl Default for FontSchemeValues {
     fn default() -> Self {
         Self::None
     }
 }
+
 impl EnumTrait for FontSchemeValues {
     fn get_value_string(&self) -> &str {
         match &self {
@@ -20,6 +23,7 @@ impl EnumTrait for FontSchemeValues {
         }
     }
 }
+
 impl FromStr for FontSchemeValues {
     type Err = ();
     fn from_str(input: &str) -> Result<Self, Self::Err> {

--- a/src/structs/font_size.rs
+++ b/src/structs/font_size.rs
@@ -11,6 +11,7 @@ use writer::driver::*;
 pub struct FontSize {
     pub(crate) val: DoubleValue,
 }
+
 impl FontSize {
     pub fn get_val(&self) -> &f64 {
         self.val.get_value()
@@ -31,7 +32,7 @@ impl FontSize {
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // sz
-        if &self.val.has_value() == &true {
+        if self.val.has_value() {
             write_start_tag(
                 writer,
                 "sz",

--- a/src/structs/formula.rs
+++ b/src/structs/formula.rs
@@ -5,6 +5,7 @@ use helper::address::*;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -13,6 +14,7 @@ pub struct Formula {
     address: Address,
     string_value: StringValue,
 }
+
 impl Formula {
     pub fn get_address(&self) -> &Address {
         &self.address
@@ -56,22 +58,18 @@ impl Formula {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => {
-                    self.set_address_str(e.unescape().unwrap().to_string());
+        xml_read_loop!(
+            reader,
+            Event::Text(e) => {
+                self.set_address_str(e.unescape().unwrap().to_string());
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"formula" {
+                    return
                 }
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"formula" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "formula"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Eof => panic!("Error not find {} end element", "formula")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/int32_value.rs
+++ b/src/structs/int32_value.rs
@@ -24,10 +24,7 @@ impl Int32Value {
     }
 
     pub(crate) fn has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 
     pub(crate) fn get_hash_string(&self) -> String {

--- a/src/structs/int64_value.rs
+++ b/src/structs/int64_value.rs
@@ -24,10 +24,7 @@ impl Int64Value {
     }
 
     pub(crate) fn has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 
     pub(crate) fn _get_hash_string(&self) -> String {

--- a/src/structs/italic.rs
+++ b/src/structs/italic.rs
@@ -11,6 +11,7 @@ use writer::driver::*;
 pub struct Italic {
     pub(crate) val: BooleanValue,
 }
+
 impl Italic {
     pub fn get_val(&self) -> &bool {
         self.val.get_value()
@@ -27,12 +28,7 @@ impl Italic {
         e: &BytesStart,
     ) {
         self.val.set_value(true);
-        match get_attribute(e, b"val") {
-            Some(v) => {
-                self.val.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, val, "val");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/numbering_format.rs
+++ b/src/structs/numbering_format.rs
@@ -13,6 +13,7 @@ pub struct NumberingFormat {
     format_code: String,
     is_build_in: bool,
 }
+
 impl Default for NumberingFormat {
     fn default() -> Self {
         Self {
@@ -22,6 +23,7 @@ impl Default for NumberingFormat {
         }
     }
 }
+
 impl NumberingFormat {
     // Pre-defined formats
     pub const FORMAT_GENERAL: &'static str = "General";
@@ -59,14 +61,14 @@ impl NumberingFormat {
     pub const FORMAT_DATE_TIME8: &'static str = "h:mm:ss;@";
     pub const FORMAT_DATE_YYYYMMDDSLASH: &'static str = "yyyy/mm/dd;@";
 
-    pub const FORMAT_CURRENCY_USD_SIMPLE: &'static str = r###""$"#,##0.00_-"###;
+    pub const FORMAT_CURRENCY_USD_SIMPLE: &'static str = r##""$"#,##0.00_-"##;
     pub const FORMAT_CURRENCY_USD: &'static str = r###"$#,##0_-"###;
-    pub const FORMAT_CURRENCY_EUR_SIMPLE: &'static str = r###"#,##0.00_-"€""###;
-    pub const FORMAT_CURRENCY_EUR: &'static str = r###"#,##0_-"€""###;
+    pub const FORMAT_CURRENCY_EUR_SIMPLE: &'static str = r#"#,##0.00_-"€""#;
+    pub const FORMAT_CURRENCY_EUR: &'static str = r#"#,##0_-"€""#;
     pub const FORMAT_ACCOUNTING_USD: &'static str =
-        r###"_("$"* #,##0.00_);_("$"* \(#,##0.00\);_("$"* "-"??_);_(@_)"###;
+        r#"_("$"* #,##0.00_);_("$"* \(#,##0.00\);_("$"* "-"??_);_(@_)"#;
     pub const FORMAT_ACCOUNTING_EUR: &'static str =
-        r###"_("€"* #,##0.00_);_("€"* \(#,##0.00\);_("€"* "-"??_);_(@_)"###;
+        r#"_("€"* #,##0.00_);_("€"* \(#,##0.00\);_("€"* "-"??_);_(@_)"#;
 
     pub fn get_number_format_id(&self) -> &u32 {
         &self.number_format_id
@@ -194,7 +196,7 @@ lazy_static! {
         map.insert(39, "#,##0.00_);(#,##0.00)".to_string()); //  Despite ECMA '#,##0.00;(#,##0.00)");
         map.insert(40, "#,##0.00_);[Red](#,##0.00)".to_string()); //  Despite ECMA '#,##0.00;[Red](#,##0.00)");
 
-        map.insert(44, r###"_("$"* #,##0.00_);_("$"* \(#,##0.00\);_("$"* "-"??_);_(@_)"###.to_string());
+        map.insert(44, r#"_("$"* #,##0.00_);_("$"* \(#,##0.00\);_("$"* "-"??_);_(@_)"#.to_string());
         map.insert(45, "mm:ss".to_string());
         map.insert(46, "[h]:mm:ss".to_string());
         map.insert(47, "mm:ss.0".to_string()); //  Despite ECMA 'mmss.0");
@@ -219,20 +221,20 @@ lazy_static! {
         map.insert(70, "t# ??/??".to_string());
 
         // JPN
-        map.insert(28, r###"[$-411]ggge"年"m"月"d"日""###.to_string());
-        map.insert(29, r###"[$-411]ggge"年"m"月"d"日""###.to_string());
-        map.insert(31, r###"yyyy"年"m"月"d"日""###.to_string());
-        map.insert(32, r###"h"時"mm"分""###.to_string());
-        map.insert(33, r###"h"時"mm"分"ss"秒""###.to_string());
-        map.insert(34, r###"yyyy"年"m"月""###.to_string());
-        map.insert(35, r###"m"月"d"日""###.to_string());
-        map.insert(51, r###"[$-411]ggge"年"m"月"d"日""###.to_string());
-        map.insert(52, r###"yyyy"年"m"月""###.to_string());
-        map.insert(53, r###"m"月"d"日""###.to_string());
-        map.insert(54, r###"[$-411]ggge"年"m"月"d"日""###.to_string());
-        map.insert(55, r###"yyyy"年"m"月""###.to_string());
-        map.insert(56, r###"m"月"d"日""###.to_string());
-        map.insert(58, r###"[$-411]ggge"年"m"月"d"日""###.to_string());
+        map.insert(28, r#"[$-411]ggge"年"m"月"d"日""#.to_string());
+        map.insert(29, r#"[$-411]ggge"年"m"月"d"日""#.to_string());
+        map.insert(31, r#"yyyy"年"m"月"d"日""#.to_string());
+        map.insert(32, r#"h"時"mm"分""#.to_string());
+        map.insert(33, r#"h"時"mm"分"ss"秒""#.to_string());
+        map.insert(34, r#"yyyy"年"m"月""#.to_string());
+        map.insert(35, r#"m"月"d"日""#.to_string());
+        map.insert(51, r#"[$-411]ggge"年"m"月"d"日""#.to_string());
+        map.insert(52, r#"yyyy"年"m"月""#.to_string());
+        map.insert(53, r#"m"月"d"日""#.to_string());
+        map.insert(54, r#"[$-411]ggge"年"m"月"d"日""#.to_string());
+        map.insert(55, r#"yyyy"年"m"月""#.to_string());
+        map.insert(56, r#"m"月"d"日""#.to_string());
+        map.insert(58, r#"[$-411]ggge"年"m"月"d"日""#.to_string());
 
         map
     };

--- a/src/structs/odd_footer.rs
+++ b/src/structs/odd_footer.rs
@@ -3,6 +3,7 @@ use md5::Digest;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::StringValue;
 use writer::driver::*;
@@ -11,6 +12,7 @@ use writer::driver::*;
 pub struct OddFooter {
     value: StringValue,
 }
+
 impl OddFooter {
     pub fn get_value(&self) -> &str {
         self.value.get_value()
@@ -37,22 +39,18 @@ impl OddFooter {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => {
-                    self.set_value(e.unescape().unwrap());
+        xml_read_loop!(
+            reader,
+            Event::Text(e) => {
+                self.set_value(e.unescape().unwrap());
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"oddFooter" {
+                    return
                 }
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"oddFooter" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "oddFooter"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Eof => panic!("Error not find {} end element", "oddFooter")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/office2010/drawing/charts/style.rs
+++ b/src/structs/office2010/drawing/charts/style.rs
@@ -2,30 +2,28 @@
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct Style {}
+
 impl Style {
     pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"mc:AlternateContent" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "mc:AlternateContent"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"mc:AlternateContent" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "mc:AlternateContent")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/page_setup.rs
+++ b/src/structs/page_setup.rs
@@ -1,13 +1,12 @@
-use structs::EnumValue;
-use structs::OrientationValues;
-use structs::UInt32Value;
-
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::raw::RawRelationships;
+use structs::EnumValue;
+use structs::OrientationValues;
+use structs::UInt32Value;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -21,6 +20,7 @@ pub struct PageSetup {
     vertical_dpi: UInt32Value,
     object_data: Option<Vec<u8>>,
 }
+
 impl PageSetup {
     pub fn get_paper_size(&self) -> &u32 {
         self.paper_size.get_value()
@@ -132,64 +132,20 @@ impl PageSetup {
         e: &BytesStart,
         relationships: Option<&RawRelationships>,
     ) {
-        match get_attribute(e, b"paperSize") {
-            Some(v) => {
-                self.paper_size.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, paper_size, "paperSize");
+        set_string_from_xml!(self, e, orientation, "orientation");
+        set_string_from_xml!(self, e, scale, "scale");
+        set_string_from_xml!(self, e, fit_to_height, "fitToHeight");
+        set_string_from_xml!(self, e, fit_to_width, "fitToWidth");
+        set_string_from_xml!(self, e, horizontal_dpi, "horizontalDpi");
+        set_string_from_xml!(self, e, vertical_dpi, "verticalDpi");
 
-        match get_attribute(e, b"orientation") {
-            Some(v) => {
-                self.orientation.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"scale") {
-            Some(v) => {
-                self.scale.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"fitToHeight") {
-            Some(v) => {
-                self.fit_to_height.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"fitToWidth") {
-            Some(v) => {
-                self.fit_to_width.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"horizontalDpi") {
-            Some(v) => {
-                self.horizontal_dpi.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"verticalDpi") {
-            Some(v) => {
-                self.vertical_dpi.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"r:id") {
-            Some(r_id) => {
-                let attached_file = relationships
-                    .unwrap()
-                    .get_relationship_by_rid(&r_id)
-                    .get_raw_file();
-                self.set_object_data(attached_file.get_file_data().clone());
-            }
-            None => {}
+        if let Some(r_id) = get_attribute(e, b"r:id") {
+            let attached_file = relationships
+                .unwrap()
+                .get_relationship_by_rid(&r_id)
+                .get_raw_file();
+            self.set_object_data(attached_file.get_file_data().clone());
         }
     }
 

--- a/src/structs/pane.rs
+++ b/src/structs/pane.rs
@@ -18,6 +18,7 @@ pub struct Pane {
     active_pane: EnumValue<PaneValues>,
     state: EnumValue<PaneStateValues>,
 }
+
 impl Pane {
     pub fn get_horizontal_split(&self) -> &f64 {
         self.horizontal_split.get_value()
@@ -73,39 +74,13 @@ impl Pane {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"xSplit") {
-            Some(v) => {
-                self.horizontal_split.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, horizontal_split, "xSplit");
+        set_string_from_xml!(self, e, vertical_split, "ySplit");
+        set_string_from_xml!(self, e, active_pane, "activePane");
+        set_string_from_xml!(self, e, state, "state");
 
-        match get_attribute(e, b"ySplit") {
-            Some(v) => {
-                self.vertical_split.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"topLeftCell") {
-            Some(v) => {
-                self.top_left_cell.set_coordinate(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"activePane") {
-            Some(v) => {
-                self.active_pane.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"state") {
-            Some(v) => {
-                self.state.set_value_string(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"topLeftCell") {
+            self.top_left_cell.set_coordinate(v);
         }
     }
 

--- a/src/structs/phonetic_run.rs
+++ b/src/structs/phonetic_run.rs
@@ -2,29 +2,27 @@
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 
 #[derive(Default, Debug)]
 pub(crate) struct PhoneticRun {}
+
 impl PhoneticRun {
     pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"rPh" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "rPh"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"rPh" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "rPh")
+        );
     }
 
     pub(crate) fn _write_to(&self, _writer: &mut Writer<Cursor<Vec<u8>>>) {}

--- a/src/structs/print_options.rs
+++ b/src/structs/print_options.rs
@@ -11,6 +11,7 @@ pub struct PrintOptions {
     horizontal_centered: BooleanValue,
     vertical_centered: BooleanValue,
 }
+
 impl PrintOptions {
     pub fn get_horizontal_centered(&self) -> &bool {
         self.horizontal_centered.get_value()
@@ -45,19 +46,8 @@ impl PrintOptions {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"horizontalCentered") {
-            Some(v) => {
-                self.horizontal_centered.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"verticalCentered") {
-            Some(v) => {
-                self.vertical_centered.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, horizontal_centered, "horizontalCentered");
+        set_string_from_xml!(self, e, vertical_centered, "verticalCentered");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/range.rs
+++ b/src/structs/range.rs
@@ -9,6 +9,7 @@ pub struct Range {
     coordinate_end_col: Option<ColumnReference>,
     coordinate_end_row: Option<RowReference>,
 }
+
 impl Range {
     pub fn set_range<S: Into<String>>(&mut self, value: S) -> &mut Self {
         let org_value = value.into();
@@ -26,23 +27,17 @@ impl Range {
                 is_lock_col, //
                 is_lock_row,
             ) = index_from_coordinate(coordinate_str);
-            match row {
-                Some(v) => {
-                    let mut coordinate_start_col = ColumnReference::default();
-                    coordinate_start_col.set_num(v);
-                    coordinate_start_col.set_is_lock(is_lock_col.unwrap());
-                    self.coordinate_start_col = Some(coordinate_start_col);
-                }
-                None => {}
+            if let Some(v) = row {
+                let mut coordinate_start_col = ColumnReference::default();
+                coordinate_start_col.set_num(v);
+                coordinate_start_col.set_is_lock(is_lock_col.unwrap());
+                self.coordinate_start_col = Some(coordinate_start_col);
             };
-            match col {
-                Some(v) => {
-                    let mut coordinate_start_row = RowReference::default();
-                    coordinate_start_row.set_num(v);
-                    coordinate_start_row.set_is_lock(is_lock_row.unwrap());
-                    self.coordinate_start_row = Some(coordinate_start_row);
-                }
-                None => {}
+            if let Some(v) = col {
+                let mut coordinate_start_row = RowReference::default();
+                coordinate_start_row.set_num(v);
+                coordinate_start_row.set_is_lock(is_lock_row.unwrap());
+                self.coordinate_start_row = Some(coordinate_start_row);
             }
         }
 
@@ -54,23 +49,17 @@ impl Range {
                 is_lock_col, //
                 is_lock_row,
             ) = index_from_coordinate(coordinate_str);
-            match row {
-                Some(v) => {
-                    let mut coordinate_end_col = ColumnReference::default();
-                    coordinate_end_col.set_num(v);
-                    coordinate_end_col.set_is_lock(is_lock_col.unwrap());
-                    self.coordinate_end_col = Some(coordinate_end_col);
-                }
-                None => {}
+            if let Some(v) = row {
+                let mut coordinate_end_col = ColumnReference::default();
+                coordinate_end_col.set_num(v);
+                coordinate_end_col.set_is_lock(is_lock_col.unwrap());
+                self.coordinate_end_col = Some(coordinate_end_col);
             };
-            match col {
-                Some(v) => {
-                    let mut coordinate_end_row = RowReference::default();
-                    coordinate_end_row.set_num(v);
-                    coordinate_end_row.set_is_lock(is_lock_row.unwrap());
-                    self.coordinate_end_row = Some(coordinate_end_row);
-                }
-                None => {}
+            if let Some(v) = col {
+                let mut coordinate_end_row = RowReference::default();
+                coordinate_end_row.set_num(v);
+                coordinate_end_row.set_is_lock(is_lock_row.unwrap());
+                self.coordinate_end_row = Some(coordinate_end_row);
             }
         }
         self

--- a/src/structs/raw/raw_relationship.rs
+++ b/src/structs/raw/raw_relationship.rs
@@ -18,6 +18,7 @@ pub(crate) struct RawRelationship {
     raw_file: RawFile,
     target_mode: StringValue,
 }
+
 impl RawRelationship {
     pub(crate) fn get_id(&self) -> &str {
         self.id.get_value()
@@ -78,11 +79,8 @@ impl RawRelationship {
         self.set_id(get_attribute(e, b"Id").unwrap());
         self.set_type(get_attribute(e, b"Type").unwrap());
         self.set_target(get_attribute(e, b"Target").unwrap());
-        match get_attribute(e, b"TargetMode") {
-            Some(v) => {
-                self.set_target_mode(v);
-            }
-            None => {}
+        if let Some(v) = get_attribute(e, b"TargetMode") {
+            self.set_target_mode(v);
         }
         if self.get_target_mode() != "External" {
             let target = self.get_target().to_string();

--- a/src/structs/row_breaks.rs
+++ b/src/structs/row_breaks.rs
@@ -2,6 +2,7 @@
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::Break;
 use writer::driver::*;
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub struct RowBreaks {
     break_list: Vec<Break>,
 }
+
 impl RowBreaks {
     pub fn get_break_list(&self) -> &Vec<Break> {
         &self.break_list
@@ -36,27 +38,21 @@ impl RowBreaks {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"brk" => {
-                        let mut obj = Break::default();
-                        obj.set_attributes(reader, e);
-                        self.add_break_list(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"rowBreaks" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "rowBreaks"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(reader,
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"brk" {
+                    let mut obj = Break::default();
+                    obj.set_attributes(reader, e);
+                    self.add_break_list(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"rowBreaks" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "rowBreaks")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/row_reference.rs
+++ b/src/structs/row_reference.rs
@@ -26,11 +26,11 @@ impl RowReference {
     }
 
     pub(crate) fn offset_num(&mut self, value: i32) -> &mut Self {
-        if &value > &0 {
+        if value > 0 {
             self.plus_num(value as u32);
         }
-        if &value < &0 {
-            self.minus_num((value * -1) as u32);
+        if value < 0 {
+            self.minus_num(-value as u32);
         }
         self
     }
@@ -60,11 +60,7 @@ impl RowReference {
     }
 
     pub fn get_coordinate(&self) -> String {
-        format!(
-            "{}{}",
-            if &self.is_lock == &true { "$" } else { "" },
-            &self.num,
-        )
+        format!("{}{}", if self.is_lock { "$" } else { "" }, self.num)
     }
 
     pub(crate) fn adjustment_insert_coordinate(
@@ -85,9 +81,7 @@ impl RowReference {
 
     pub(crate) fn is_remove(&self, root_row_num: &u32, offset_row_num: &u32) -> bool {
         if root_row_num > &0 {
-            let row_result =
-                &self.num >= root_row_num && &self.num < &(root_row_num + offset_row_num);
-            return row_result;
+            return &self.num >= root_row_num && self.num < (root_row_num + offset_row_num);
         }
         false
     }

--- a/src/structs/run_properties.rs
+++ b/src/structs/run_properties.rs
@@ -1,23 +1,23 @@
 // rPr
-use super::FontName;
-use super::FontSize;
-use super::FontFamilyNumbering;
 use super::Bold;
-use super::Italic;
-use super::Underline;
-use super::UnderlineValues;
-use super::Strike;
 use super::Color;
+use super::Font;
 use super::FontCharSet;
+use super::FontFamilyNumbering;
+use super::FontName;
 use super::FontScheme;
 use super::FontSchemeValues;
-use super::Font;
-use std::str::FromStr;
-use writer::driver::*;
+use super::FontSize;
+use super::Italic;
+use super::Strike;
+use super::Underline;
+use super::UnderlineValues;
+use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
-use quick_xml::events::{Event, BytesStart};
 use quick_xml::Writer;
 use std::io::Cursor;
+use std::str::FromStr;
+use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct RunProperties {
@@ -32,6 +32,7 @@ pub struct RunProperties {
     font_char_set: FontCharSet,
     font_scheme: FontScheme,
 }
+
 impl RunProperties {
     // Charset
     pub const CHARSET_ANSI: i32 = 0;
@@ -62,216 +63,218 @@ impl RunProperties {
     pub const UNDERLINE_SINGLE: &'static str = "single";
     pub const UNDERLINE_SINGLEACCOUNTING: &'static str = "singleAccounting";
 
-    pub fn get_font_name(&self)-> &FontName {
+    pub fn get_font_name(&self) -> &FontName {
         &self.font_name
     }
 
-    pub fn get_font_name_mut(&mut self)-> &mut FontName {
+    pub fn get_font_name_mut(&mut self) -> &mut FontName {
         &mut self.font_name
     }
 
-    pub fn set_font_name(&mut self, value:FontName)-> &mut Self {
+    pub fn set_font_name(&mut self, value: FontName) -> &mut Self {
         self.font_name = value;
         self
     }
 
-    pub fn get_name(&self)-> &str {
+    pub fn get_name(&self) -> &str {
         self.font_name.get_val()
     }
 
-    pub fn set_name<S: Into<String>>(&mut self, value:S)-> &mut Self {
+    pub fn set_name<S: Into<String>>(&mut self, value: S) -> &mut Self {
         self.font_name.set_val(value);
         self
     }
 
-    pub fn get_font_size(&self)-> &FontSize {
+    pub fn get_font_size(&self) -> &FontSize {
         &self.font_size
     }
 
-    pub fn get_font_size_mut(&mut self)-> &mut FontSize {
+    pub fn get_font_size_mut(&mut self) -> &mut FontSize {
         &mut self.font_size
     }
 
-    pub fn set_font_size(&mut self, value:FontSize)-> &mut Self {
+    pub fn set_font_size(&mut self, value: FontSize) -> &mut Self {
         self.font_size = value;
         self
     }
 
-    pub fn get_size(&self)-> &f64 {
+    pub fn get_size(&self) -> &f64 {
         self.font_size.get_val()
     }
 
-    pub fn set_size(&mut self, value:f64)-> &mut Self {
+    pub fn set_size(&mut self, value: f64) -> &mut Self {
         self.font_size.set_val(value);
         self
     }
 
-    pub fn get_font_family_numbering(&self)-> &FontFamilyNumbering {
+    pub fn get_font_family_numbering(&self) -> &FontFamilyNumbering {
         &self.font_family_numbering
     }
 
-    pub fn get_font_family_numbering_mut(&mut self)-> &mut FontFamilyNumbering {
+    pub fn get_font_family_numbering_mut(&mut self) -> &mut FontFamilyNumbering {
         &mut self.font_family_numbering
     }
 
-    pub fn set_font_family_numbering(&mut self, value:FontFamilyNumbering)-> &mut Self {
+    pub fn set_font_family_numbering(&mut self, value: FontFamilyNumbering) -> &mut Self {
         self.font_family_numbering = value;
         self
     }
-    
-    pub fn get_family(&self)-> &i32 {
+
+    pub fn get_family(&self) -> &i32 {
         self.font_family_numbering.get_val()
     }
 
-    pub fn set_family(&mut self, value:i32)-> &mut Self {
+    pub fn set_family(&mut self, value: i32) -> &mut Self {
         self.font_family_numbering.set_val(value);
         self
     }
 
-    pub fn get_font_bold(&self)-> &Bold {
+    pub fn get_font_bold(&self) -> &Bold {
         &self.font_bold
     }
 
-    pub fn get_font_bold_mut(&mut self)-> &mut Bold {
+    pub fn get_font_bold_mut(&mut self) -> &mut Bold {
         &mut self.font_bold
     }
 
-    pub fn set_font_bold(&mut self, value:Bold)-> &mut Self {
+    pub fn set_font_bold(&mut self, value: Bold) -> &mut Self {
         self.font_bold = value;
         self
     }
 
-    pub fn get_bold(&self)-> &bool {
+    pub fn get_bold(&self) -> &bool {
         self.font_bold.get_val()
     }
 
-    pub fn set_bold(&mut self, value:bool)-> &mut Self {
+    pub fn set_bold(&mut self, value: bool) -> &mut Self {
         self.font_bold.set_val(value);
         self
     }
 
-    pub fn get_font_italic(&self)-> &Italic {
+    pub fn get_font_italic(&self) -> &Italic {
         &self.font_italic
     }
 
-    pub fn get_font_italic_mut(&mut self)-> &mut Italic {
+    pub fn get_font_italic_mut(&mut self) -> &mut Italic {
         &mut self.font_italic
     }
 
-    pub fn set_font_italic(&mut self, value:Italic)-> &mut Self {
+    pub fn set_font_italic(&mut self, value: Italic) -> &mut Self {
         self.font_italic = value;
         self
     }
 
-    pub fn get_italic(&self)-> &bool {
+    pub fn get_italic(&self) -> &bool {
         self.font_italic.get_val()
     }
 
-    pub fn set_italic(&mut self, value:bool)-> &mut Self {
+    pub fn set_italic(&mut self, value: bool) -> &mut Self {
         self.font_italic.set_val(value);
         self
     }
 
-    pub fn get_font_underline(&self)-> &Underline {
+    pub fn get_font_underline(&self) -> &Underline {
         &self.font_underline
     }
 
-    pub fn get_font_underline_mut(&mut self)-> &mut Underline {
+    pub fn get_font_underline_mut(&mut self) -> &mut Underline {
         &mut self.font_underline
     }
 
-    pub fn set_font_underline(&mut self, value:Underline)-> &mut Self {
+    pub fn set_font_underline(&mut self, value: Underline) -> &mut Self {
         self.font_underline = value;
         self
     }
 
-    pub fn get_underline(&self)-> &str {
+    pub fn get_underline(&self) -> &str {
         self.font_underline.val.get_value_string()
     }
 
-    pub fn set_underline<S: Into<String>>(&mut self, value:S)-> &mut Self {
+    pub fn set_underline<S: Into<String>>(&mut self, value: S) -> &mut Self {
         let obj = value.into();
-        self.font_underline.set_val(UnderlineValues::from_str(&obj).unwrap());
+        self.font_underline
+            .set_val(UnderlineValues::from_str(&obj).unwrap());
         self
     }
 
-    pub fn get_font_strike(&self)-> &Strike {
+    pub fn get_font_strike(&self) -> &Strike {
         &self.font_strike
     }
 
-    pub fn get_font_strike_mut(&mut self)-> &mut Strike {
+    pub fn get_font_strike_mut(&mut self) -> &mut Strike {
         &mut self.font_strike
     }
 
-    pub fn set_font_strike(&mut self, value:Strike)-> &mut Self {
+    pub fn set_font_strike(&mut self, value: Strike) -> &mut Self {
         self.font_strike = value;
         self
     }
 
-    pub fn get_strikethrough(&self)-> &bool {
+    pub fn get_strikethrough(&self) -> &bool {
         self.font_strike.get_val()
     }
 
-    pub fn set_strikethrough(&mut self, value:bool)-> &mut Self {
+    pub fn set_strikethrough(&mut self, value: bool) -> &mut Self {
         self.font_strike.set_val(value);
         self
     }
 
-    pub fn get_color(&self)-> &Color {
+    pub fn get_color(&self) -> &Color {
         &self.color
     }
 
-    pub fn get_color_mut(&mut self)-> &mut Color {
+    pub fn get_color_mut(&mut self) -> &mut Color {
         &mut self.color
     }
 
-    pub fn set_color(&mut self, value:Color)-> &mut Self {
+    pub fn set_color(&mut self, value: Color) -> &mut Self {
         self.color = value;
         self
     }
 
-    pub fn get_font_char_set(&self)-> &FontCharSet {
+    pub fn get_font_char_set(&self) -> &FontCharSet {
         &self.font_char_set
     }
 
-    pub fn get_font_char_set_mut(&mut self)-> &mut FontCharSet {
+    pub fn get_font_char_set_mut(&mut self) -> &mut FontCharSet {
         &mut self.font_char_set
     }
 
-    pub fn set_font_char_set(&mut self, value:FontCharSet)-> &mut Self {
+    pub fn set_font_char_set(&mut self, value: FontCharSet) -> &mut Self {
         self.font_char_set = value;
         self
     }
 
-    pub fn get_charset(&self)-> &i32 {
+    pub fn get_charset(&self) -> &i32 {
         self.font_char_set.get_val()
     }
 
-    pub fn set_charset(&mut self, value:i32)-> &mut Self {
+    pub fn set_charset(&mut self, value: i32) -> &mut Self {
         self.font_char_set.set_val(value);
         self
     }
 
-    pub fn get_font_scheme(&self)-> &FontScheme {
+    pub fn get_font_scheme(&self) -> &FontScheme {
         &self.font_scheme
     }
 
-    pub fn get_font_scheme_mut(&mut self)-> &mut FontScheme {
+    pub fn get_font_scheme_mut(&mut self) -> &mut FontScheme {
         &mut self.font_scheme
     }
 
-    pub fn set_font_scheme(&mut self, value:FontScheme)-> &mut Self {
+    pub fn set_font_scheme(&mut self, value: FontScheme) -> &mut Self {
         self.font_scheme = value;
         self
     }
 
-    pub fn get_scheme(&self)-> &str {
+    pub fn get_scheme(&self) -> &str {
         self.font_scheme.val.get_value_string()
     }
 
-    pub fn set_scheme<S: Into<String>>(&mut self, value:S)-> &mut Self {
+    pub fn set_scheme<S: Into<String>>(&mut self, value: S) -> &mut Self {
         let obj = value.into();
-        self.font_scheme.set_val(FontSchemeValues::from_str(&obj).unwrap());
+        self.font_scheme
+            .set_val(FontSchemeValues::from_str(&obj).unwrap());
         self
     }
 
@@ -301,7 +304,7 @@ impl RunProperties {
         obj
     }
 
-    pub(crate) fn from_font(&mut self, value:Font) -> &mut Self {
+    pub(crate) fn from_font(&mut self, value: Font) -> &mut Self {
         self.set_font_name(value.get_font_name().clone());
         self.set_font_size(value.get_font_size().clone());
         self.set_font_family_numbering(value.get_font_family_numbering().clone());
@@ -316,50 +319,69 @@ impl RunProperties {
         self
     }
 
-    pub(crate) fn get_hash_code(&self)-> String
-    {
-        format!("{:x}", md5::Md5::digest(format!("{}{}{}{}{}{}{}{}{}{}",
-            &self.font_name.val.get_hash_string(),
-            &self.font_size.val.get_hash_string(),
-            &self.font_family_numbering.val.get_hash_string(),
-            &self.font_bold.val.get_hash_string(),
-            &self.font_italic.val.get_hash_string(),
-            &self.font_underline.val.get_hash_string(),
-            &self.font_strike.val.get_hash_string(),
-            &self.color.get_hash_code(),
-            &self.font_char_set.val.get_hash_string(),
-            &self.font_scheme.val.get_hash_string(),
-        )))
+    pub(crate) fn get_hash_code(&self) -> String {
+        format!(
+            "{:x}",
+            md5::Md5::digest(format!(
+                "{}{}{}{}{}{}{}{}{}{}",
+                &self.font_name.val.get_hash_string(),
+                &self.font_size.val.get_hash_string(),
+                &self.font_family_numbering.val.get_hash_string(),
+                &self.font_bold.val.get_hash_string(),
+                &self.font_italic.val.get_hash_string(),
+                &self.font_underline.val.get_hash_string(),
+                &self.font_strike.val.get_hash_string(),
+                &self.color.get_hash_code(),
+                &self.font_char_set.val.get_hash_string(),
+                &self.font_scheme.val.get_hash_string(),
+            ))
+        )
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
-        reader:&mut Reader<R>,
-        _e:&BytesStart
+        reader: &mut Reader<R>,
+        _e: &BytesStart,
     ) {
         let mut buf = Vec::new();
         loop {
             match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => {
-                    match e.name().into_inner() {
-                        b"name" => {self.font_name.set_attributes(reader,e);},
-                        b"sz" => {self.font_size.set_attributes(reader,e);},
-                        b"family" => {self.font_family_numbering.set_attributes(reader,e);},
-                        b"b" => {self.font_bold.set_attributes(reader,e);},
-                        b"i" => {self.font_italic.set_attributes(reader,e);},
-                        b"u" => {self.font_underline.set_attributes(reader,e);},
-                        b"strike" => {self.font_strike.set_attributes(reader,e);},
-                        b"color" => {self.color.set_attributes(reader,e);},
-                        b"charset" => {self.font_char_set.set_attributes(reader,e);},
-                        b"scheme" => {self.font_scheme.set_attributes(reader,e);},
-                        _ => (),
+                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+                    b"name" => {
+                        self.font_name.set_attributes(reader, e);
                     }
+                    b"sz" => {
+                        self.font_size.set_attributes(reader, e);
+                    }
+                    b"family" => {
+                        self.font_family_numbering.set_attributes(reader, e);
+                    }
+                    b"b" => {
+                        self.font_bold.set_attributes(reader, e);
+                    }
+                    b"i" => {
+                        self.font_italic.set_attributes(reader, e);
+                    }
+                    b"u" => {
+                        self.font_underline.set_attributes(reader, e);
+                    }
+                    b"strike" => {
+                        self.font_strike.set_attributes(reader, e);
+                    }
+                    b"color" => {
+                        self.color.set_attributes(reader, e);
+                    }
+                    b"charset" => {
+                        self.font_char_set.set_attributes(reader, e);
+                    }
+                    b"scheme" => {
+                        self.font_scheme.set_attributes(reader, e);
+                    }
+                    _ => (),
                 },
-                Ok(Event::End(ref e)) => {
-                    match e.name().into_inner() {
-                        b"rPr" => return,
-                        _ => (),
-                    }
+                Ok(Event::End(ref e)) => match e.name().into_inner() {
+                    b"rPr" => return,
+                    _ => (),
                 },
                 Ok(Event::Eof) => panic!("Error not find {} end element", "rPr"),
                 Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
@@ -393,7 +415,7 @@ impl RunProperties {
 
         // charset
         self.font_char_set.write_to(writer);
-        
+
         // scheme
         self.font_scheme.write_to(writer);
 

--- a/src/structs/s_byte_value.rs
+++ b/src/structs/s_byte_value.rs
@@ -24,9 +24,6 @@ impl SByteValue {
     }
 
     pub(crate) fn _has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 }

--- a/src/structs/security.rs
+++ b/src/structs/security.rs
@@ -6,28 +6,32 @@ pub struct Security {
     revisions_password: String,
     workbook_password: String,
 }
+
 impl Security {
     pub(crate) fn is_security_enabled(&self) -> bool {
-        if self.lock_revision {
-            true
-        } else if self.lock_structure {
+        if self.lock_revision || self.lock_structure {
             true
         } else {
             self.lock_windows
         }
     }
+
     pub fn get_lock_revision(&self) -> &bool {
         &self.lock_revision
     }
+
     pub fn get_lock_structure(&self) -> &bool {
         &self.lock_structure
     }
+
     pub fn get_lock_windows(&self) -> &bool {
         &self.lock_windows
     }
+
     pub fn get_revisions_password(&self) -> &str {
         &self.revisions_password
     }
+
     pub fn get_workbook_password(&self) -> &str {
         &self.workbook_password
     }

--- a/src/structs/sheet_format_properties.rs
+++ b/src/structs/sheet_format_properties.rs
@@ -22,6 +22,7 @@ pub struct SheetFormatProperties {
     thick_bottom: BooleanValue,
     thick_top: BooleanValue,
 }
+
 impl SheetFormatProperties {
     pub fn get_base_column_width(&self) -> &u32 {
         self.base_column_width.get_value()
@@ -115,68 +116,15 @@ impl SheetFormatProperties {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"baseColWidth") {
-            Some(v) => {
-                self.base_column_width.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"customHeight") {
-            Some(v) => {
-                self.custom_height.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"defaultColWidth") {
-            Some(v) => {
-                self.default_column_width.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"defaultRowHeight") {
-            Some(v) => {
-                self.default_row_height.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"x14ac:dyDescent") {
-            Some(v) => {
-                self.dy_descent.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"outlineLevelCol") {
-            Some(v) => {
-                self.outline_level_column.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"outlineLevelRow") {
-            Some(v) => {
-                self.outline_level_row.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"thickBottom") {
-            Some(v) => {
-                self.thick_bottom.set_value_string(v);
-            }
-            None => {}
-        }
-
-        match get_attribute(e, b"thickTop") {
-            Some(v) => {
-                self.thick_top.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, base_column_width, "baseColWidth");
+        set_string_from_xml!(self, e, custom_height, "customHeight");
+        set_string_from_xml!(self, e, default_column_width, "defaultColWidth");
+        set_string_from_xml!(self, e, default_row_height, "defaultRowHeight");
+        set_string_from_xml!(self, e, dy_descent, "x14ac:dyDescent");
+        set_string_from_xml!(self, e, outline_level_column, "outlineLevelCol");
+        set_string_from_xml!(self, e, outline_level_row, "outlineLevelRow");
+        set_string_from_xml!(self, e, thick_bottom, "thickBottom");
+        set_string_from_xml!(self, e, thick_top, "thickTop");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/sheet_views.rs
+++ b/src/structs/sheet_views.rs
@@ -3,6 +3,7 @@ use super::SheetView;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use writer::driver::*;
 
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub struct SheetViews {
     sheet_view_list: Vec<SheetView>,
 }
+
 impl SheetViews {
     pub fn get_sheet_view_list(&self) -> &Vec<SheetView> {
         &self.sheet_view_list
@@ -29,35 +31,29 @@ impl SheetViews {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"sheetView" => {
-                        let mut obj = SheetView::default();
-                        obj.set_attributes(reader, e, true);
-                        self.add_sheet_view_list_mut(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"sheetView" => {
-                        let mut obj = SheetView::default();
-                        obj.set_attributes(reader, e, false);
-                        self.add_sheet_view_list_mut(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"sheetViews" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "sheetViews"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                if e.name().into_inner() == b"sheetView" {
+                    let mut obj = SheetView::default();
+                    obj.set_attributes(reader, e, true);
+                    self.add_sheet_view_list_mut(obj);
+                }
+            },
+            Event::Start(ref e) => {
+                if e.name().into_inner() == b"sheetView" {
+                    let mut obj = SheetView::default();
+                    obj.set_attributes(reader, e, false);
+                    self.add_sheet_view_list_mut(obj);
+                }
+            },
+            Event::End(ref e) => {
+                if e.name().into_inner() == b"sheetViews" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "sheetViews")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/spreadsheet.rs
+++ b/src/structs/spreadsheet.rs
@@ -30,6 +30,7 @@ pub struct Spreadsheet {
     backup_context_types: Vec<(String, String)>,
     pivot_caches: Vec<(String, String, String)>,
 }
+
 impl Spreadsheet {
     // ************************
     // update Coordinate
@@ -380,12 +381,10 @@ impl Spreadsheet {
     }
 
     pub(crate) fn find_sheet_index_by_name(&self, sheet_name: &str) -> Result<usize, &'static str> {
-        let mut result = 0;
-        for sheet in &self.work_sheet_collection {
+        for (result, sheet) in self.work_sheet_collection.iter().enumerate() {
             if sheet.get_name() == sheet_name {
                 return Ok(result);
             }
-            result += 1;
         }
         Err("not found.")
     }
@@ -425,7 +424,7 @@ impl Spreadsheet {
         let shared_string_table = self.get_shared_string_table();
         match self.work_sheet_collection.get(*index) {
             Some(v) => Ok(v.get_cell_collection_stream(
-                &*shared_string_table.read().unwrap(),
+                &shared_string_table.read().unwrap(),
                 self.get_stylesheet(),
             )),
             None => Err("Not found."),

--- a/src/structs/strike.rs
+++ b/src/structs/strike.rs
@@ -11,6 +11,7 @@ use writer::driver::*;
 pub struct Strike {
     pub(crate) val: BooleanValue,
 }
+
 impl Strike {
     pub fn get_val(&self) -> &bool {
         self.val.get_value()
@@ -27,12 +28,7 @@ impl Strike {
         e: &BytesStart,
     ) {
         self.val.set_value(true);
-        match get_attribute(e, b"val") {
-            Some(v) => {
-                self.val.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, val, "val");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/string_value.rs
+++ b/src/structs/string_value.rs
@@ -29,10 +29,7 @@ impl StringValue {
     }
 
     pub(crate) fn has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 
     pub(crate) fn get_hash_string(&self) -> &str {

--- a/src/structs/true_false_blank_value.rs
+++ b/src/structs/true_false_blank_value.rs
@@ -44,10 +44,7 @@ impl TrueFalseBlankValue {
     }
 
     pub(crate) fn has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 
     pub(crate) fn _get_hash_string(&self) -> &str {

--- a/src/structs/true_false_value.rs
+++ b/src/structs/true_false_value.rs
@@ -29,10 +29,7 @@ impl TrueFalseValue {
     }
 
     pub(crate) fn has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 
     pub(crate) fn _get_hash_string(&self) -> &str {

--- a/src/structs/u_int16_value.rs
+++ b/src/structs/u_int16_value.rs
@@ -24,9 +24,6 @@ impl UInt16Value {
     }
 
     pub(crate) fn _has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 }

--- a/src/structs/u_int32_value.rs
+++ b/src/structs/u_int32_value.rs
@@ -29,10 +29,7 @@ impl UInt32Value {
     }
 
     pub(crate) fn has_value(&self) -> bool {
-        match &self.value {
-            Some(_) => true,
-            None => false,
-        }
+        self.value.is_some()
     }
 
     pub(crate) fn get_hash_string(&self) -> String {

--- a/src/structs/underline.rs
+++ b/src/structs/underline.rs
@@ -13,6 +13,7 @@ use writer::driver::*;
 pub struct Underline {
     pub(crate) val: EnumValue<UnderlineValues>,
 }
+
 impl Underline {
     pub fn get_val(&self) -> &UnderlineValues {
         if self.val.has_value() {
@@ -32,19 +33,14 @@ impl Underline {
         e: &BytesStart,
     ) {
         self.set_val(UnderlineValues::default());
-        match get_attribute(e, b"val") {
-            Some(v) => {
-                self.val.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, val, "val")
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // u
         if self.val.has_value() {
             let mut attributes: Vec<(&str, &str)> = Vec::new();
-            if &self.val.get_value_string() != &UnderlineValues::Single.get_value_string() {
+            if self.val.get_value_string() != UnderlineValues::Single.get_value_string() {
                 attributes.push(("val", self.val.get_value_string()));
             }
             write_start_tag(writer, "u", attributes, true);

--- a/src/structs/vertical_text_alignment.rs
+++ b/src/structs/vertical_text_alignment.rs
@@ -12,6 +12,7 @@ use writer::driver::*;
 pub struct VerticalTextAlignment {
     pub(crate) val: EnumValue<VerticalAlignmentRunValues>,
 }
+
 impl VerticalTextAlignment {
     pub fn get_val(&self) -> &VerticalAlignmentRunValues {
         self.val.get_value()
@@ -27,17 +28,12 @@ impl VerticalTextAlignment {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"val") {
-            Some(v) => {
-                self.val.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, val, "val");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // vertAlign
-        if &self.val.has_value() == &true {
+        if self.val.has_value() {
             write_start_tag(
                 writer,
                 "vertAlign",

--- a/src/structs/vml/fill.rs
+++ b/src/structs/vml/fill.rs
@@ -14,6 +14,7 @@ pub struct Fill {
     on: TrueFalseValue,
     focus_size: StringValue,
 }
+
 impl Fill {
     pub fn get_color(&self) -> &str {
         self.color.get_value()
@@ -56,30 +57,10 @@ impl Fill {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"color") {
-            Some(v) => {
-                self.color.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"color2") {
-            Some(v) => {
-                self.color_2.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"on") {
-            Some(v) => {
-                self.on.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"focussize") {
-            Some(v) => {
-                self.focus_size.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, color, "color");
+        set_string_from_xml!(self, e, color_2, "color2");
+        set_string_from_xml!(self, e, on, "on");
+        set_string_from_xml!(self, e, focus_size, "focussize");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/vml/image_data.rs
+++ b/src/structs/vml/image_data.rs
@@ -12,6 +12,7 @@ pub struct ImageData {
     image_name: StringValue,
     title: StringValue,
 }
+
 impl ImageData {
     pub fn get_image_name(&self) -> &str {
         self.image_name.get_value()
@@ -37,23 +38,15 @@ impl ImageData {
         e: &BytesStart,
         drawing_relationships: Option<&RawRelationships>,
     ) {
-        match get_attribute(e, b"o:relid") {
-            Some(relid) => {
-                let relationship = drawing_relationships
-                    .unwrap()
-                    .get_relationship_by_rid(&relid);
-                self.image_name
-                    .set_value_string(relationship.get_raw_file().get_file_name());
-            }
-            None => {}
+        if let Some(relid) = get_attribute(e, b"o:relid") {
+            let relationship = drawing_relationships
+                .unwrap()
+                .get_relationship_by_rid(&relid);
+            self.image_name
+                .set_value_string(relationship.get_raw_file().get_file_name());
         }
 
-        match get_attribute(e, b"o:title") {
-            Some(v) => {
-                self.title.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, title, "o:title");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, r_id: &usize) {

--- a/src/structs/vml/path.rs
+++ b/src/structs/vml/path.rs
@@ -26,12 +26,7 @@ impl Path {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"o:connecttype") {
-            Some(v) => {
-                self.connection_point_type.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, connection_point_type, "o:connecttype");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/vml/shadow.rs
+++ b/src/structs/vml/shadow.rs
@@ -46,24 +46,9 @@ impl Shadow {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"on") {
-            Some(v) => {
-                self.on.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"color") {
-            Some(v) => {
-                self.color.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"obscured") {
-            Some(v) => {
-                self.obscured.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, on, "on");
+        set_string_from_xml!(self, e, color, "color");
+        set_string_from_xml!(self, e, obscured, "obscured");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/vml/shape.rs
+++ b/src/structs/vml/shape.rs
@@ -38,6 +38,7 @@ pub struct Shape {
     optional_number: Int32Value,
     coordinate_size: StringValue,
 }
+
 impl Shape {
     pub fn get_style(&self) -> &str {
         self.style.get_value()
@@ -226,121 +227,71 @@ impl Shape {
         e: &BytesStart,
         drawing_relationships: Option<&RawRelationships>,
     ) {
-        match get_attribute(e, b"type") {
-            Some(v) => {
-                self.r_type.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"style") {
-            Some(v) => {
-                self.style.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"filled") {
-            Some(v) => {
-                self.filled.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"fillcolor") {
-            Some(v) => {
-                self.fill_color.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"stroked") {
-            Some(v) => {
-                self.stroked.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"strokecolor") {
-            Some(v) => {
-                self.stroke_color.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"strokeweight") {
-            Some(v) => {
-                self.stroke_weight.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"o:insetmode") {
-            Some(v) => {
-                self.inset_mode.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"o:spt") {
-            Some(v) => {
-                self.optional_number.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"coordsize") {
-            Some(v) => {
-                self.coordinate_size.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, r_type, "type");
+        set_string_from_xml!(self, e, style, "style");
+        set_string_from_xml!(self, e, filled, "filled");
+        set_string_from_xml!(self, e, fill_color, "fillcolor");
+        set_string_from_xml!(self, e, stroked, "stoked");
+        set_string_from_xml!(self, e, stroke_color, "stokecolor");
+        set_string_from_xml!(self, e, stroke_weight, "stokeweight");
+        set_string_from_xml!(self, e, inset_mode, "o:insetmode");
+        set_string_from_xml!(self, e, optional_number, "o:spt");
+        set_string_from_xml!(self, e, coordinate_size, "coordsize");
 
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
-                    b"v:fill" => {
-                        let mut obj = Fill::default();
-                        obj.set_attributes(reader, e);
-                        self.set_fill(obj);
-                    }
-                    b"v:shadow" => {
-                        let mut obj = Shadow::default();
-                        obj.set_attributes(reader, e);
-                        self.set_shadow(obj);
-                    }
-                    b"v:path" => {
-                        let mut obj = Path::default();
-                        obj.set_attributes(reader, e);
-                        self.set_path(obj);
-                    }
-                    b"v:stroke" => {
-                        let mut obj = Stroke::default();
-                        obj.set_attributes(reader, e);
-                        self.set_stroke(obj);
-                    }
-                    b"v:imagedata" => {
-                        let mut obj = ImageData::default();
-                        obj.set_attributes(reader, e, drawing_relationships);
-                        self.set_image_data(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::Start(ref e)) => match e.name().into_inner() {
-                    b"v:textbox" => {
-                        let mut obj = TextBox::default();
-                        obj.set_attributes(reader, e);
-                        self.set_text_box(obj);
-                    }
-                    b"x:ClientData" => {
-                        let mut obj = ClientData::default();
-                        obj.set_attributes(reader, e);
-                        self.set_client_data(obj);
-                    }
-                    _ => (),
-                },
-                Ok(Event::End(ref e)) => match e.name().into_inner() {
-                    b"v:shape" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "v:shape"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
+        xml_read_loop!(
+            reader,
+            Event::Empty(ref e) => {
+                match e.name().into_inner() {
+                b"v:fill" => {
+                    let mut obj = Fill::default();
+                    obj.set_attributes(reader, e);
+                    self.set_fill(obj);
+                }
+                b"v:shadow" => {
+                    let mut obj = Shadow::default();
+                    obj.set_attributes(reader, e);
+                    self.set_shadow(obj);
+                }
+                b"v:path" => {
+                    let mut obj = Path::default();
+                    obj.set_attributes(reader, e);
+                    self.set_path(obj);
+                }
+                b"v:stroke" => {
+                    let mut obj = Stroke::default();
+                    obj.set_attributes(reader, e);
+                    self.set_stroke(obj);
+                }
+                b"v:imagedata" => {
+                    let mut obj = ImageData::default();
+                    obj.set_attributes(reader, e, drawing_relationships);
+                    self.set_image_data(obj);
+                }
                 _ => (),
-            }
-            buf.clear();
-        }
+                }
+            },
+            Event::Start(ref e) => {
+                match e.name().into_inner() {
+                b"v:textbox" => {
+                    let mut obj = TextBox::default();
+                    obj.set_attributes(reader, e);
+                    self.set_text_box(obj);
+                }
+                b"x:ClientData" => {
+                    let mut obj = ClientData::default();
+                    obj.set_attributes(reader, e);
+                    self.set_client_data(obj);
+                }
+                _ => (),
+                }
+            },
+            Event::End(ref e) => {
+                if  e.name().into_inner() == b"v:shape" {
+                    return
+                }
+            },
+            Event::Eof => panic!("Error not find {} end element", "v:shape")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, id: &usize, r_id: &usize) {
@@ -382,51 +333,33 @@ impl Shape {
         write_start_tag(writer, "v:shape", attributes, false);
 
         // v:fill
-        match &self.fill {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.fill {
+            v.write_to(writer);
         }
 
         // v:shadow
-        match &self.shadow {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.shadow {
+            v.write_to(writer);
         }
 
         // v:path
-        match &self.path {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.path {
+            v.write_to(writer);
         }
 
         // v:textbox
-        match &self.text_box {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.text_box {
+            v.write_to(writer);
         }
 
         // v:stroke
-        match &self.stroke {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.stroke {
+            v.write_to(writer);
         }
 
         // v:imagedata
-        match &self.image_data {
-            Some(v) => {
-                v.write_to(writer, r_id);
-            }
-            None => {}
+        if let Some(v) = &self.image_data {
+            v.write_to(writer, r_id);
         }
 
         // x:ClientData

--- a/src/structs/vml/spreadsheet/auto_size_picture.rs
+++ b/src/structs/vml/spreadsheet/auto_size_picture.rs
@@ -1,6 +1,7 @@
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::TrueFalseBlankValue;
 use writer::driver::*;
@@ -9,6 +10,7 @@ use writer::driver::*;
 pub struct AutoSizePicture {
     value: TrueFalseBlankValue,
 }
+
 impl AutoSizePicture {
     pub fn get_value(&self) -> &Option<bool> {
         self.value.get_value()
@@ -28,22 +30,19 @@ impl AutoSizePicture {
         if empty_flag {
             return;
         }
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => {
-                    self.value.set_value_string(e.unescape().unwrap());
+
+        xml_read_loop!(
+            reader,
+            Event::Text(e) => {
+                self.value.set_value_string(e.unescape().unwrap());
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"x:AutoPict" {
+                    return
                 }
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"x:AutoPict" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "x:AutoPict"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Eof => panic!("Error not find {} end element", "x:AutoPict")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/vml/spreadsheet/clipboard_format.rs
+++ b/src/structs/vml/spreadsheet/clipboard_format.rs
@@ -2,6 +2,7 @@ use super::ClipboardFormatValues;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::EnumValue;
 use writer::driver::*;
@@ -10,6 +11,7 @@ use writer::driver::*;
 pub struct ClipboardFormat {
     value: EnumValue<ClipboardFormatValues>,
 }
+
 impl ClipboardFormat {
     pub fn get_value(&self) -> &ClipboardFormatValues {
         self.value.get_value()
@@ -25,22 +27,18 @@ impl ClipboardFormat {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => {
-                    self.value.set_value_string(e.unescape().unwrap());
+        xml_read_loop!(
+            reader,
+            Event::Text(e) => {
+                self.value.set_value_string(e.unescape().unwrap());
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"x:CF" {
+                    return
                 }
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"x:CF" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "x:CF"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Eof => panic!("Error not find {} end element", "x:CF")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/vml/spreadsheet/comment_row_target.rs
+++ b/src/structs/vml/spreadsheet/comment_row_target.rs
@@ -1,6 +1,7 @@
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::UInt32Value;
 use writer::driver::*;
@@ -9,6 +10,7 @@ use writer::driver::*;
 pub struct CommentRowTarget {
     value: UInt32Value,
 }
+
 impl CommentRowTarget {
     pub fn get_value(&self) -> &u32 {
         self.value.get_value()
@@ -38,22 +40,18 @@ impl CommentRowTarget {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => {
-                    self.value.set_value_string(e.unescape().unwrap());
+        xml_read_loop!(
+            reader,
+            Event::Text(e) => {
+                self.value.set_value_string(e.unescape().unwrap());
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"x:Row" {
+                    return
                 }
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"x:Row" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "x:Row"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Eof => panic!("Error not find {} end element", "x:Row")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/vml/spreadsheet/move_with_cells.rs
+++ b/src/structs/vml/spreadsheet/move_with_cells.rs
@@ -1,6 +1,7 @@
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::TrueFalseBlankValue;
 use writer::driver::*;
@@ -9,6 +10,7 @@ use writer::driver::*;
 pub struct MoveWithCells {
     value: TrueFalseBlankValue,
 }
+
 impl MoveWithCells {
     pub fn get_value(&self) -> &Option<bool> {
         self.value.get_value()
@@ -28,22 +30,19 @@ impl MoveWithCells {
         if empty_flag {
             return;
         }
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => {
-                    self.value.set_value_string(e.unescape().unwrap());
+
+        xml_read_loop!(
+            reader,
+            Event::Text(e) => {
+                self.value.set_value_string(e.unescape().unwrap());
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"x:MoveWithCells" {
+                    return
                 }
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"x:MoveWithCells" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "x:MoveWithCells"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Eof => panic!("Error not find {} end element", "x:MoveWithCells")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/vml/spreadsheet/resize_with_cells.rs
+++ b/src/structs/vml/spreadsheet/resize_with_cells.rs
@@ -1,6 +1,7 @@
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::TrueFalseBlankValue;
 use writer::driver::*;
@@ -9,6 +10,7 @@ use writer::driver::*;
 pub struct ResizeWithCells {
     value: TrueFalseBlankValue,
 }
+
 impl ResizeWithCells {
     pub fn get_value(&self) -> &Option<bool> {
         self.value.get_value()
@@ -28,22 +30,19 @@ impl ResizeWithCells {
         if empty_flag {
             return;
         }
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => {
-                    self.value.set_value_string(e.unescape().unwrap());
+
+        xml_read_loop!(
+            reader,
+            Event::Text(e) => {
+                self.value.set_value_string(e.unescape().unwrap());
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"x:SizeWithCells" {
+                    return
                 }
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"x:SizeWithCells" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "x:SizeWithCells"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Eof => panic!("Error not find {} end element", "x:SizeWithCells")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/vml/spreadsheet/visible.rs
+++ b/src/structs/vml/spreadsheet/visible.rs
@@ -1,6 +1,7 @@
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
+use reader::driver::*;
 use std::io::Cursor;
 use structs::TrueFalseBlankValue;
 use writer::driver::*;
@@ -9,6 +10,7 @@ use writer::driver::*;
 pub struct Visible {
     value: TrueFalseBlankValue,
 }
+
 impl Visible {
     pub fn get_value(&self) -> &Option<bool> {
         self.value.get_value()
@@ -28,22 +30,19 @@ impl Visible {
         if empty_flag {
             return;
         }
-        let mut buf = Vec::new();
-        loop {
-            match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => {
-                    self.value.set_value_string(e.unescape().unwrap());
+
+        xml_read_loop!(
+            reader,
+            Event::Text(e) => {
+                self.value.set_value_string(e.unescape().unwrap());
+            },
+            Event::End(ref e) => {
+                if e.name().0 == b"x:Visible" {
+                    return
                 }
-                Ok(Event::End(ref e)) => match e.name().0 {
-                    b"x:Visible" => return,
-                    _ => (),
-                },
-                Ok(Event::Eof) => panic!("Error not find {} end element", "x:Visible"),
-                Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
-                _ => (),
-            }
-            buf.clear();
-        }
+            },
+            Event::Eof => panic!("Error not find {} end element", "x:Visible")
+        );
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/vml/stroke.rs
+++ b/src/structs/vml/stroke.rs
@@ -12,6 +12,7 @@ pub struct Stroke {
     color_2: StringValue,
     dash_style: StringValue,
 }
+
 impl Stroke {
     pub fn get_color(&self) -> &str {
         self.color.get_value()
@@ -45,24 +46,9 @@ impl Stroke {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"color") {
-            Some(v) => {
-                self.color.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"color2") {
-            Some(v) => {
-                self.color_2.set_value_string(v);
-            }
-            None => {}
-        }
-        match get_attribute(e, b"dashstyle") {
-            Some(v) => {
-                self.dash_style.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, color, "color");
+        set_string_from_xml!(self, e, color_2, "color2");
+        set_string_from_xml!(self, e, dash_style, "dashstyle");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/workbook_view.rs
+++ b/src/structs/workbook_view.rs
@@ -10,6 +10,7 @@ use writer::driver::*;
 pub struct WorkbookView {
     active_tab: UInt32Value,
 }
+
 impl WorkbookView {
     pub fn get_active_tab(&self) -> &u32 {
         self.active_tab.get_value()
@@ -25,21 +26,17 @@ impl WorkbookView {
         _reader: &mut Reader<R>,
         e: &BytesStart,
     ) {
-        match get_attribute(e, b"activeTab") {
-            Some(v) => {
-                self.active_tab.set_value_string(v);
-            }
-            None => {}
-        }
+        set_string_from_xml!(self, e, active_tab, "activeTab")
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // selection
-        let mut attributes: Vec<(&str, &str)> = Vec::new();
-        attributes.push(("xWindow", "240"));
-        attributes.push(("yWindow", "105"));
-        attributes.push(("windowWidth", "14805"));
-        attributes.push(("windowHeight", "8010"));
+        let mut attributes = vec![
+            ("xWindow", "240"),
+            ("yWindow", "105"),
+            ("windowWidth", "14805"),
+            ("windowHeight", "8010"),
+        ];
         let active_tab = self.active_tab.get_value_string();
         if self.active_tab.has_value() {
             attributes.push(("activeTab", &active_tab));

--- a/src/structs/worksheet.rs
+++ b/src/structs/worksheet.rs
@@ -68,6 +68,7 @@ pub struct Worksheet {
     data_validations: Option<DataValidations>,
     sheet_format_properties: SheetFormatProperties,
 }
+
 impl Worksheet {
     // ************************
     // Value
@@ -1785,13 +1786,8 @@ impl Worksheet {
         // Iterate row by row, collecting cell information (do I copy)
         let mut copy_cells: Vec<Cell> = Vec::new();
         let cells = self.cell_collection.get_cell_by_range(range);
-        for cell in cells {
-            match cell {
-                Some(v) => {
-                    copy_cells.push(v.clone());
-                }
-                None => {}
-            }
+        for cell in cells.into_iter().flatten() {
+            copy_cells.push(cell.clone());
         }
 
         // Delete cell information as iterating through

--- a/src/structs/writer_manager.rs
+++ b/src/structs/writer_manager.rs
@@ -10,6 +10,7 @@ pub struct WriterManager<W: io::Seek + io::Write> {
     arv: zip::ZipWriter<W>,
     is_light: bool,
 }
+
 impl<W: io::Seek + io::Write> WriterManager<W> {
     pub fn new(arv: zip::ZipWriter<W>) -> Self {
         WriterManager {
@@ -41,7 +42,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
         Ok(())
     }
 
-    pub(crate) fn add_bin(&mut self, target: &str, data: &Vec<u8>) -> Result<(), XlsxError> {
+    pub(crate) fn add_bin(&mut self, target: &str, data: &[u8]) -> Result<(), XlsxError> {
         let is_match = self.check_file_exist(target);
         if !is_match {
             make_file_from_bin(target, &mut self.arv, data, None, &self.is_light)?;
@@ -62,7 +63,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
     pub(crate) fn check_file_exist(&mut self, file_path: &str) -> bool {
         self.file_list_sort();
         for file in &self.files {
-            if file == &file_path {
+            if file == file_path {
                 return true;
             }
         }
@@ -133,7 +134,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
         }
     }
 
-    pub(crate) fn add_file_at_ole_object(&mut self, writer: &Vec<u8>) -> Result<i32, XlsxError> {
+    pub(crate) fn add_file_at_ole_object(&mut self, writer: &[u8]) -> Result<i32, XlsxError> {
         let mut index = 0;
         loop {
             index += 1;
@@ -146,7 +147,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
         }
     }
 
-    pub(crate) fn add_file_at_excel(&mut self, writer: &Vec<u8>) -> Result<i32, XlsxError> {
+    pub(crate) fn add_file_at_excel(&mut self, writer: &[u8]) -> Result<i32, XlsxError> {
         let mut index = 0;
         loop {
             index += 1;
@@ -158,10 +159,8 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
             }
         }
     }
-    pub(crate) fn add_file_at_printer_settings(
-        &mut self,
-        writer: &Vec<u8>,
-    ) -> Result<i32, XlsxError> {
+
+    pub(crate) fn add_file_at_printer_settings(&mut self, writer: &[u8]) -> Result<i32, XlsxError> {
         let mut index = 0;
         loop {
             index += 1;

--- a/src/writer/csv.rs
+++ b/src/writer/csv.rs
@@ -82,48 +82,48 @@ pub fn write_writer<W: io::Seek + io::Write>(
 
     // encoding.
     let res_into: Vec<u8>;
-    let data_bytes = match option.get_csv_encode_value() {
-        &CsvEncodeValues::ShiftJis => {
+    let data_bytes = match *option.get_csv_encode_value() {
+        CsvEncodeValues::ShiftJis => {
             let (res, _, _) = encoding_rs::SHIFT_JIS.encode(&data);
             res_into = res.into_owned();
             &res_into[..]
         }
-        &CsvEncodeValues::Koi8u => {
+        CsvEncodeValues::Koi8u => {
             let (res, _, _) = encoding_rs::KOI8_U.encode(&data);
             res_into = res.into_owned();
             &res_into[..]
         }
-        &CsvEncodeValues::Koi8r => {
+        CsvEncodeValues::Koi8r => {
             let (res, _, _) = encoding_rs::KOI8_R.encode(&data);
             res_into = res.into_owned();
             &res_into[..]
         }
-        &CsvEncodeValues::Iso88598i => {
+        CsvEncodeValues::Iso88598i => {
             let (res, _, _) = encoding_rs::ISO_8859_8_I.encode(&data);
             res_into = res.into_owned();
             &res_into[..]
         }
-        &CsvEncodeValues::Gbk => {
+        CsvEncodeValues::Gbk => {
             let (res, _, _) = encoding_rs::GBK.encode(&data);
             res_into = res.into_owned();
             &res_into[..]
         }
-        &CsvEncodeValues::EucKr => {
+        CsvEncodeValues::EucKr => {
             let (res, _, _) = encoding_rs::EUC_KR.encode(&data);
             res_into = res.into_owned();
             &res_into[..]
         }
-        &CsvEncodeValues::Big5 => {
+        CsvEncodeValues::Big5 => {
             let (res, _, _) = encoding_rs::BIG5.encode(&data);
             res_into = res.into_owned();
             &res_into[..]
         }
-        &CsvEncodeValues::Utf16Le => {
+        CsvEncodeValues::Utf16Le => {
             let (res, _, _) = encoding_rs::UTF_16LE.encode(&data);
             res_into = res.into_owned();
             &res_into[..]
         }
-        &CsvEncodeValues::Utf16Be => {
+        CsvEncodeValues::Utf16Be => {
             let (res, _, _) = encoding_rs::UTF_16BE.encode(&data);
             res_into = res.into_owned();
             &res_into[..]
@@ -132,7 +132,7 @@ pub fn write_writer<W: io::Seek + io::Write>(
     };
 
     // output.
-    writer.write(data_bytes).unwrap();
+    writer.write_all(data_bytes).unwrap();
     Ok(())
 }
 

--- a/src/writer/driver.rs
+++ b/src/writer/driver.rs
@@ -63,17 +63,15 @@ pub(crate) fn make_file_from_writer<W: io::Seek + io::Write>(
 pub(crate) fn make_file_from_bin<W: io::Seek + io::Write>(
     path: &str,
     arv: &mut zip::ZipWriter<W>,
-    writer: &Vec<u8>,
+    writer: &[u8],
     dir: Option<&str>,
     is_light: &bool,
 ) -> Result<(), io::Error> {
-    let zip_opt =
-        match is_light {
-            &false => zip::write::FileOptions::default()
-                .compression_method(zip::CompressionMethod::DEFLATE),
-            &true => zip::write::FileOptions::default()
-                .compression_method(zip::CompressionMethod::Stored),
-        };
+    let zip_opt = if *is_light {
+        zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored)
+    } else {
+        zip::write::FileOptions::default().compression_method(zip::CompressionMethod::DEFLATE)
+    };
     arv.start_file(&to_path(path, dir), zip_opt)?;
     arv.write_all(writer)
 }

--- a/src/writer/xlsx/comment.rs
+++ b/src/writer/xlsx/comment.rs
@@ -86,7 +86,7 @@ fn get_authors(worksheet: &Worksheet) -> Vec<String> {
     authors
 }
 
-fn get_author_id(authors: &Vec<String>, author: &str) -> String {
+fn get_author_id(authors: &[String], author: &str) -> String {
     for (i, value) in authors.iter().enumerate() {
         if author == value {
             return i.to_string();

--- a/src/writer/xlsx/content_types.rs
+++ b/src/writer/xlsx/content_types.rs
@@ -11,7 +11,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     spreadsheet: &Spreadsheet,
     writer_mng: &mut WriterManager<W>,
 ) -> Result<(), XlsxError> {
-    let is_light = writer_mng.get_is_light().clone();
+    let is_light = *writer_mng.get_is_light();
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(

--- a/src/writer/xlsx/workbook.rs
+++ b/src/writer/xlsx/workbook.rs
@@ -117,10 +117,11 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     for worksheet in spreadsheet.get_sheet_collection_no_check() {
         let id = index.to_string();
         let r_id = format!("rId{}", index);
-        let mut attributes: Vec<(&str, &str)> = Vec::new();
-        attributes.push(("name", worksheet.get_name()));
-        attributes.push(("sheetId", &id));
-        attributes.push(("r:id", &r_id));
+        let attributes: Vec<(&str, &str)> = vec![
+            ("name", worksheet.get_name()),
+            ("sheetId", &id),
+            ("r:id", &r_id),
+        ];
 
         // sheet
         write_start_tag(&mut writer, "sheet", attributes, true);

--- a/src/writer/xlsx/workbook_rels.rs
+++ b/src/writer/xlsx/workbook_rels.rs
@@ -12,7 +12,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     has_shared_string_table: bool,
     writer_mng: &mut WriterManager<W>,
 ) -> Result<(), XlsxError> {
-    let is_light = writer_mng.get_is_light().clone();
+    let is_light = *writer_mng.get_is_light();
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
     let _ = writer.write_event(Event::Decl(BytesDecl::new(
@@ -24,11 +24,10 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     // relationships
     let root_tag_name = "Relationships";
-    let mut attributes: Vec<(&str, &str)> = Vec::new();
-    attributes.push((
+    let attributes: Vec<(&str, &str)> = vec![(
         "xmlns",
         "http://schemas.openxmlformats.org/package/2006/relationships",
-    ));
+    )];
     write_start_tag(&mut writer, root_tag_name, attributes, false);
 
     let mut index = 1;

--- a/src/writer/xlsx/worksheet_rels.rs
+++ b/src/writer/xlsx/worksheet_rels.rs
@@ -7,14 +7,15 @@ use super::XlsxError;
 use structs::Worksheet;
 use structs::WriterManager;
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn write<W: io::Seek + io::Write>(
     worksheet: &Worksheet,
     worksheet_no: &str,
     drawing_no: &str,
     vml_drawing_no: &str,
     comment_no: &str,
-    ole_object_no_list: &Vec<String>,
-    excel_no_list: &Vec<String>,
+    ole_object_no_list: &[String],
+    excel_no_list: &[String],
     printer_settings_no: &str,
     writer_mng: &mut WriterManager<W>,
 ) -> Result<(), XlsxError> {


### PR DESCRIPTION
Hi, apologies for the extremely large change but I thought that it would be great for this library to use [clippy](https://github.com/rust-lang/rust-clippy) to enforce common coding standards and best practices.  There are a lot of changes here but fortunately they are all pretty much the same changes repeated all over the place.  And none of them affect functionality - they are all just style changes

I created two macros here:  https://github.com/MathNya/umya-spreadsheet/compare/master...patrickomatic:umya-spreadsheet:use-clippy?expand=1#diff-4494fe6dbf95718223777235622fbbb23e342a166b0b558f80d3904007a98cbdR6 which allowed me to combine a lot of repetitive code and at the same time fix warnings by clippy

To make sure any future problems are caught I set up a github actions workflow to: 1.) build the PR 2.) run clippy 3.) run rustfmt and 4.) run tests
