### PR TITLE
replaced `convert_character_reference` with `quick_xml` internal function

### DIFF
--- a/src/reader/driver.rs
+++ b/src/reader/driver.rs
@@ -91,11 +91,3 @@ pub(crate) fn get_attribute_value(attr: &Attribute) -> Result<String, FromUtf8Er
     let value = attr.value.clone().into_owned();
     String::from_utf8(value)
 }
-
-pub(crate) fn convert_character_reference(src: &str) -> String {
-    src.replace("&amp;", "&")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
-        .replace("&apos;", "'")
-}

--- a/src/structs/numbering_format.rs
+++ b/src/structs/numbering_format.rs
@@ -1,4 +1,5 @@
 use md5::Digest;
+use quick_xml::escape;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -147,8 +148,9 @@ impl NumberingFormat {
             .unwrap()
             .parse::<u32>()
             .unwrap();
-        self.format_code =
-            convert_character_reference(get_attribute(e, b"formatCode").unwrap().as_str());
+        self.format_code = escape::unescape(get_attribute(e, b"formatCode").unwrap().as_str())
+            .unwrap()
+            .to_string();
         self.is_build_in = false;
     }
 


### PR DESCRIPTION
Reimplantation "unescaping" of xml character sequences are replaced with `quick_xml` internal function to maintain better support.