### PR TITLE
minor changes to logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,27 +11,27 @@ description = "umya-spreadsheet is a library written in pure Rust to read and wr
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-quick-xml = { version = "0.31.0", features = [ "serialize" ] }
-zip = {version = "0.6.6", default-features = false, features = ["deflate"]}
-md-5 = "0.10.6"
-lazy_static = "1.4.0"
-thousands = "0.2.0"
-chrono = {version = "0.4.31", default-features = false, features = ["clock"]}
-encoding_rs = "0.8.33"
-image = "0.24.7"
-hashbrown = "0.14.3"
-ahash = "0.8.6"
-regex = "1.10.2"
-fancy-regex = "0.13.0"
-base64 = "0.21.5"
-getrandom = "0.2.11"
-byteorder = "1.5"
-cfb = "0.9.0"
-hmac = "0.12.1"
-sha2 = "0.10.8"
 aes = "0.8.3"
+ahash = "0.8.6"
+base64 = "0.21.5"
+byteorder = "1.5"
 cbc = "0.1.2"
+cfb = "0.9.0"
+chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
+encoding_rs = "0.8.33"
+fancy-regex = "0.13.0"
+getrandom = "0.2.11"
+hashbrown = "0.14.3"
+hmac = "0.12.1"
 html_parser = "0.7.0"
+image = "0.24.7"
+lazy_static = "1.4.0"
+md-5 = "0.10.6"
+regex = "1.10.2"
+sha2 = "0.10.8"
+thousands = "0.2.0"
+quick-xml = { version = "0.31.0", features = ["serialize"] }
+zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 
 [lib]
 doctest = false

--- a/src/helper/const_str.rs
+++ b/src/helper/const_str.rs
@@ -9,15 +9,17 @@ pub(crate) const COREPROPS_NS: &str =
     "http://schemas.openxmlformats.org/package/2006/metadata/core-properties";
 pub(crate) const CUSTOMUI_NS: &str =
     "http://schemas.microsoft.com/office/2006/relationships/ui/extensibility";
+pub(crate) const DCMITYPE_NS: &str = "http://purl.org/dc/dcmitype/";
+pub(crate) const DCORE_NS: &str = "http://purl.org/dc/elements/1.1/";
+pub(crate) const DCTERMS_NS: &str = "http://purl.org/dc/terms/";
+pub(crate) const DRAWING_CHART_NS: &str =
+    "http://schemas.microsoft.com/office/drawing/2007/8/2/chart";
 pub(crate) const DRAWING_MAIN_NS: &str = "http://schemas.microsoft.com/office/drawing/2010/main";
 pub(crate) const DRAWINGML_CHART_NS: &str =
     "http://schemas.openxmlformats.org/drawingml/2006/chart";
 pub(crate) const DRAWINGML_MAIN_NS: &str = "http://schemas.openxmlformats.org/drawingml/2006/main";
 pub(crate) const DRAWINGS_NS: &str =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing";
-pub(crate) const DCMITYPE_NS: &str = "http://purl.org/dc/dcmitype/";
-pub(crate) const DCORE_NS: &str = "http://purl.org/dc/elements/1.1/";
-pub(crate) const DCTERMS_NS: &str = "http://purl.org/dc/terms/";
 pub(crate) const ENCRYPTION_NS: &str = "http://schemas.microsoft.com/office/2006/encryption";
 pub(crate) const HYPERLINK_NS: &str =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink";

--- a/src/helper/coordinate.rs
+++ b/src/helper/coordinate.rs
@@ -3,9 +3,7 @@ use std::iter::successors;
 use fancy_regex::Regex;
 
 fn index_to_alpha(index: u32) -> String {
-    if index < 1 {
-        panic!("Index cannot be less than one.")
-    }
+    assert!(index >= 1, "Index cannot be less than one.");
 
     const BASE_CHAR_CODE: u32 = 'A' as u32;
     // below code is based on the source code of `radix_fmt`
@@ -54,9 +52,7 @@ pub fn column_index_from_string<S: AsRef<str>>(column: S) -> u32 {
 }
 
 pub fn string_from_column_index(column_index: &u32) -> String {
-    if column_index < &1u32 {
-        panic!("Column number starts from 1.");
-    }
+    assert!(column_index >= &1u32, "Column number starts from 1.");
 
     index_to_alpha(*column_index)
 }

--- a/src/helper/range.rs
+++ b/src/helper/range.rs
@@ -28,31 +28,24 @@ pub fn get_start_and_end_point(range_str: &str) -> (u32, u32, u32, u32) {
 
     let mut is_col_select = false;
     let mut is_row_select = false;
-    let mut col_start = 0;
-    let mut col_end = 0;
-    let mut row_start = 0;
-    let mut row_end = 0;
+    let (mut col_start, mut col_end, mut row_start, mut row_end) = (0, 0, 0, 0);
 
-    if coordinate_collection.len() == 1 || coordinate_collection.len() == 2 {
-        let coordinate_str = coordinate_collection[0].to_string();
-        let (col, row, ..) = index_from_coordinate(coordinate_str);
+    let (col, row, ..) = index_from_coordinate(coordinate_collection[0]);
 
-        if let Some(v) = col {
-            is_col_select = true;
-            col_start = v;
-            col_end = v;
-        }
+    if let Some(v) = col {
+        is_col_select = true;
+        col_start = v;
+        col_end = v;
+    }
 
-        if let Some(v) = row {
-            is_row_select = true;
-            row_start = v;
-            row_end = v;
-        }
+    if let Some(v) = row {
+        is_row_select = true;
+        row_start = v;
+        row_end = v;
     }
 
     if coordinate_collection.len() == 2 {
-        let coordinate_str = coordinate_collection[1].to_string();
-        let (col, row, ..) = index_from_coordinate(coordinate_str);
+        let (col, row, ..) = index_from_coordinate(coordinate_collection[1]);
 
         match col {
             Some(v) => {
@@ -72,5 +65,6 @@ pub fn get_start_and_end_point(range_str: &str) -> (u32, u32, u32, u32) {
             }
         }
     }
+
     (row_start, row_end, col_start, col_end)
 }

--- a/src/helper/range.rs
+++ b/src/helper/range.rs
@@ -20,9 +20,11 @@ pub fn get_coordinate_list(range_str: &str) -> Vec<BasicCellIndex> {
 
 pub fn get_start_and_end_point(range_str: &str) -> (u32, u32, u32, u32) {
     let coordinate_collection: Vec<&str> = range_str.split(':').collect();
-    if coordinate_collection.is_empty() || coordinate_collection.len() > 2 {
-        panic!("Non-standard range.");
-    }
+
+    assert!(
+        matches!(coordinate_collection.len(), 1 | 2),
+        "Non-standard range."
+    );
 
     let mut is_col_select = false;
     let mut is_row_select = false;
@@ -57,9 +59,7 @@ pub fn get_start_and_end_point(range_str: &str) -> (u32, u32, u32, u32) {
                 col_end = v;
             }
             None => {
-                if !is_col_select {
-                    panic!("Non-standard range.");
-                }
+                assert!(is_col_select, "Non-standard range.");
             }
         };
 
@@ -68,9 +68,7 @@ pub fn get_start_and_end_point(range_str: &str) -> (u32, u32, u32, u32) {
                 row_end = v;
             }
             None => {
-                if !is_row_select {
-                    panic!("Non-standard range.");
-                }
+                assert!(is_row_select, "Non-standard range.");
             }
         }
     }

--- a/src/reader/xlsx.rs
+++ b/src/reader/xlsx.rs
@@ -89,23 +89,23 @@ pub fn read_reader<R: io::Read + io::Seek>(
 ) -> Result<Spreadsheet, XlsxError> {
     let mut arv = zip::read::ZipArchive::new(reader)?;
 
-    let mut book = workbook::read(&mut arv).unwrap();
-    doc_props_app::read(&mut arv, &mut book).unwrap();
-    doc_props_core::read(&mut arv, &mut book).unwrap();
-    vba_project_bin::read(&mut arv, &mut book).unwrap();
-    content_types::read(&mut arv, &mut book).unwrap();
-    let workbook_rel = workbook_rels::read(&mut arv, &mut book).unwrap();
+    let mut book = workbook::read(&mut arv)?;
+    doc_props_app::read(&mut arv, &mut book)?;
+    doc_props_core::read(&mut arv, &mut book)?;
+    vba_project_bin::read(&mut arv, &mut book)?;
+    content_types::read(&mut arv, &mut book)?;
+    let workbook_rel = workbook_rels::read(&mut arv, &mut book)?;
 
     book.set_theme(Theme::get_default_value());
     for (_, type_value, rel_target) in &workbook_rel {
         if type_value == THEME_NS {
-            let theme = theme::read(&mut arv, rel_target).unwrap();
+            let theme = theme::read(&mut arv, rel_target)?;
             book.set_theme(theme);
         }
     }
 
-    shared_strings::read(&mut arv, &mut book).unwrap();
-    styles::read(&mut arv, &mut book).unwrap();
+    shared_strings::read(&mut arv, &mut book)?;
+    styles::read(&mut arv, &mut book)?;
 
     for sheet in book.get_sheet_collection_mut() {
         for (rel_id, _, rel_target) in &workbook_rel {

--- a/src/structs/drawing/charts/plot_area.rs
+++ b/src/structs/drawing/charts/plot_area.rs
@@ -507,46 +507,19 @@ impl PlotArea {
     }
 
     pub(crate) fn is_support(&self) -> bool {
-        if self.line_chart.is_some() {
-            return true;
-        }
-        if self.line_3d_chart.is_some() {
-            return true;
-        }
-        if self.pie_chart.is_some() {
-            return true;
-        }
-        if self.pie_3d_chart.is_some() {
-            return true;
-        }
-        if self.doughnut_chart.is_some() {
-            return true;
-        }
-        if self.scatter_chart.is_some() {
-            return true;
-        }
-        if self.bar_chart.is_some() {
-            return true;
-        }
-        if self.bar_3d_chart.is_some() {
-            return true;
-        }
-        if self.radar_chart.is_some() {
-            return true;
-        }
-        if self.bubble_chart.is_some() {
-            return true;
-        }
-        if self.area_chart.is_some() {
-            return true;
-        }
-        if self.area_3d_chart.is_some() {
-            return true;
-        }
-        if self.of_pie_chart.is_some() {
-            return true;
-        }
-        false
+        self.line_chart.is_some()
+            || self.line_3d_chart.is_some()
+            || self.pie_chart.is_some()
+            || self.pie_3d_chart.is_some()
+            || self.doughnut_chart.is_some()
+            || self.scatter_chart.is_some()
+            || self.bar_chart.is_some()
+            || self.bar_3d_chart.is_some()
+            || self.radar_chart.is_some()
+            || self.bubble_chart.is_some()
+            || self.area_chart.is_some()
+            || self.area_3d_chart.is_some()
+            || self.of_pie_chart.is_some()
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/numbering_format.rs
+++ b/src/structs/numbering_format.rs
@@ -83,10 +83,8 @@ impl NumberingFormat {
                 None
             }
         });
-        if format_code_result.is_none() {
-            panic!("Not Found NumberFormatId.");
-        }
-        self.format_code = format_code_result.unwrap();
+
+        self.format_code = format_code_result.expect("Not Found NumberFormatId.");
         self.number_format_id = value;
         self.is_build_in = true;
         self

--- a/src/structs/office2010/drawing/charts/style.rs
+++ b/src/structs/office2010/drawing/charts/style.rs
@@ -40,13 +40,7 @@ impl Style {
         write_start_tag(
             writer,
             "mc:Choice",
-            vec![
-                ("Requires", "c14"),
-                (
-                    "xmlns:c14",
-                    "http://schemas.microsoft.com/office/drawing/2007/8/2/chart",
-                ),
-            ],
+            vec![("Requires", "c14"), ("xmlns:c14", DRAWING_CHART_NS)],
             false,
         );
 

--- a/src/structs/range.rs
+++ b/src/structs/range.rs
@@ -15,40 +15,37 @@ impl Range {
         let org_value = value.into();
         let coordinate_collection: Vec<&str> = org_value.split(':').collect();
 
-        if coordinate_collection.is_empty() || coordinate_collection.len() > 2 {
-            panic!("Non-standard coordinate");
-        }
+        assert!(
+            matches!(coordinate_collection.len(), 1 | 2),
+            "Non-standard coordinate"
+        );
 
-        if coordinate_collection.len() == 1 || coordinate_collection.len() == 2 {
-            let coordinate_str = coordinate_collection[0].to_string();
-            let (
-                row,         //
-                col,         //
-                is_lock_col, //
-                is_lock_row,
-            ) = index_from_coordinate(coordinate_str);
-            if let Some(v) = row {
-                let mut coordinate_start_col = ColumnReference::default();
-                coordinate_start_col.set_num(v);
-                coordinate_start_col.set_is_lock(is_lock_col.unwrap());
-                self.coordinate_start_col = Some(coordinate_start_col);
-            };
-            if let Some(v) = col {
-                let mut coordinate_start_row = RowReference::default();
-                coordinate_start_row.set_num(v);
-                coordinate_start_row.set_is_lock(is_lock_row.unwrap());
-                self.coordinate_start_row = Some(coordinate_start_row);
-            }
+        let (
+            row,         //
+            col,         //
+            is_lock_col, //
+            is_lock_row,
+        ) = index_from_coordinate(coordinate_collection[0]);
+        if let Some(v) = row {
+            let mut coordinate_start_col = ColumnReference::default();
+            coordinate_start_col.set_num(v);
+            coordinate_start_col.set_is_lock(is_lock_col.unwrap());
+            self.coordinate_start_col = Some(coordinate_start_col);
+        };
+        if let Some(v) = col {
+            let mut coordinate_start_row = RowReference::default();
+            coordinate_start_row.set_num(v);
+            coordinate_start_row.set_is_lock(is_lock_row.unwrap());
+            self.coordinate_start_row = Some(coordinate_start_row);
         }
 
         if coordinate_collection.len() == 2 {
-            let coordinate_str = coordinate_collection[1].to_string();
             let (
                 row,         //
                 col,         //
                 is_lock_col, //
                 is_lock_row,
-            ) = index_from_coordinate(coordinate_str);
+            ) = index_from_coordinate(coordinate_collection[1]);
             if let Some(v) = row {
                 let mut coordinate_end_col = ColumnReference::default();
                 coordinate_end_col.set_num(v);

--- a/src/structs/spreadsheet.rs
+++ b/src/structs/spreadsheet.rs
@@ -310,9 +310,7 @@ impl Spreadsheet {
     /// Get Work Sheet List.
     pub fn get_sheet_collection(&self) -> &Vec<Worksheet> {
         for worksheet in &self.work_sheet_collection {
-            if !worksheet.is_deserialized() {
-                panic!("This Worksheet is Not Deserialized. Please exec to read_sheet(&mut self, index: usize);");
-            }
+            assert!(worksheet.is_deserialized(),"This Worksheet is Not Deserialized. Please exec to read_sheet(&mut self, index: usize);");
         }
         &self.work_sheet_collection
     }
@@ -362,29 +360,27 @@ impl Spreadsheet {
         self
     }
 
-    pub(crate) fn find_sheet_index_by_name(&self, sheet_name: &str) -> Result<usize, &'static str> {
+    pub(crate) fn find_sheet_index_by_name(&self, sheet_name: &str) -> Option<usize> {
         for (result, sheet) in self.work_sheet_collection.iter().enumerate() {
             if sheet.get_name() == sheet_name {
-                return Ok(result);
+                return Some(result);
             }
         }
-        Err("not found.")
+        None
     }
 
     /// Get Work Sheet.
     /// # Arguments
     /// * `index` - sheet index
     /// # Return value
-    /// * `Result<&Worksheet, &'static str>` - OK:work sheet. Err:Error.
-    pub fn get_sheet(&self, index: &usize) -> Result<&Worksheet, &'static str> {
+    /// * `Option<&Worksheet>`.
+    pub fn get_sheet(&self, index: &usize) -> Option<&Worksheet> {
         match self.work_sheet_collection.get(*index) {
             Some(v) => {
-                if !v.is_deserialized() {
-                    panic!("This Worksheet is Not Deserialized. Please exec to read_sheet(&mut self, index: usize);");
-                }
-                Ok(v)
+                assert!(v.is_deserialized(),"This Worksheet is Not Deserialized. Please exec to read_sheet(&mut self, index: usize);");
+                Some(v)
             }
-            None => Err("Not found."),
+            None => None,
         }
     }
 
@@ -392,13 +388,13 @@ impl Spreadsheet {
     /// # Arguments
     /// * `sheet_name` - sheet name
     /// # Return value
-    /// * `Result<&Worksheet, &'static str>` - OK:work sheet. Err:Error.
-    pub fn get_sheet_by_name(&self, sheet_name: &str) -> Result<&Worksheet, &'static str> {
+    /// * `Option<&Worksheet>.
+    pub fn get_sheet_by_name(&self, sheet_name: &str) -> Option<&Worksheet> {
         match self.find_sheet_index_by_name(sheet_name) {
-            Ok(index) => {
+            Some(index) => {
                 return self.get_sheet(&index);
             }
-            Err(e) => Err(e),
+            None => None,
         }
     }
 
@@ -417,17 +413,17 @@ impl Spreadsheet {
     /// # Arguments
     /// * `index` - sheet index
     /// # Return value
-    /// * `Result<&mut Worksheet, &'static str>` - OK:work sheet. Err:Error.
-    pub fn get_sheet_mut(&mut self, index: &usize) -> Result<&mut Worksheet, &'static str> {
+    /// * `Option<&mut Worksheet>`.
+    pub fn get_sheet_mut(&mut self, index: &usize) -> Option<&mut Worksheet> {
         let theme = self.get_theme().clone();
         let shared_string_table = self.get_shared_string_table();
         let stylesheet = self.get_stylesheet().clone();
         match self.work_sheet_collection.get_mut(*index) {
             Some(v) => {
                 raw_to_deserialize_by_worksheet(v, &theme, shared_string_table, &stylesheet);
-                Ok(v)
+                Some(v)
             }
-            None => Err("Not found."),
+            None => None,
         }
     }
 
@@ -435,16 +431,13 @@ impl Spreadsheet {
     /// # Arguments
     /// * `sheet_name` - sheet name
     /// # Return value
-    /// * `Result<&mut Worksheet, &'static str>` - OK:work sheet. Err:Error.
-    pub fn get_sheet_by_name_mut(
-        &mut self,
-        sheet_name: &str,
-    ) -> Result<&mut Worksheet, &'static str> {
+    /// * `Option<&mut Worksheet>`.
+    pub fn get_sheet_by_name_mut(&mut self, sheet_name: &str) -> Option<&mut Worksheet> {
         match self.find_sheet_index_by_name(sheet_name) {
-            Ok(index) => {
+            Some(index) => {
                 return self.get_sheet_mut(&index);
             }
-            Err(e) => Err(e),
+            None => None,
         }
     }
 

--- a/src/structs/worksheet.rs
+++ b/src/structs/worksheet.rs
@@ -171,9 +171,8 @@ impl Worksheet {
         shared_string_table: &SharedStringTable,
         stylesheet: &Stylesheet,
     ) -> Cells {
-        if self.is_deserialized() {
-            panic!("This Worksheet is Deserialized.");
-        }
+        assert!(!self.is_deserialized(), "This Worksheet is Deserialized.");
+
         read_lite(
             self.raw_data_of_worksheet.as_ref().unwrap(),
             shared_string_table,
@@ -1739,10 +1738,7 @@ impl Worksheet {
     /// (This method is crate only.)
     /// Has Defined Names.
     pub(crate) fn has_defined_names(&self) -> bool {
-        if !self.get_defined_names().is_empty() {
-            return true;
-        }
-        false
+        !self.get_defined_names().is_empty()
     }
 
     pub(crate) fn is_deserialized(&self) -> bool {
@@ -1750,13 +1746,9 @@ impl Worksheet {
     }
 
     pub(crate) fn get_raw_data_of_worksheet(&self) -> &RawWorksheet {
-        match &self.raw_data_of_worksheet {
-            Some(v) => {
-                return v;
-            }
-            None => {}
-        }
-        panic!("Not found at raw data of worksheet.");
+        self.raw_data_of_worksheet
+            .as_ref()
+            .expect("Not found at raw data of worksheet.")
     }
 
     pub(crate) fn set_raw_data_of_worksheet(&mut self, value: RawWorksheet) -> &mut Self {
@@ -1824,11 +1816,12 @@ impl Worksheet {
         }
 
         // Iterate row by row, collecting cell information (do I copy)
-        let mut copy_cells: Vec<Cell> = Vec::new();
         let cells = self.cell_collection.get_cell_by_range(range);
-        for cell in cells.into_iter().flatten() {
-            copy_cells.push(cell.clone());
-        }
+        let mut copy_cells: Vec<Cell> = cells
+            .into_iter()
+            .flatten()
+            .map(|cell| cell.clone())
+            .collect();
 
         // Delete cell information as iterating through
         let coordinate_list = get_coordinate_list(&range_upper);

--- a/src/writer/xlsx/shared_strings.rs
+++ b/src/writer/xlsx/shared_strings.rs
@@ -34,6 +34,5 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     shared_string_table.write().unwrap().write_to(&mut writer);
 
-    let target = PKG_SHARED_STRINGS;
-    writer_mng.add_writer(target, writer)
+    writer_mng.add_writer(PKG_SHARED_STRINGS, writer)
 }


### PR DESCRIPTION
The following changes are done:

- Formatted `cargo.toml` file alphabetically and with consistent format.
- Replaced sensible occurrences of panic!() with assert!() for better readability.
-In `src/reader/xlsx.rs` the return is already `XlsxError` therefore it doesn't make sense to `unwrap()` there. Therefore, the error due to read is passed to caller function.
- in `src/structs/drawing/charts/plot_area.rs` some modification to minimize redundant lines.
- in `src/structs/numbering_format.rs` it made sense to use inbuilt method `expect()` rather than elaborate checking done.
- in `src/structs/range.rs` as the `panic!()` was already preventing the case where `coordinate_collection` is other than 1 or 2. It didn't made sense to check again. Hence removed it. Also as it is already known that `coordinate_collection` is always has length of atleast one. Hence removed redundunt checks.
- In `src/writer/xlsx/shared_strings.rs` small changes to logic to prevent redundant allocation.
- In `src/structs/worksheet.rs` small logical changes to done and removed elaborate checks for simpler logic.
- In `src/structs/spreadsheet.rs` the function return type of several functions changed from `Result` type to `Option` type as the only logical reason why getting a sheet with a certain criterion may fail is because it is not found. Therefore reducing the allocation of static string in the binary. 