### PR TITLE
Changing Reference of Option to Optional Reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,15 @@ description = "umya-spreadsheet is a library written in pure Rust to read and wr
 
 [dependencies]
 aes = "0.8.3"
-ahash = "0.8.6"
-base64 = "0.21.5"
+ahash = "0.8.7"
+base64 = "0.21.6"
 byteorder = "1.5"
 cbc = "0.1.2"
 cfb = "0.9.0"
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 encoding_rs = "0.8.33"
 fancy-regex = "0.13.0"
-getrandom = "0.2.11"
+getrandom = "0.2.12"
 hashbrown = "0.14.3"
 hmac = "0.12.1"
 html_parser = "0.7.0"

--- a/src/helper/crypt.rs
+++ b/src/helper/crypt.rs
@@ -480,19 +480,19 @@ fn hash(algorithm: &str, buffers: Vec<&Vec<u8>>) -> Result<Vec<u8>, String> {
 
 fn gen_random_16() -> Vec<u8> {
     let buf: &mut [u8] = &mut [0; 16];
-    let _ = getrandom::getrandom(buf);
+    getrandom::getrandom(buf);
     buf.to_vec()
 }
 
 fn gen_random_32() -> Vec<u8> {
     let buf: &mut [u8] = &mut [0; 32];
-    let _ = getrandom::getrandom(buf);
+    getrandom::getrandom(buf);
     buf.to_vec()
 }
 
 fn gen_random_64() -> Vec<u8> {
     let buf: &mut [u8] = &mut [0; 64];
-    let _ = getrandom::getrandom(buf);
+    getrandom::getrandom(buf);
     buf.to_vec()
 }
 
@@ -529,7 +529,7 @@ fn build_encryption_info(
 ) -> Vec<u8> {
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),
@@ -649,7 +649,7 @@ fn buffer_concat(buffers: Vec<&Vec<u8>>) -> Vec<u8> {
 }
 fn buffer_copy(buffer1: &mut [u8], buffer2: &[u8]) {
     for (i, byte) in buffer2.iter().enumerate() {
-        let _ = std::mem::replace(&mut buffer1[i], *byte);
+        std::mem::replace(&mut buffer1[i], *byte);
     }
 }
 

--- a/src/helper/number_format.rs
+++ b/src/helper/number_format.rs
@@ -219,7 +219,7 @@ fn split_format(sections: Vec<&str>, value: &f64) -> (String, String, String) {
             for ite in color_re.captures(section).ok().flatten().unwrap().iter() {
                 item.push(ite.unwrap().as_str().to_string());
             }
-            let _ = std::mem::replace(&mut colors[idx], item.get(0).unwrap().to_string());
+            std::mem::replace(&mut colors[idx], item.get(0).unwrap().to_string());
             converted_section = color_re.replace_all(section, "").to_string();
         }
         if cond_regex.contains(section) {
@@ -227,8 +227,8 @@ fn split_format(sections: Vec<&str>, value: &f64) -> (String, String, String) {
             for ite in cond_re.captures(section).ok().flatten().unwrap().iter() {
                 item.push(ite.unwrap().as_str().to_string());
             }
-            let _ = std::mem::replace(&mut condops[idx], item.get(1).unwrap().to_string());
-            let _ = std::mem::replace(&mut condvals[idx], item.get(2).unwrap().to_string());
+            std::mem::replace(&mut condops[idx], item.get(1).unwrap().to_string());
+            std::mem::replace(&mut condvals[idx], item.get(2).unwrap().to_string());
             converted_section = cond_re.replace_all(section, "").to_string();
         }
         converted_sections.insert(idx, converted_section);

--- a/src/reader/xlsx/vba_project_bin.rs
+++ b/src/reader/xlsx/vba_project_bin.rs
@@ -19,7 +19,7 @@ pub(crate) fn read<R: io::Read + io::Seek>(
         }
     });
     let mut buf = Vec::new();
-    let _ = r.read_to_end(&mut buf)?;
+    r.read_to_end(&mut buf)?;
 
     spreadsheet.set_macros_code(buf);
 

--- a/src/reader/xlsx/workbook.rs
+++ b/src/reader/xlsx/workbook.rs
@@ -49,7 +49,7 @@ pub(crate) fn read<R: io::Read + io::Seek>(
                     worksheet.set_name(escape::unescape(&name_value).unwrap());
                     worksheet.set_sheet_id(sheet_id_value);
                     worksheet.set_r_id(r_id_value);
-                    let _ = spreadsheet.add_sheet(worksheet);
+                    spreadsheet.add_sheet(worksheet);
                 }
                 b"pivotCache" => {
                     let cache_id = get_attribute(e, b"cacheId").unwrap();

--- a/src/reader/xlsx/worksheet.rs
+++ b/src/reader/xlsx/worksheet.rs
@@ -181,7 +181,7 @@ pub(crate) fn read(
             }
             b"hyperlink" => {
                 let (coor, hyperlink) = get_hyperlink(e, raw_data_of_worksheet.get_worksheet_relationships());
-                let _ = worksheet.get_cell_mut(coor).set_hyperlink(hyperlink);
+                worksheet.get_cell_mut(coor).set_hyperlink(hyperlink);
             }
             b"printOptions" => {
                 worksheet
@@ -265,8 +265,8 @@ fn get_hyperlink(
 
     let coordition = get_attribute(e, b"ref").unwrap_or_default();
     if let Some(v) = get_attribute(e, b"location") {
-        let _ = hyperlink.set_url(v);
-        let _ = hyperlink.set_location(true);
+        hyperlink.set_url(v);
+        hyperlink.set_location(true);
     }
     if let Some(v) = get_attribute(e, b"r:id") {
         let relationship = raw_relationships.unwrap().get_relationship_by_rid(&v);

--- a/src/reader/xlsx/worksheet.rs
+++ b/src/reader/xlsx/worksheet.rs
@@ -264,19 +264,13 @@ fn get_hyperlink(
     let mut rid = String::from("");
 
     let coordition = get_attribute(e, b"ref").unwrap_or_default();
-    match get_attribute(e, b"location") {
-        Some(v) => {
-            let _ = hyperlink.set_url(v);
-            let _ = hyperlink.set_location(true);
-        }
-        None => {}
+    if let Some(v) = get_attribute(e, b"location") {
+        let _ = hyperlink.set_url(v);
+        let _ = hyperlink.set_location(true);
     }
-    match get_attribute(e, b"r:id") {
-        Some(v) => {
-            let relationship = raw_relationships.unwrap().get_relationship_by_rid(&v);
-            hyperlink.set_url(relationship.get_target());
-        }
-        None => {}
+    if let Some(v) = get_attribute(e, b"r:id") {
+        let relationship = raw_relationships.unwrap().get_relationship_by_rid(&v);
+        hyperlink.set_url(relationship.get_target());
     }
     (coordition, hyperlink)
 }

--- a/src/structs/boolean_value.rs
+++ b/src/structs/boolean_value.rs
@@ -5,17 +5,13 @@ pub struct BooleanValue {
 
 impl BooleanValue {
     pub(crate) fn get_value(&self) -> &bool {
-        match &self.value {
-            Some(v) => v,
-            None => &false,
-        }
+        self.value.as_ref().unwrap_or(&false)
     }
 
     pub(crate) fn get_value_string(&self) -> &str {
-        if *self.get_value() {
-            "1"
-        } else {
-            "0"
+        match *self.get_value() {
+            true => "1",
+            false => "0",
         }
     }
 

--- a/src/structs/border.rs
+++ b/src/structs/border.rs
@@ -135,13 +135,13 @@ impl Border {
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, tag_name: &str) {
-        let empty_flag = !self.color.has_value();
-
         // left,right,top,bottom,diagonal,vertical,horizontal
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.style.has_value() {
             attributes.push(("style", self.style.get_value_string()));
         }
+
+        let empty_flag = !self.color.has_value();
         write_start_tag(writer, tag_name, attributes, empty_flag);
 
         if !empty_flag {

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -65,10 +65,10 @@ impl Cell {
     }
 
     pub fn get_hyperlink_mut(&mut self) -> &mut Hyperlink {
-        if let Some(_) = &self.hyperlink {
+        if self.hyperlink.is_some() {
             return self.hyperlink.as_mut().unwrap();
         }
-        let _ = self.set_hyperlink(Hyperlink::default());
+        self.set_hyperlink(Hyperlink::default());
         self.hyperlink.as_mut().unwrap()
     }
 
@@ -325,11 +325,11 @@ impl Cell {
                             self.set_shared_string_item(shared_string_item.clone());
                         } else if type_value == "b" {
                             let prm = &string_value == "1";
-                            let _ = self.set_value_bool(prm);
+                            self.set_value_bool(prm);
                         } else if type_value == "e" {
-                            let _ = self.set_error();
+                            self.set_error();
                         } else if type_value.is_empty() || type_value == "n" {
-                            let _ = self.set_value_crate(string_value.clone());
+                            self.set_value_crate(string_value.clone());
                         };
                     }
                     b"is" => {

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -65,9 +65,8 @@ impl Cell {
     }
 
     pub fn get_hyperlink_mut(&mut self) -> &mut Hyperlink {
-        match &self.hyperlink {
-            Some(_) => return self.hyperlink.as_mut().unwrap(),
-            None => {}
+        if let Some(_) = &self.hyperlink {
+            return self.hyperlink.as_mut().unwrap();
         }
         let _ = self.set_hyperlink(Hyperlink::default());
         self.hyperlink.as_mut().unwrap()

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -60,8 +60,8 @@ impl Cell {
         &mut self.coordinate
     }
 
-    pub fn get_hyperlink(&self) -> &Option<Hyperlink> {
-        &self.hyperlink
+    pub fn get_hyperlink(&self) -> Option<&Hyperlink> {
+        self.hyperlink.as_ref()
     }
 
     pub fn get_hyperlink_mut(&mut self) -> &mut Hyperlink {
@@ -231,7 +231,7 @@ impl Cell {
     pub(crate) fn set_obj(&mut self, cell: Self) -> &mut Self {
         self.cell_value = cell.get_cell_value().clone();
         self.style = cell.get_style().clone();
-        self.hyperlink = cell.get_hyperlink().clone();
+        self.hyperlink = cell.get_hyperlink().cloned();
         self
     }
 

--- a/src/structs/cell_format.rs
+++ b/src/structs/cell_format.rs
@@ -265,18 +265,12 @@ impl CellFormat {
 
         if !empty_flag {
             // alignment
-            match &self.alignment {
-                Some(v) => {
-                    v.write_to(writer);
-                }
-                None => {}
+            if let Some(v) = &self.alignment {
+                v.write_to(writer);
             }
             // protection
-            match &self.protection {
-                Some(v) => {
-                    v.write_to(writer);
-                }
-                None => {}
+            if let Some(v) = &self.protection {
+                v.write_to(writer);
             }
             write_end_tag(writer, "xf");
         }

--- a/src/structs/cell_format.rs
+++ b/src/structs/cell_format.rs
@@ -152,12 +152,12 @@ impl CellFormat {
         self.apply_protection.has_value()
     }
 
-    pub(crate) fn get_alignment(&self) -> &Option<Alignment> {
-        &self.alignment
+    pub(crate) fn get_alignment(&self) -> Option<&Alignment> {
+        self.alignment.as_ref()
     }
 
-    pub(crate) fn _get_alignment_mut(&mut self) -> &mut Option<Alignment> {
-        &mut self.alignment
+    pub(crate) fn _get_alignment_mut(&mut self) -> Option<&mut Alignment> {
+        self.alignment.as_mut()
     }
 
     pub(crate) fn set_alignment(&mut self, value: Alignment) -> &mut Self {
@@ -165,12 +165,12 @@ impl CellFormat {
         self
     }
 
-    pub(crate) fn get_protection(&self) -> &Option<Protection> {
-        &self.protection
+    pub(crate) fn get_protection(&self) -> Option<&Protection> {
+        self.protection.as_ref()
     }
 
-    pub(crate) fn _get_protection_mut(&mut self) -> &mut Option<Protection> {
-        &mut self.protection
+    pub(crate) fn _get_protection_mut(&mut self) -> Option<&mut Protection> {
+        self.protection.as_mut()
     }
 
     pub(crate) fn set_protection(&mut self, value: Protection) -> &mut Self {

--- a/src/structs/cell_value.rs
+++ b/src/structs/cell_value.rs
@@ -132,17 +132,11 @@ impl CellValue {
     }
 
     pub(crate) fn set_shared_string_item(&mut self, value: SharedStringItem) -> &mut Self {
-        match value.get_text() {
-            Some(v) => {
-                self.set_value_string(v.get_value());
-            }
-            None => {}
+        if let Some(v) = value.get_text() {
+            self.set_value_string(v.get_value());
         }
-        match value.get_rich_text() {
-            Some(v) => {
-                self.set_rich_text(v.clone());
-            }
-            None => {}
+        if let Some(v) = value.get_rich_text() {
+            self.set_rich_text(v.clone());
         }
         self.remove_formula();
         self
@@ -153,13 +147,7 @@ impl CellValue {
     }
 
     pub fn get_formula(&self) -> &str {
-        match &self.formula {
-            Some(v) => {
-                return v;
-            }
-            None => {}
-        }
-        ""
+        self.formula.as_deref().unwrap_or("")
     }
 
     pub(crate) fn guess_typed_data(value: &str) -> CellRawValue {
@@ -214,20 +202,17 @@ impl CellValue {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        match &self.formula {
-            Some(v) => {
-                let formula = adjustment_insert_formula_coordinate(
-                    v,
-                    root_col_num,
-                    offset_col_num,
-                    root_row_num,
-                    offset_row_num,
-                    sheet_name,
-                    self_sheet_name,
-                );
-                self.formula = Some(formula);
-            }
-            None => {}
+        if let Some(v) = &self.formula {
+            let formula = adjustment_insert_formula_coordinate(
+                v,
+                root_col_num,
+                offset_col_num,
+                root_row_num,
+                offset_row_num,
+                sheet_name,
+                self_sheet_name,
+            );
+            self.formula = Some(formula);
         }
     }
 
@@ -240,20 +225,17 @@ impl CellValue {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        match &self.formula {
-            Some(v) => {
-                let formula = adjustment_remove_formula_coordinate(
-                    v,
-                    root_col_num,
-                    offset_col_num,
-                    root_row_num,
-                    offset_row_num,
-                    sheet_name,
-                    self_sheet_name,
-                );
-                self.formula = Some(formula);
-            }
-            None => {}
+        if let Some(v) = &self.formula {
+            let formula = adjustment_remove_formula_coordinate(
+                v,
+                root_col_num,
+                offset_col_num,
+                root_row_num,
+                offset_row_num,
+                sheet_name,
+                self_sheet_name,
+            );
+            self.formula = Some(formula);
         }
     }
 }

--- a/src/structs/colors.rs
+++ b/src/structs/colors.rs
@@ -48,14 +48,15 @@ impl Colors {
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
-        if !self.mru_colors.get_color().is_empty() {
-            // colors
-            write_start_tag(writer, "colors", vec![], false);
-
-            // mruColors
-            let _ = &self.mru_colors.write_to(writer);
-
-            write_end_tag(writer, "colors");
+        if self.mru_colors.get_color().is_empty() {
+            return;
         }
+        // colors
+        write_start_tag(writer, "colors", vec![], false);
+
+        // mruColors
+        let _ = &self.mru_colors.write_to(writer);
+
+        write_end_tag(writer, "colors");
     }
 }

--- a/src/structs/column_breaks.rs
+++ b/src/structs/column_breaks.rs
@@ -27,10 +27,7 @@ impl ColumnBreaks {
     }
 
     pub(crate) fn has_param(&self) -> bool {
-        if !self.break_list.is_empty() {
-            return true;
-        }
-        false
+        !self.break_list.is_empty()
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/comment.rs
+++ b/src/structs/comment.rs
@@ -91,28 +91,22 @@ impl Comment {
         if &org_col_num != self.coordinate.get_col_num() {
             self.get_anchor_mut()
                 .adjustment_insert_column(offset_col_num);
-            match self
+            if let Some(v) = self
                 .get_shape_mut()
                 .get_client_data_mut()
                 .get_comment_column_target_mut()
             {
-                Some(v) => {
-                    v.adjustment_insert_column(offset_col_num);
-                }
-                None => {}
+                v.adjustment_insert_column(offset_col_num);
             }
         }
         if &org_row_num != self.coordinate.get_row_num() {
             self.get_anchor_mut().adjustment_insert_row(offset_row_num);
-            match self
+            if let Some(v) = self
                 .get_shape_mut()
                 .get_client_data_mut()
                 .get_comment_row_target_mut()
             {
-                Some(v) => {
-                    v.adjustment_insert_row(offset_row_num);
-                }
-                None => {}
+                v.adjustment_insert_row(offset_row_num);
             }
         }
     }
@@ -135,28 +129,22 @@ impl Comment {
         if &org_col_num != self.coordinate.get_col_num() {
             self.get_anchor_mut()
                 .adjustment_remove_column(offset_col_num);
-            match self
+            if let Some(v) = self
                 .get_shape_mut()
                 .get_client_data_mut()
                 .get_comment_column_target_mut()
             {
-                Some(v) => {
-                    v.adjustment_remove_column(offset_col_num);
-                }
-                None => {}
+                v.adjustment_remove_column(offset_col_num);
             }
         }
         if &org_row_num != self.coordinate.get_row_num() {
             self.get_anchor_mut().adjustment_remove_row(offset_row_num);
-            match self
+            if let Some(v) = self
                 .get_shape_mut()
                 .get_client_data_mut()
                 .get_comment_row_target_mut()
             {
-                Some(v) => {
-                    v.adjustment_remove_row(offset_row_num);
-                }
-                None => {}
+                v.adjustment_remove_row(offset_row_num);
             }
         }
     }

--- a/src/structs/conditional_formatting_rule.rs
+++ b/src/structs/conditional_formatting_rule.rs
@@ -310,13 +310,10 @@ impl ConditionalFormattingRule {
         }
 
         let dxf_id_str: String;
-        match &self.style {
-            Some(v) => {
-                let dxf_id = differential_formats.set_style(v);
-                dxf_id_str = dxf_id.to_string();
-                attributes.push(("dxfId", &dxf_id_str));
-            }
-            None => {}
+        if let Some(v) = &self.style {
+            let dxf_id = differential_formats.set_style(v);
+            dxf_id_str = dxf_id.to_string();
+            attributes.push(("dxfId", &dxf_id_str));
         }
 
         let priority = self.priority.get_value_string();
@@ -368,27 +365,23 @@ impl ConditionalFormattingRule {
 
         if is_inner {
             // colorScale
-            match &self.color_scale {
-                Some(v) => v.write_to(writer),
-                None => {}
+            if let Some(v) = &self.color_scale {
+                v.write_to(writer)
             }
 
             // dataBar
-            match &self.data_bar {
-                Some(v) => v.write_to(writer),
-                None => {}
+            if let Some(v) = &self.data_bar {
+                v.write_to(writer)
             }
 
             // iconSet
-            match &self.icon_set {
-                Some(v) => v.write_to(writer),
-                None => {}
+            if let Some(v) = &self.icon_set {
+                v.write_to(writer)
             }
 
             // formula
-            match &self.formula {
-                Some(v) => v.write_to(writer),
-                None => {}
+            if let Some(v) = &self.formula {
+                v.write_to(writer)
             }
 
             write_end_tag(writer, "cfRule");

--- a/src/structs/conditional_formatting_rule.rs
+++ b/src/structs/conditional_formatting_rule.rs
@@ -150,8 +150,8 @@ impl ConditionalFormattingRule {
         self
     }
 
-    pub fn get_style(&self) -> &Option<Style> {
-        &self.style
+    pub fn get_style(&self) -> Option<&Style> {
+        self.style.as_ref()
     }
 
     pub fn set_style(&mut self, value: Style) -> &mut Self {
@@ -164,8 +164,8 @@ impl ConditionalFormattingRule {
         self
     }
 
-    pub fn get_color_scale(&self) -> &Option<ColorScale> {
-        &self.color_scale
+    pub fn get_color_scale(&self) -> Option<&ColorScale> {
+        self.color_scale.as_ref()
     }
 
     pub fn set_color_scale(&mut self, value: ColorScale) -> &mut Self {
@@ -178,8 +178,8 @@ impl ConditionalFormattingRule {
         self
     }
 
-    pub fn get_data_bar(&self) -> &Option<DataBar> {
-        &self.data_bar
+    pub fn get_data_bar(&self) -> Option<&DataBar> {
+        self.data_bar.as_ref()
     }
 
     pub fn set_data_bar(&mut self, value: DataBar) -> &mut Self {
@@ -192,8 +192,8 @@ impl ConditionalFormattingRule {
         self
     }
 
-    pub fn get_icon_set(&self) -> &Option<IconSet> {
-        &self.icon_set
+    pub fn get_icon_set(&self) -> Option<&IconSet> {
+        self.icon_set.as_ref()
     }
 
     pub fn set_icon_set(&mut self, value: IconSet) -> &mut Self {
@@ -206,8 +206,8 @@ impl ConditionalFormattingRule {
         self
     }
 
-    pub fn get_formula(&self) -> &Option<Formula> {
-        &self.formula
+    pub fn get_formula(&self) -> Option<&Formula> {
+        self.formula.as_ref()
     }
 
     pub fn set_formula(&mut self, value: Formula) -> &mut Self {

--- a/src/structs/coordinate.rs
+++ b/src/structs/coordinate.rs
@@ -119,12 +119,7 @@ impl Coordinate {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) -> bool {
-        if self.column.is_remove(root_col_num, offset_col_num) {
-            return true;
-        }
-        if self.row.is_remove(root_row_num, offset_row_num) {
-            return true;
-        }
-        false
+        self.column.is_remove(root_col_num, offset_col_num)
+            || self.row.is_remove(root_row_num, offset_row_num)
     }
 }

--- a/src/structs/differential_format.rs
+++ b/src/structs/differential_format.rs
@@ -176,35 +176,23 @@ impl DifferentialFormat {
         write_start_tag(writer, "dxf", vec![], false);
 
         // font
-        match &self.font {
-            Some(v) => {
-                v.write_to_font(writer);
-            }
-            None => {}
+        if let Some(v) = &self.font {
+            v.write_to_font(writer);
         }
 
         // fill
-        match &self.fill {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.fill {
+            v.write_to(writer);
         }
 
         // border
-        match &self.borders {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.borders {
+            v.write_to(writer);
         }
 
         // alignment
-        match &self.alignment {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.alignment {
+            v.write_to(writer);
         }
 
         write_end_tag(writer, "dxf");

--- a/src/structs/differential_format.rs
+++ b/src/structs/differential_format.rs
@@ -21,12 +21,12 @@ pub(crate) struct DifferentialFormat {
 }
 
 impl DifferentialFormat {
-    pub(crate) fn _get_font(&self) -> &Option<Font> {
-        &self.font
+    pub(crate) fn _get_font(&self) -> Option<&Font> {
+        self.font.as_ref()
     }
 
-    pub(crate) fn _get_font_mut(&mut self) -> &mut Option<Font> {
-        &mut self.font
+    pub(crate) fn _get_font_mut(&mut self) -> Option<&mut Font> {
+        self.font.as_mut()
     }
 
     pub(crate) fn set_font(&mut self, value: Font) -> &mut Self {
@@ -34,12 +34,12 @@ impl DifferentialFormat {
         self
     }
 
-    pub(crate) fn _get_fill(&self) -> &Option<Fill> {
-        &self.fill
+    pub(crate) fn _get_fill(&self) -> Option<&Fill> {
+        self.fill.as_ref()
     }
 
-    pub(crate) fn _get_fill_mut(&mut self) -> &mut Option<Fill> {
-        &mut self.fill
+    pub(crate) fn _get_fill_mut(&mut self) -> Option<&mut Fill> {
+        self.fill.as_mut()
     }
 
     pub(crate) fn set_fill(&mut self, value: Fill) -> &mut Self {
@@ -47,12 +47,12 @@ impl DifferentialFormat {
         self
     }
 
-    pub(crate) fn _get_borders(&self) -> &Option<Borders> {
-        &self.borders
+    pub(crate) fn _get_borders(&self) -> Option<&Borders> {
+        self.borders.as_ref()
     }
 
-    pub(crate) fn _get_borders_mut(&mut self) -> &mut Option<Borders> {
-        &mut self.borders
+    pub(crate) fn _get_borders_mut(&mut self) -> Option<&mut Borders> {
+        self.borders.as_mut()
     }
 
     pub(crate) fn set_borders(&mut self, value: Borders) -> &mut Self {
@@ -60,12 +60,12 @@ impl DifferentialFormat {
         self
     }
 
-    pub(crate) fn _get_alignment(&self) -> &Option<Alignment> {
-        &self.alignment
+    pub(crate) fn _get_alignment(&self) -> Option<&Alignment> {
+        self.alignment.as_ref()
     }
 
-    pub(crate) fn _get_alignment_mut(&mut self) -> &mut Option<Alignment> {
-        &mut self.alignment
+    pub(crate) fn _get_alignment_mut(&mut self) -> Option<&mut Alignment> {
+        self.alignment.as_mut()
     }
 
     pub(crate) fn set_alignment(&mut self, value: Alignment) -> &mut Self {

--- a/src/structs/differential_format.rs
+++ b/src/structs/differential_format.rs
@@ -83,10 +83,10 @@ impl DifferentialFormat {
     }
 
     pub(crate) fn set_style(&mut self, style: &Style) {
-        self.font = style.get_font().clone();
-        self.fill = style.get_fill().clone();
-        self.borders = style.get_borders().clone();
-        self.alignment = style.get_alignment().clone();
+        self.font = style.get_font().cloned();
+        self.fill = style.get_fill().cloned();
+        self.borders = style.get_borders().cloned();
+        self.alignment = style.get_alignment().cloned();
     }
 
     pub(crate) fn get_hash_code(&self) -> String {

--- a/src/structs/drawing/body_properties.rs
+++ b/src/structs/drawing/body_properties.rs
@@ -25,8 +25,8 @@ pub struct BodyProperties {
 }
 
 impl BodyProperties {
-    pub fn get_vert_overflow(&self) -> &Option<String> {
-        &self.vert_overflow
+    pub fn get_vert_overflow(&self) -> Option<&String> {
+        self.vert_overflow.as_ref()
     }
 
     pub fn set_vert_overflow<S: Into<String>>(&mut self, value: S) -> &mut BodyProperties {
@@ -34,8 +34,8 @@ impl BodyProperties {
         self
     }
 
-    pub fn get_horz_overflow(&self) -> &Option<String> {
-        &self.horz_overflow
+    pub fn get_horz_overflow(&self) -> Option<&String> {
+        self.horz_overflow.as_ref()
     }
 
     pub fn set_horz_overflow<S: Into<String>>(&mut self, value: S) -> &mut BodyProperties {
@@ -43,8 +43,8 @@ impl BodyProperties {
         self
     }
 
-    pub fn get_rtl_col(&self) -> &Option<String> {
-        &self.rtl_col
+    pub fn get_rtl_col(&self) -> Option<&String> {
+        self.rtl_col.as_ref()
     }
 
     pub fn set_rtl_col<S: Into<String>>(&mut self, value: S) -> &mut BodyProperties {
@@ -52,8 +52,8 @@ impl BodyProperties {
         self
     }
 
-    pub fn get_anchor(&self) -> &Option<String> {
-        &self.anchor
+    pub fn get_anchor(&self) -> Option<&String> {
+        self.anchor.as_ref()
     }
 
     pub fn set_anchor<S: Into<String>>(&mut self, value: S) -> &mut BodyProperties {
@@ -102,8 +102,8 @@ impl BodyProperties {
         self.bottom_inset.set_value(value);
     }
 
-    pub fn get_shape_auto_fit(&self) -> &Option<ShapeAutoFit> {
-        &self.shape_auto_fit
+    pub fn get_shape_auto_fit(&self) -> Option<&ShapeAutoFit> {
+        self.shape_auto_fit.as_ref()
     }
 
     pub fn set_shape_auto_fit(&mut self, value: ShapeAutoFit) -> &mut BodyProperties {
@@ -217,7 +217,7 @@ impl BodyProperties {
 
         write_start_tag(writer, "a:bodyPr", attributes, *empty_flag);
 
-        if empty_flag == &false {
+        if !*empty_flag {
             if let Some(v) = &self.shape_auto_fit {
                 v.write_to(writer);
             }

--- a/src/structs/drawing/camera.rs
+++ b/src/structs/drawing/camera.rs
@@ -25,12 +25,12 @@ impl Camera {
         self
     }
 
-    pub fn get_rotation(&self) -> &Option<Rotation> {
-        &self.rotation
+    pub fn get_rotation(&self) -> Option<&Rotation> {
+        self.rotation.as_ref()
     }
 
-    pub fn get_rotation_mut(&mut self) -> &mut Option<Rotation> {
-        &mut self.rotation
+    pub fn get_rotation_mut(&mut self) -> Option<&mut Rotation> {
+        self.rotation.as_mut()
     }
 
     pub fn set_rotation(&mut self, value: Rotation) -> &mut Self {

--- a/src/structs/drawing/charts/area_3d_chart.rs
+++ b/src/structs/drawing/charts/area_3d_chart.rs
@@ -62,12 +62,12 @@ impl Area3DChart {
         self
     }
 
-    pub fn get_data_labels(&self) -> &Option<DataLabels> {
-        &self.data_labels
+    pub fn get_data_labels(&self) -> Option<&DataLabels> {
+        self.data_labels.as_ref()
     }
 
-    pub fn get_data_labels_mut(&mut self) -> &mut Option<DataLabels> {
-        &mut self.data_labels
+    pub fn get_data_labels_mut(&mut self) -> Option<&mut DataLabels> {
+        self.data_labels.as_mut()
     }
 
     pub fn set_data_labels(&mut self, value: DataLabels) -> &mut Self {

--- a/src/structs/drawing/charts/area_chart_series.rs
+++ b/src/structs/drawing/charts/area_chart_series.rs
@@ -69,8 +69,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_series_text(&self) -> &Option<SeriesText> {
-        &self.series_text
+    pub fn get_series_text(&self) -> Option<&SeriesText> {
+        self.series_text.as_ref()
     }
 
     pub fn get_series_text_mut(&mut self) -> &mut Option<SeriesText> {
@@ -82,8 +82,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_explosion(&self) -> &Option<Explosion> {
-        &self.explosion
+    pub fn get_explosion(&self) -> Option<&Explosion> {
+        self.explosion.as_ref()
     }
 
     pub fn get_explosion_mut(&mut self) -> &mut Option<Explosion> {
@@ -95,8 +95,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_invert_if_negative(&self) -> &Option<InvertIfNegative> {
-        &self.invert_if_negative
+    pub fn get_invert_if_negative(&self) -> Option<&InvertIfNegative> {
+        self.invert_if_negative.as_ref()
     }
 
     pub fn get_invert_if_negative_mut(&mut self) -> &mut Option<InvertIfNegative> {
@@ -108,8 +108,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_marker(&self) -> &Option<Marker> {
-        &self.marker
+    pub fn get_marker(&self) -> Option<&Marker> {
+        self.marker.as_ref()
     }
 
     pub fn get_marker_mut(&mut self) -> &mut Option<Marker> {
@@ -121,8 +121,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_shape_properties(&self) -> &Option<ShapeProperties> {
-        &self.shape_properties
+    pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
+        self.shape_properties.as_ref()
     }
 
     pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
@@ -134,8 +134,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_category_axis_data(&self) -> &Option<CategoryAxisData> {
-        &self.category_axis_data
+    pub fn get_category_axis_data(&self) -> Option<&CategoryAxisData> {
+        self.category_axis_data.as_ref()
     }
 
     pub fn get_category_axis_data_mut(&mut self) -> &mut Option<CategoryAxisData> {
@@ -147,8 +147,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_values(&self) -> &Option<Values> {
-        &self.values
+    pub fn get_values(&self) -> Option<&Values> {
+        self.values.as_ref()
     }
 
     pub fn get_values_mut(&mut self) -> &mut Option<Values> {
@@ -160,8 +160,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_x_values(&self) -> &Option<XValues> {
-        &self.x_values
+    pub fn get_x_values(&self) -> Option<&XValues> {
+        self.x_values.as_ref()
     }
 
     pub fn get_x_values_mut(&mut self) -> &mut Option<XValues> {
@@ -173,8 +173,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_y_values(&self) -> &Option<YValues> {
-        &self.y_values
+    pub fn get_y_values(&self) -> Option<&YValues> {
+        self.y_values.as_ref()
     }
 
     pub fn get_y_values_mut(&mut self) -> &mut Option<YValues> {
@@ -186,8 +186,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_bubble_size(&self) -> &Option<BubbleSize> {
-        &self.bubble_size
+    pub fn get_bubble_size(&self) -> Option<&BubbleSize> {
+        self.bubble_size.as_ref()
     }
 
     pub fn get_bubble_size_mut(&mut self) -> &mut Option<BubbleSize> {
@@ -199,8 +199,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_bubble_3d(&self) -> &Option<Bubble3D> {
-        &self.bubble_3d
+    pub fn get_bubble_3d(&self) -> Option<&Bubble3D> {
+        self.bubble_3d.as_ref()
     }
 
     pub fn get_bubble_3d_mut(&mut self) -> &mut Option<Bubble3D> {
@@ -212,8 +212,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_smooth(&self) -> &Option<Smooth> {
-        &self.smooth
+    pub fn get_smooth(&self) -> Option<&Smooth> {
+        self.smooth.as_ref()
     }
 
     pub fn get_smooth_mut(&mut self) -> &mut Option<Smooth> {
@@ -225,8 +225,8 @@ impl AreaChartSeries {
         self
     }
 
-    pub fn get_data_labels(&self) -> &Option<DataLabels> {
-        &self.data_labels
+    pub fn get_data_labels(&self) -> Option<&DataLabels> {
+        self.data_labels.as_ref()
     }
 
     pub fn get_data_labels_mut(&mut self) -> &mut Option<DataLabels> {

--- a/src/structs/drawing/charts/area_chart_series.rs
+++ b/src/structs/drawing/charts/area_chart_series.rs
@@ -73,8 +73,8 @@ impl AreaChartSeries {
         self.series_text.as_ref()
     }
 
-    pub fn get_series_text_mut(&mut self) -> &mut Option<SeriesText> {
-        &mut self.series_text
+    pub fn get_series_text_mut(&mut self) -> Option<&mut SeriesText> {
+        self.series_text.as_mut()
     }
 
     pub fn set_series_text(&mut self, value: SeriesText) -> &mut Self {
@@ -86,8 +86,8 @@ impl AreaChartSeries {
         self.explosion.as_ref()
     }
 
-    pub fn get_explosion_mut(&mut self) -> &mut Option<Explosion> {
-        &mut self.explosion
+    pub fn get_explosion_mut(&mut self) -> Option<&mut Explosion> {
+        self.explosion.as_mut()
     }
 
     pub fn set_explosion(&mut self, value: Explosion) -> &mut Self {
@@ -99,8 +99,8 @@ impl AreaChartSeries {
         self.invert_if_negative.as_ref()
     }
 
-    pub fn get_invert_if_negative_mut(&mut self) -> &mut Option<InvertIfNegative> {
-        &mut self.invert_if_negative
+    pub fn get_invert_if_negative_mut(&mut self) -> Option<&mut InvertIfNegative> {
+        self.invert_if_negative.as_mut()
     }
 
     pub fn set_invert_if_negative(&mut self, value: InvertIfNegative) -> &mut Self {
@@ -112,8 +112,8 @@ impl AreaChartSeries {
         self.marker.as_ref()
     }
 
-    pub fn get_marker_mut(&mut self) -> &mut Option<Marker> {
-        &mut self.marker
+    pub fn get_marker_mut(&mut self) -> Option<&mut Marker> {
+        self.marker.as_mut()
     }
 
     pub fn set_marker(&mut self, value: Marker) -> &mut Self {
@@ -125,8 +125,8 @@ impl AreaChartSeries {
         self.shape_properties.as_ref()
     }
 
-    pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
-        &mut self.shape_properties
+    pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
+        self.shape_properties.as_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {
@@ -138,8 +138,8 @@ impl AreaChartSeries {
         self.category_axis_data.as_ref()
     }
 
-    pub fn get_category_axis_data_mut(&mut self) -> &mut Option<CategoryAxisData> {
-        &mut self.category_axis_data
+    pub fn get_category_axis_data_mut(&mut self) -> Option<&mut CategoryAxisData> {
+        self.category_axis_data.as_mut()
     }
 
     pub fn set_category_axis_data(&mut self, value: CategoryAxisData) -> &mut Self {
@@ -151,8 +151,8 @@ impl AreaChartSeries {
         self.values.as_ref()
     }
 
-    pub fn get_values_mut(&mut self) -> &mut Option<Values> {
-        &mut self.values
+    pub fn get_values_mut(&mut self) -> Option<&mut Values> {
+        self.values.as_mut()
     }
 
     pub fn set_values(&mut self, value: Values) -> &mut Self {
@@ -164,8 +164,8 @@ impl AreaChartSeries {
         self.x_values.as_ref()
     }
 
-    pub fn get_x_values_mut(&mut self) -> &mut Option<XValues> {
-        &mut self.x_values
+    pub fn get_x_values_mut(&mut self) -> Option<&mut XValues> {
+        self.x_values.as_mut()
     }
 
     pub fn set_x_values(&mut self, value: XValues) -> &mut Self {
@@ -177,8 +177,8 @@ impl AreaChartSeries {
         self.y_values.as_ref()
     }
 
-    pub fn get_y_values_mut(&mut self) -> &mut Option<YValues> {
-        &mut self.y_values
+    pub fn get_y_values_mut(&mut self) -> Option<&mut YValues> {
+        self.y_values.as_mut()
     }
 
     pub fn set_y_values(&mut self, value: YValues) -> &mut Self {
@@ -190,8 +190,8 @@ impl AreaChartSeries {
         self.bubble_size.as_ref()
     }
 
-    pub fn get_bubble_size_mut(&mut self) -> &mut Option<BubbleSize> {
-        &mut self.bubble_size
+    pub fn get_bubble_size_mut(&mut self) -> Option<&mut BubbleSize> {
+        self.bubble_size.as_mut()
     }
 
     pub fn set_bubble_size(&mut self, value: BubbleSize) -> &mut Self {
@@ -203,8 +203,8 @@ impl AreaChartSeries {
         self.bubble_3d.as_ref()
     }
 
-    pub fn get_bubble_3d_mut(&mut self) -> &mut Option<Bubble3D> {
-        &mut self.bubble_3d
+    pub fn get_bubble_3d_mut(&mut self) -> Option<&mut Bubble3D> {
+        self.bubble_3d.as_mut()
     }
 
     pub fn set_bubble_3d(&mut self, value: Bubble3D) -> &mut Self {
@@ -216,8 +216,8 @@ impl AreaChartSeries {
         self.smooth.as_ref()
     }
 
-    pub fn get_smooth_mut(&mut self) -> &mut Option<Smooth> {
-        &mut self.smooth
+    pub fn get_smooth_mut(&mut self) -> Option<&mut Smooth> {
+        self.smooth.as_mut()
     }
 
     pub fn set_smooth(&mut self, value: Smooth) -> &mut Self {
@@ -229,8 +229,8 @@ impl AreaChartSeries {
         self.data_labels.as_ref()
     }
 
-    pub fn get_data_labels_mut(&mut self) -> &mut Option<DataLabels> {
-        &mut self.data_labels
+    pub fn get_data_labels_mut(&mut self) -> Option<&mut DataLabels> {
+        self.data_labels.as_mut()
     }
 
     pub fn set_data_labels(&mut self, value: DataLabels) -> &mut Self {

--- a/src/structs/drawing/charts/back_wall.rs
+++ b/src/structs/drawing/charts/back_wall.rs
@@ -15,12 +15,12 @@ pub struct BackWall {
 }
 
 impl BackWall {
-    pub fn get_thickness(&self) -> &Option<Thickness> {
-        &self.thickness
+    pub fn get_thickness(&self) -> Option<&Thickness> {
+        self.thickness.as_ref()
     }
 
-    pub fn get_thickness_mut(&mut self) -> &mut Option<Thickness> {
-        &mut self.thickness
+    pub fn get_thickness_mut(&mut self) -> Option<&mut Thickness> {
+        self.thickness.as_mut()
     }
 
     pub fn set_thickness(&mut self, value: Thickness) -> &mut BackWall {
@@ -28,12 +28,12 @@ impl BackWall {
         self
     }
 
-    pub fn get_shape_properties(&self) -> &Option<ShapeProperties> {
-        &self.shape_properties
+    pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
+        self.shape_properties.as_ref()
     }
 
-    pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
-        &mut self.shape_properties
+    pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
+        self.shape_properties.as_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {

--- a/src/structs/drawing/charts/category_axis.rs
+++ b/src/structs/drawing/charts/category_axis.rs
@@ -98,8 +98,8 @@ impl CategoryAxis {
         self
     }
 
-    pub fn get_title(&self) -> &Option<Title> {
-        &self.title
+    pub fn get_title(&self) -> Option<&Title> {
+        self.title.as_ref()
     }
 
     pub fn get_title_mut(&mut self) -> &mut Option<Title> {
@@ -111,8 +111,8 @@ impl CategoryAxis {
         self
     }
 
-    pub fn get_major_gridlines(&self) -> &Option<MajorGridlines> {
-        &self.major_gridlines
+    pub fn get_major_gridlines(&self) -> Option<&MajorGridlines> {
+        self.major_gridlines.as_ref()
     }
 
     pub fn get_major_gridlines_mut(&mut self) -> &mut Option<MajorGridlines> {
@@ -241,8 +241,8 @@ impl CategoryAxis {
         self
     }
 
-    pub fn get_shape_properties(&self) -> &Option<ShapeProperties> {
-        &self.shape_properties
+    pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
+        self.shape_properties.as_ref()
     }
 
     pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
@@ -254,8 +254,8 @@ impl CategoryAxis {
         self
     }
 
-    pub fn get_text_properties(&self) -> &Option<TextProperties> {
-        &self.text_properties
+    pub fn get_text_properties(&self) -> Option<&TextProperties> {
+        self.text_properties.as_ref()
     }
 
     pub fn get_text_properties_mut(&mut self) -> &mut Option<TextProperties> {

--- a/src/structs/drawing/charts/category_axis.rs
+++ b/src/structs/drawing/charts/category_axis.rs
@@ -102,8 +102,8 @@ impl CategoryAxis {
         self.title.as_ref()
     }
 
-    pub fn get_title_mut(&mut self) -> &mut Option<Title> {
-        &mut self.title
+    pub fn get_title_mut(&mut self) -> Option<&mut Title> {
+        self.title.as_mut()
     }
 
     pub fn set_title(&mut self, value: Title) -> &mut Self {
@@ -115,8 +115,8 @@ impl CategoryAxis {
         self.major_gridlines.as_ref()
     }
 
-    pub fn get_major_gridlines_mut(&mut self) -> &mut Option<MajorGridlines> {
-        &mut self.major_gridlines
+    pub fn get_major_gridlines_mut(&mut self) -> Option<&mut MajorGridlines> {
+        self.major_gridlines.as_mut()
     }
 
     pub fn set_major_gridlines(&mut self, value: MajorGridlines) -> &mut Self {
@@ -245,8 +245,8 @@ impl CategoryAxis {
         self.shape_properties.as_ref()
     }
 
-    pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
-        &mut self.shape_properties
+    pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
+        self.shape_properties.as_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {
@@ -258,8 +258,8 @@ impl CategoryAxis {
         self.text_properties.as_ref()
     }
 
-    pub fn get_text_properties_mut(&mut self) -> &mut Option<TextProperties> {
-        &mut self.text_properties
+    pub fn get_text_properties_mut(&mut self) -> Option<&mut TextProperties> {
+        self.text_properties.as_mut()
     }
 
     pub fn set_text_properties(&mut self, value: TextProperties) -> &mut Self {

--- a/src/structs/drawing/charts/category_axis_data.rs
+++ b/src/structs/drawing/charts/category_axis_data.rs
@@ -16,12 +16,12 @@ pub struct CategoryAxisData {
 }
 
 impl CategoryAxisData {
-    pub fn get_string_reference(&self) -> &Option<StringReference> {
-        &self.string_reference
+    pub fn get_string_reference(&self) -> Option<&StringReference> {
+        self.string_reference.as_ref()
     }
 
-    pub fn get_string_reference_mut(&mut self) -> &mut Option<StringReference> {
-        &mut self.string_reference
+    pub fn get_string_reference_mut(&mut self) -> Option<&mut StringReference> {
+        self.string_reference.as_mut()
     }
 
     pub fn set_string_reference(&mut self, value: StringReference) -> &mut Self {
@@ -34,12 +34,12 @@ impl CategoryAxisData {
         self
     }
 
-    pub fn get_string_literal(&self) -> &Option<StringLiteral> {
-        &self.string_literal
+    pub fn get_string_literal(&self) -> Option<&StringLiteral> {
+        self.string_literal.as_ref()
     }
 
-    pub fn get_string_literal_mut(&mut self) -> &mut Option<StringLiteral> {
-        &mut self.string_literal
+    pub fn get_string_literal_mut(&mut self) -> Option<&mut StringLiteral> {
+        self.string_literal.as_mut()
     }
 
     pub fn set_string_literal(&mut self, value: StringLiteral) -> &mut Self {

--- a/src/structs/drawing/charts/chart.rs
+++ b/src/structs/drawing/charts/chart.rs
@@ -41,8 +41,8 @@ impl Chart {
         self.title.as_ref()
     }
 
-    pub fn get_title_mut(&mut self) -> &mut Option<Title> {
-        &mut self.title
+    pub fn get_title_mut(&mut self) -> Option<&mut Title> {
+        self.title.as_mut()
     }
 
     pub fn set_title(&mut self, value: Title) -> &mut Self {
@@ -67,8 +67,8 @@ impl Chart {
         self.view_3d.as_ref()
     }
 
-    pub fn get_view_3d_mut(&mut self) -> &mut Option<View3D> {
-        &mut self.view_3d
+    pub fn get_view_3d_mut(&mut self) -> Option<&mut View3D> {
+        self.view_3d.as_mut()
     }
 
     pub fn set_view_3d(&mut self, value: View3D) -> &mut Self {
@@ -80,8 +80,8 @@ impl Chart {
         self.floor.as_ref()
     }
 
-    pub fn get_floor_mut(&mut self) -> &mut Option<Floor> {
-        &mut self.floor
+    pub fn get_floor_mut(&mut self) -> Option<&mut Floor> {
+        self.floor.as_mut()
     }
 
     pub fn set_floor(&mut self, value: Floor) -> &mut Self {
@@ -93,8 +93,8 @@ impl Chart {
         self.side_wall.as_ref()
     }
 
-    pub fn get_side_wall_mut(&mut self) -> &mut Option<SideWall> {
-        &mut self.side_wall
+    pub fn get_side_wall_mut(&mut self) -> Option<&mut SideWall> {
+        self.side_wall.as_mut()
     }
 
     pub fn set_side_wall(&mut self, value: SideWall) -> &mut Self {
@@ -106,8 +106,8 @@ impl Chart {
         self.back_wall.as_ref()
     }
 
-    pub fn get_back_wall_mut(&mut self) -> &mut Option<BackWall> {
-        &mut self.back_wall
+    pub fn get_back_wall_mut(&mut self) -> Option<&mut BackWall> {
+        self.back_wall.as_mut()
     }
 
     pub fn set_back_wall(&mut self, value: BackWall) -> &mut Self {

--- a/src/structs/drawing/charts/chart.rs
+++ b/src/structs/drawing/charts/chart.rs
@@ -37,8 +37,8 @@ impl Chart {
     pub const LANG_EN_GB: &'static str = "en_GB";
     pub const LANG_JA_JP: &'static str = "ja-JP";
 
-    pub fn get_title(&self) -> &Option<Title> {
-        &self.title
+    pub fn get_title(&self) -> Option<&Title> {
+        self.title.as_ref()
     }
 
     pub fn get_title_mut(&mut self) -> &mut Option<Title> {
@@ -63,8 +63,8 @@ impl Chart {
         self
     }
 
-    pub fn get_view_3d(&self) -> &Option<View3D> {
-        &self.view_3d
+    pub fn get_view_3d(&self) -> Option<&View3D> {
+        self.view_3d.as_ref()
     }
 
     pub fn get_view_3d_mut(&mut self) -> &mut Option<View3D> {
@@ -76,8 +76,8 @@ impl Chart {
         self
     }
 
-    pub fn get_floor(&self) -> &Option<Floor> {
-        &self.floor
+    pub fn get_floor(&self) -> Option<&Floor> {
+        self.floor.as_ref()
     }
 
     pub fn get_floor_mut(&mut self) -> &mut Option<Floor> {
@@ -89,8 +89,8 @@ impl Chart {
         self
     }
 
-    pub fn get_side_wall(&self) -> &Option<SideWall> {
-        &self.side_wall
+    pub fn get_side_wall(&self) -> Option<&SideWall> {
+        self.side_wall.as_ref()
     }
 
     pub fn get_side_wall_mut(&mut self) -> &mut Option<SideWall> {
@@ -102,8 +102,8 @@ impl Chart {
         self
     }
 
-    pub fn get_back_wall(&self) -> &Option<BackWall> {
-        &self.back_wall
+    pub fn get_back_wall(&self) -> Option<&BackWall> {
+        self.back_wall.as_ref()
     }
 
     pub fn get_back_wall_mut(&mut self) -> &mut Option<BackWall> {

--- a/src/structs/drawing/charts/chart_space.rs
+++ b/src/structs/drawing/charts/chart_space.rs
@@ -93,12 +93,12 @@ impl ChartSpace {
         self
     }
 
-    pub fn get_shape_properties(&self) -> &Option<ShapeProperties> {
-        &self.shape_properties
+    pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
+        self.shape_properties.as_ref()
     }
 
-    pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
-        &mut self.shape_properties
+    pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
+        self.shape_properties.as_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {
@@ -106,12 +106,12 @@ impl ChartSpace {
         self
     }
 
-    pub fn get_print_settings(&self) -> &Option<PrintSettings> {
-        &self.print_settings
+    pub fn get_print_settings(&self) -> Option<&PrintSettings> {
+        self.print_settings.as_ref()
     }
 
-    pub fn get_print_settings_mut(&mut self) -> &mut Option<PrintSettings> {
-        &mut self.print_settings
+    pub fn get_print_settings_mut(&mut self) -> Option<&mut PrintSettings> {
+        self.print_settings.as_mut()
     }
 
     pub fn set_print_settings(&mut self, value: PrintSettings) -> &mut Self {

--- a/src/structs/drawing/charts/data_labels.rs
+++ b/src/structs/drawing/charts/data_labels.rs
@@ -105,12 +105,12 @@ impl DataLabels {
         self
     }
 
-    pub fn get_show_leader_lines(&self) -> &Option<ShowLeaderLines> {
-        &self.show_leader_lines
+    pub fn get_show_leader_lines(&self) -> Option<&ShowLeaderLines> {
+        self.show_leader_lines.as_ref()
     }
 
-    pub fn get_show_leader_lines_mut(&mut self) -> &mut Option<ShowLeaderLines> {
-        &mut self.show_leader_lines
+    pub fn get_show_leader_lines_mut(&mut self) -> Option<&mut ShowLeaderLines> {
+        self.show_leader_lines.as_mut()
     }
 
     pub fn set_show_leader_lines(&mut self, value: ShowLeaderLines) -> &mut Self {
@@ -118,12 +118,12 @@ impl DataLabels {
         self
     }
 
-    pub fn get_text_properties(&self) -> &Option<TextProperties> {
-        &self.text_properties
+    pub fn get_text_properties(&self) -> Option<&TextProperties> {
+        self.text_properties.as_ref()
     }
 
-    pub fn get_text_properties_mut(&mut self) -> &mut Option<TextProperties> {
-        &mut self.text_properties
+    pub fn get_text_properties_mut(&mut self) -> Option<&mut TextProperties> {
+        self.text_properties.as_mut()
     }
 
     pub fn set_text_properties(&mut self, value: TextProperties) -> &mut Self {

--- a/src/structs/drawing/charts/floor.rs
+++ b/src/structs/drawing/charts/floor.rs
@@ -15,12 +15,12 @@ pub struct Floor {
 }
 
 impl Floor {
-    pub fn get_thickness(&self) -> &Option<Thickness> {
-        &self.thickness
+    pub fn get_thickness(&self) -> Option<&Thickness> {
+        self.thickness.as_ref()
     }
 
-    pub fn get_thickness_mut(&mut self) -> &mut Option<Thickness> {
-        &mut self.thickness
+    pub fn get_thickness_mut(&mut self) -> Option<&mut Thickness> {
+        self.thickness.as_mut()
     }
 
     pub fn set_thickness(&mut self, value: Thickness) -> &mut Floor {
@@ -28,12 +28,12 @@ impl Floor {
         self
     }
 
-    pub fn get_shape_properties(&self) -> &Option<ShapeProperties> {
-        &self.shape_properties
+    pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
+        self.shape_properties.as_ref()
     }
 
-    pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
-        &mut self.shape_properties
+    pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
+        self.shape_properties.as_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {

--- a/src/structs/drawing/charts/layout.rs
+++ b/src/structs/drawing/charts/layout.rs
@@ -13,12 +13,12 @@ pub struct Layout {
 }
 
 impl Layout {
-    pub fn get_manual_layout(&self) -> &Option<ManualLayout> {
-        &self.manual_layout
+    pub fn get_manual_layout(&self) -> Option<&ManualLayout> {
+        self.manual_layout.as_ref()
     }
 
-    pub fn get_manual_layout_mut(&mut self) -> &mut Option<ManualLayout> {
-        &mut self.manual_layout
+    pub fn get_manual_layout_mut(&mut self) -> Option<&mut ManualLayout> {
+        self.manual_layout.as_mut()
     }
 
     pub fn set_manual_layout(&mut self, value: ManualLayout) -> &mut Layout {

--- a/src/structs/drawing/charts/legend.rs
+++ b/src/structs/drawing/charts/legend.rs
@@ -34,12 +34,12 @@ impl Legend {
         self
     }
 
-    pub fn get_layout(&self) -> &Option<Layout> {
-        &self.layout
+    pub fn get_layout(&self) -> Option<&Layout> {
+        self.layout.as_ref()
     }
 
-    pub fn get_layout_mut(&mut self) -> &mut Option<Layout> {
-        &mut self.layout
+    pub fn get_layout_mut(&mut self) -> Option<&mut Layout> {
+        self.layout.as_mut()
     }
 
     pub fn set_layout(&mut self, value: Layout) -> &mut Self {
@@ -60,12 +60,12 @@ impl Legend {
         self
     }
 
-    pub fn get_shape_properties(&self) -> &Option<ShapeProperties> {
-        &self.shape_properties
+    pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
+        self.shape_properties.as_ref()
     }
 
-    pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
-        &mut self.shape_properties
+    pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
+        self.shape_properties.as_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {
@@ -73,12 +73,12 @@ impl Legend {
         self
     }
 
-    pub fn get_text_properties(&self) -> &Option<TextProperties> {
-        &self.text_properties
+    pub fn get_text_properties(&self) -> Option<&TextProperties> {
+        self.text_properties.as_ref()
     }
 
-    pub fn get_text_properties_mut(&mut self) -> &mut Option<TextProperties> {
-        &mut self.text_properties
+    pub fn get_text_properties_mut(&mut self) -> Option<&mut TextProperties> {
+        self.text_properties.as_mut()
     }
 
     pub fn set_text_properties(&mut self, value: TextProperties) -> &mut Self {

--- a/src/structs/drawing/charts/major_gridlines.rs
+++ b/src/structs/drawing/charts/major_gridlines.rs
@@ -59,19 +59,19 @@ impl MajorGridlines {
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
-        if self.with_include() {
-            // c:majorGridlines
-            write_start_tag(writer, "c:majorGridlines", vec![], false);
-
-            // c:spPr
-            if let Some(v) = &self.shape_properties {
-                v.write_to(writer);
-            }
-
-            write_end_tag(writer, "c:majorGridlines");
-        } else {
+        if !self.with_include() {
             // c:majorGridlines
             write_start_tag(writer, "c:majorGridlines", vec![], true);
+            return;
         }
+        // c:majorGridlines
+        write_start_tag(writer, "c:majorGridlines", vec![], false);
+
+        // c:spPr
+        if let Some(v) = &self.shape_properties {
+            v.write_to(writer);
+        }
+
+        write_end_tag(writer, "c:majorGridlines");
     }
 }

--- a/src/structs/drawing/charts/major_gridlines.rs
+++ b/src/structs/drawing/charts/major_gridlines.rs
@@ -17,8 +17,8 @@ impl MajorGridlines {
         self.shape_properties.as_ref()
     }
 
-    pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
-        &mut self.shape_properties
+    pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
+        self.shape_properties.as_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {

--- a/src/structs/drawing/charts/major_gridlines.rs
+++ b/src/structs/drawing/charts/major_gridlines.rs
@@ -13,8 +13,8 @@ pub struct MajorGridlines {
 }
 
 impl MajorGridlines {
-    pub fn get_shape_properties(&self) -> &Option<ShapeProperties> {
-        &self.shape_properties
+    pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
+        self.shape_properties.as_ref()
     }
 
     pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
@@ -55,10 +55,7 @@ impl MajorGridlines {
     }
 
     fn with_include(&self) -> bool {
-        if self.shape_properties.is_some() {
-            return true;
-        }
-        false
+        self.shape_properties.is_some()
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/charts/manual_layout.rs
+++ b/src/structs/drawing/charts/manual_layout.rs
@@ -29,8 +29,8 @@ pub struct ManualLayout {
 }
 
 impl ManualLayout {
-    pub fn get_height(&self) -> &Option<Height> {
-        &self.height
+    pub fn get_height(&self) -> Option<&Height> {
+        self.height.as_ref()
     }
 
     pub fn get_height_mut(&mut self) -> &mut Option<Height> {
@@ -42,8 +42,8 @@ impl ManualLayout {
         self
     }
 
-    pub fn get_height_mode(&self) -> &Option<HeightMode> {
-        &self.height_mode
+    pub fn get_height_mode(&self) -> Option<&HeightMode> {
+        self.height_mode.as_ref()
     }
 
     pub fn get_height_mode_mut(&mut self) -> &mut Option<HeightMode> {
@@ -55,8 +55,8 @@ impl ManualLayout {
         self
     }
 
-    pub fn get_layout_target(&self) -> &Option<LayoutTarget> {
-        &self.layout_target
+    pub fn get_layout_target(&self) -> Option<&LayoutTarget> {
+        self.layout_target.as_ref()
     }
 
     pub fn get_layout_target_mut(&mut self) -> &mut Option<LayoutTarget> {
@@ -68,8 +68,8 @@ impl ManualLayout {
         self
     }
 
-    pub fn get_left(&self) -> &Option<Left> {
-        &self.left
+    pub fn get_left(&self) -> Option<&Left> {
+        self.left.as_ref()
     }
 
     pub fn get_left_mut(&mut self) -> &mut Option<Left> {
@@ -81,8 +81,8 @@ impl ManualLayout {
         self
     }
 
-    pub fn get_left_mode(&self) -> &Option<LeftMode> {
-        &self.left_mode
+    pub fn get_left_mode(&self) -> Option<&LeftMode> {
+        self.left_mode.as_ref()
     }
 
     pub fn get_left_mode_mut(&mut self) -> &mut Option<LeftMode> {
@@ -94,8 +94,8 @@ impl ManualLayout {
         self
     }
 
-    pub fn get_top(&self) -> &Option<Top> {
-        &self.top
+    pub fn get_top(&self) -> Option<&Top> {
+        self.top.as_ref()
     }
 
     pub fn get_top_mut(&mut self) -> &mut Option<Top> {
@@ -107,8 +107,8 @@ impl ManualLayout {
         self
     }
 
-    pub fn get_top_mode(&self) -> &Option<TopMode> {
-        &self.top_mode
+    pub fn get_top_mode(&self) -> Option<&TopMode> {
+        self.top_mode.as_ref()
     }
 
     pub fn get_top_mode_mut(&mut self) -> &mut Option<TopMode> {
@@ -120,8 +120,8 @@ impl ManualLayout {
         self
     }
 
-    pub fn get_width(&self) -> &Option<Width> {
-        &self.width
+    pub fn get_width(&self) -> Option<&Width> {
+        self.width.as_ref()
     }
 
     pub fn get_width_mut(&mut self) -> &mut Option<Width> {
@@ -133,8 +133,8 @@ impl ManualLayout {
         self
     }
 
-    pub fn get_width_mode(&self) -> &Option<WidthMode> {
-        &self.width_mode
+    pub fn get_width_mode(&self) -> Option<&WidthMode> {
+        self.width_mode.as_ref()
     }
 
     pub fn get_width_mode_mut(&mut self) -> &mut Option<WidthMode> {
@@ -147,7 +147,7 @@ impl ManualLayout {
     }
 
     pub fn is_empty(&self) -> bool {
-        if self.height.is_none()
+        self.height.is_none()
             && self.height_mode.is_none()
             && self.layout_target.is_none()
             && self.left.is_none()
@@ -156,11 +156,6 @@ impl ManualLayout {
             && self.top_mode.is_none()
             && self.width.is_none()
             && self.width_mode.is_none()
-        {
-            return true;
-        }
-
-        false
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/charts/manual_layout.rs
+++ b/src/structs/drawing/charts/manual_layout.rs
@@ -33,8 +33,8 @@ impl ManualLayout {
         self.height.as_ref()
     }
 
-    pub fn get_height_mut(&mut self) -> &mut Option<Height> {
-        &mut self.height
+    pub fn get_height_mut(&mut self) -> Option<&mut Height> {
+        self.height.as_mut()
     }
 
     pub fn set_height(&mut self, value: Height) -> &mut ManualLayout {
@@ -46,8 +46,8 @@ impl ManualLayout {
         self.height_mode.as_ref()
     }
 
-    pub fn get_height_mode_mut(&mut self) -> &mut Option<HeightMode> {
-        &mut self.height_mode
+    pub fn get_height_mode_mut(&mut self) -> Option<&mut HeightMode> {
+        self.height_mode.as_mut()
     }
 
     pub fn set_height_mode(&mut self, value: HeightMode) -> &mut ManualLayout {
@@ -59,8 +59,8 @@ impl ManualLayout {
         self.layout_target.as_ref()
     }
 
-    pub fn get_layout_target_mut(&mut self) -> &mut Option<LayoutTarget> {
-        &mut self.layout_target
+    pub fn get_layout_target_mut(&mut self) -> Option<&mut LayoutTarget> {
+        self.layout_target.as_mut()
     }
 
     pub fn set_layout_target(&mut self, value: LayoutTarget) -> &mut ManualLayout {
@@ -72,8 +72,8 @@ impl ManualLayout {
         self.left.as_ref()
     }
 
-    pub fn get_left_mut(&mut self) -> &mut Option<Left> {
-        &mut self.left
+    pub fn get_left_mut(&mut self) -> Option<&mut Left> {
+        self.left.as_mut()
     }
 
     pub fn set_left(&mut self, value: Left) -> &mut ManualLayout {
@@ -85,8 +85,8 @@ impl ManualLayout {
         self.left_mode.as_ref()
     }
 
-    pub fn get_left_mode_mut(&mut self) -> &mut Option<LeftMode> {
-        &mut self.left_mode
+    pub fn get_left_mode_mut(&mut self) -> Option<&mut LeftMode> {
+        self.left_mode.as_mut()
     }
 
     pub fn set_left_mode(&mut self, value: LeftMode) -> &mut ManualLayout {
@@ -98,8 +98,8 @@ impl ManualLayout {
         self.top.as_ref()
     }
 
-    pub fn get_top_mut(&mut self) -> &mut Option<Top> {
-        &mut self.top
+    pub fn get_top_mut(&mut self) -> Option<&mut Top> {
+        self.top.as_mut()
     }
 
     pub fn set_top(&mut self, value: Top) -> &mut ManualLayout {
@@ -111,8 +111,8 @@ impl ManualLayout {
         self.top_mode.as_ref()
     }
 
-    pub fn get_top_mode_mut(&mut self) -> &mut Option<TopMode> {
-        &mut self.top_mode
+    pub fn get_top_mode_mut(&mut self) -> Option<&mut TopMode> {
+        self.top_mode.as_mut()
     }
 
     pub fn set_top_mode(&mut self, value: TopMode) -> &mut ManualLayout {
@@ -124,8 +124,8 @@ impl ManualLayout {
         self.width.as_ref()
     }
 
-    pub fn get_width_mut(&mut self) -> &mut Option<Width> {
-        &mut self.width
+    pub fn get_width_mut(&mut self) -> Option<&mut Width> {
+        self.width.as_mut()
     }
 
     pub fn set_width(&mut self, value: Width) -> &mut ManualLayout {
@@ -137,8 +137,8 @@ impl ManualLayout {
         self.width_mode.as_ref()
     }
 
-    pub fn get_width_mode_mut(&mut self) -> &mut Option<WidthMode> {
-        &mut self.width_mode
+    pub fn get_width_mode_mut(&mut self) -> Option<&mut WidthMode> {
+        self.width_mode.as_mut()
     }
 
     pub fn set_width_mode(&mut self, value: WidthMode) -> &mut ManualLayout {

--- a/src/structs/drawing/charts/marker.rs
+++ b/src/structs/drawing/charts/marker.rs
@@ -13,12 +13,12 @@ pub struct Marker {
 }
 
 impl Marker {
-    pub fn get_symbol(&self) -> &Option<Symbol> {
-        &self.symbol
+    pub fn get_symbol(&self) -> Option<&Symbol> {
+        self.symbol.as_ref()
     }
 
-    pub fn get_symbol_mut(&mut self) -> &mut Option<Symbol> {
-        &mut self.symbol
+    pub fn get_symbol_mut(&mut self) -> Option<&mut Symbol> {
+        self.symbol.as_mut()
     }
 
     pub fn set_symbol(&mut self, value: Symbol) -> &mut Marker {

--- a/src/structs/drawing/charts/plot_area.rs
+++ b/src/structs/drawing/charts/plot_area.rs
@@ -64,12 +64,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_line_chart(&self) -> &Option<LineChart> {
-        &self.line_chart
+    pub fn get_line_chart(&self) -> Option<&LineChart> {
+        self.line_chart.as_ref()
     }
 
-    pub fn get_line_chart_mut(&mut self) -> &mut Option<LineChart> {
-        &mut self.line_chart
+    pub fn get_line_chart_mut(&mut self) -> Option<&mut LineChart> {
+        self.line_chart.as_mut()
     }
 
     pub fn set_line_chart(&mut self, value: LineChart) -> &mut Self {
@@ -77,12 +77,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_line_3d_chart(&self) -> &Option<Line3DChart> {
-        &self.line_3d_chart
+    pub fn get_line_3d_chart(&self) -> Option<&Line3DChart> {
+        self.line_3d_chart.as_ref()
     }
 
-    pub fn get_line_3d_chart_mut(&mut self) -> &mut Option<Line3DChart> {
-        &mut self.line_3d_chart
+    pub fn get_line_3d_chart_mut(&mut self) -> Option<&mut Line3DChart> {
+        self.line_3d_chart.as_mut()
     }
 
     pub fn set_line_3d_chart(&mut self, value: Line3DChart) -> &mut Self {
@@ -90,12 +90,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_pie_chart(&self) -> &Option<PieChart> {
-        &self.pie_chart
+    pub fn get_pie_chart(&self) -> Option<&PieChart> {
+        self.pie_chart.as_ref()
     }
 
-    pub fn get_pie_chart_mut(&mut self) -> &mut Option<PieChart> {
-        &mut self.pie_chart
+    pub fn get_pie_chart_mut(&mut self) -> Option<&mut PieChart> {
+        self.pie_chart.as_mut()
     }
 
     pub fn set_pie_chart(&mut self, value: PieChart) -> &mut Self {
@@ -103,12 +103,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_pie_3d_chart(&self) -> &Option<Pie3DChart> {
-        &self.pie_3d_chart
+    pub fn get_pie_3d_chart(&self) -> Option<&Pie3DChart> {
+        self.pie_3d_chart.as_ref()
     }
 
-    pub fn get_pie_3d_chart_mut(&mut self) -> &mut Option<Pie3DChart> {
-        &mut self.pie_3d_chart
+    pub fn get_pie_3d_chart_mut(&mut self) -> Option<&mut Pie3DChart> {
+        self.pie_3d_chart.as_mut()
     }
 
     pub fn set_pie_3d_chart(&mut self, value: Pie3DChart) -> &mut Self {
@@ -116,12 +116,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_doughnut_chart(&self) -> &Option<DoughnutChart> {
-        &self.doughnut_chart
+    pub fn get_doughnut_chart(&self) -> Option<&DoughnutChart> {
+        self.doughnut_chart.as_ref()
     }
 
-    pub fn get_doughnut_chart_mut(&mut self) -> &mut Option<DoughnutChart> {
-        &mut self.doughnut_chart
+    pub fn get_doughnut_chart_mut(&mut self) -> Option<&mut DoughnutChart> {
+        self.doughnut_chart.as_mut()
     }
 
     pub fn set_doughnut_chart(&mut self, value: DoughnutChart) -> &mut Self {
@@ -129,12 +129,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_scatter_chart(&self) -> &Option<ScatterChart> {
-        &self.scatter_chart
+    pub fn get_scatter_chart(&self) -> Option<&ScatterChart> {
+        self.scatter_chart.as_ref()
     }
 
-    pub fn get_scatter_chart_mut(&mut self) -> &mut Option<ScatterChart> {
-        &mut self.scatter_chart
+    pub fn get_scatter_chart_mut(&mut self) -> Option<&mut ScatterChart> {
+        self.scatter_chart.as_mut()
     }
 
     pub fn set_scatter_chart(&mut self, value: ScatterChart) -> &mut Self {
@@ -142,12 +142,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_bar_chart(&self) -> &Option<BarChart> {
-        &self.bar_chart
+    pub fn get_bar_chart(&self) -> Option<&BarChart> {
+        self.bar_chart.as_ref()
     }
 
-    pub fn get_bar_chart_mut(&mut self) -> &mut Option<BarChart> {
-        &mut self.bar_chart
+    pub fn get_bar_chart_mut(&mut self) -> Option<&mut BarChart> {
+        self.bar_chart.as_mut()
     }
 
     pub fn set_bar_chart(&mut self, value: BarChart) -> &mut Self {
@@ -155,12 +155,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_bar_3d_chart(&self) -> &Option<Bar3DChart> {
-        &self.bar_3d_chart
+    pub fn get_bar_3d_chart(&self) -> Option<&Bar3DChart> {
+        self.bar_3d_chart.as_ref()
     }
 
-    pub fn get_bar_3d_chart_mut(&mut self) -> &mut Option<Bar3DChart> {
-        &mut self.bar_3d_chart
+    pub fn get_bar_3d_chart_mut(&mut self) -> Option<&mut Bar3DChart> {
+        self.bar_3d_chart.as_mut()
     }
 
     pub fn set_bar_3d_chart(&mut self, value: Bar3DChart) -> &mut Self {
@@ -168,12 +168,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_radar_chart(&self) -> &Option<RadarChart> {
-        &self.radar_chart
+    pub fn get_radar_chart(&self) -> Option<&RadarChart> {
+        self.radar_chart.as_ref()
     }
 
-    pub fn get_radar_chart_mut(&mut self) -> &mut Option<RadarChart> {
-        &mut self.radar_chart
+    pub fn get_radar_chart_mut(&mut self) -> Option<&mut RadarChart> {
+        self.radar_chart.as_mut()
     }
 
     pub fn set_radar_chart(&mut self, value: RadarChart) -> &mut Self {
@@ -181,12 +181,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_bubble_chart(&self) -> &Option<BubbleChart> {
-        &self.bubble_chart
+    pub fn get_bubble_chart(&self) -> Option<&BubbleChart> {
+        self.bubble_chart.as_ref()
     }
 
-    pub fn get_bubble_chart_mut(&mut self) -> &mut Option<BubbleChart> {
-        &mut self.bubble_chart
+    pub fn get_bubble_chart_mut(&mut self) -> Option<&mut BubbleChart> {
+        self.bubble_chart.as_mut()
     }
 
     pub fn set_bubble_chart(&mut self, value: BubbleChart) -> &mut Self {
@@ -194,12 +194,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_area_chart(&self) -> &Option<AreaChart> {
-        &self.area_chart
+    pub fn get_area_chart(&self) -> Option<&AreaChart> {
+        self.area_chart.as_ref()
     }
 
-    pub fn get_area_chart_mut(&mut self) -> &mut Option<AreaChart> {
-        &mut self.area_chart
+    pub fn get_area_chart_mut(&mut self) -> Option<&mut AreaChart> {
+        self.area_chart.as_mut()
     }
 
     pub fn set_area_chart(&mut self, value: AreaChart) -> &mut Self {
@@ -207,12 +207,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_area_3d_chart(&self) -> &Option<Area3DChart> {
-        &self.area_3d_chart
+    pub fn get_area_3d_chart(&self) -> Option<&Area3DChart> {
+        self.area_3d_chart.as_ref()
     }
 
-    pub fn get_area_3d_chart_mut(&mut self) -> &mut Option<Area3DChart> {
-        &mut self.area_3d_chart
+    pub fn get_area_3d_chart_mut(&mut self) -> Option<&mut Area3DChart> {
+        self.area_3d_chart.as_mut()
     }
 
     pub fn set_area_3d_chart(&mut self, value: Area3DChart) -> &mut Self {
@@ -220,12 +220,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_of_pie_chart(&self) -> &Option<OfPieChart> {
-        &self.of_pie_chart
+    pub fn get_of_pie_chart(&self) -> Option<&OfPieChart> {
+        self.of_pie_chart.as_ref()
     }
 
-    pub fn get_of_pie_chart_mut(&mut self) -> &mut Option<OfPieChart> {
-        &mut self.of_pie_chart
+    pub fn get_of_pie_chart_mut(&mut self) -> Option<&mut OfPieChart> {
+        self.of_pie_chart.as_mut()
     }
 
     pub fn set_of_pie_chart(&mut self, value: OfPieChart) -> &mut Self {
@@ -287,12 +287,12 @@ impl PlotArea {
         self
     }
 
-    pub fn get_shape_properties(&self) -> &Option<ShapeProperties> {
-        &self.shape_properties
+    pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
+        self.shape_properties.as_ref()
     }
 
-    pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
-        &mut self.shape_properties
+    pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
+        self.shape_properties.as_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {

--- a/src/structs/drawing/charts/series_axis.rs
+++ b/src/structs/drawing/charts/series_axis.rs
@@ -85,12 +85,12 @@ impl SeriesAxis {
         self
     }
 
-    pub fn get_major_gridlines(&self) -> &Option<MajorGridlines> {
-        &self.major_gridlines
+    pub fn get_major_gridlines(&self) -> Option<&MajorGridlines> {
+        self.major_gridlines.as_ref()
     }
 
-    pub fn get_major_gridlines_mut(&mut self) -> &mut Option<MajorGridlines> {
-        &mut self.major_gridlines
+    pub fn get_major_gridlines_mut(&mut self) -> Option<&mut MajorGridlines> {
+        self.major_gridlines.as_mut()
     }
 
     pub fn set_major_gridlines(&mut self, value: MajorGridlines) -> &mut SeriesAxis {
@@ -98,12 +98,12 @@ impl SeriesAxis {
         self
     }
 
-    pub fn get_title(&self) -> &Option<Title> {
-        &self.title
+    pub fn get_title(&self) -> Option<&Title> {
+        self.title.as_ref()
     }
 
-    pub fn get_title_mut(&mut self) -> &mut Option<Title> {
-        &mut self.title
+    pub fn get_title_mut(&mut self) -> Option<&mut Title> {
+        self.title.as_mut()
     }
 
     pub fn set_title(&mut self, value: Title) -> &mut SeriesAxis {

--- a/src/structs/drawing/charts/shape_properties.rs
+++ b/src/structs/drawing/charts/shape_properties.rs
@@ -33,8 +33,8 @@ impl ShapeProperties {
         self.pattern_fill.as_ref()
     }
 
-    pub fn get_pattern_fill_mut(&mut self) -> &mut Option<PatternFill> {
-        &mut self.pattern_fill
+    pub fn get_pattern_fill_mut(&mut self) -> Option<&mut PatternFill> {
+        self.pattern_fill.as_mut()
     }
 
     pub fn set_pattern_fill(&mut self, value: PatternFill) -> &mut Self {
@@ -46,8 +46,8 @@ impl ShapeProperties {
         self.transform2d.as_ref()
     }
 
-    pub fn get_transform2d_mut(&mut self) -> &mut Option<Transform2D> {
-        &mut self.transform2d
+    pub fn get_transform2d_mut(&mut self) -> Option<&mut Transform2D> {
+        self.transform2d.as_mut()
     }
 
     pub fn set_transform2d(&mut self, value: Transform2D) -> &mut Self {
@@ -59,8 +59,8 @@ impl ShapeProperties {
         self.preset_geometry.as_ref()
     }
 
-    pub fn get_geometry_mut(&mut self) -> &mut Option<PresetGeometry> {
-        &mut self.preset_geometry
+    pub fn get_geometry_mut(&mut self) -> Option<&mut PresetGeometry> {
+        self.preset_geometry.as_mut()
     }
 
     pub fn set_geometry(&mut self, value: PresetGeometry) -> &mut Self {
@@ -72,8 +72,8 @@ impl ShapeProperties {
         self.solid_fill.as_ref()
     }
 
-    pub fn get_solid_fill_mut(&mut self) -> &mut Option<SolidFill> {
-        &mut self.solid_fill
+    pub fn get_solid_fill_mut(&mut self) -> Option<&mut SolidFill> {
+        self.solid_fill.as_mut()
     }
 
     pub fn set_solid_fill(&mut self, value: SolidFill) -> &mut Self {
@@ -85,8 +85,8 @@ impl ShapeProperties {
         self.no_fill.as_ref()
     }
 
-    pub fn get_no_fill_mut(&mut self) -> &mut Option<NoFill> {
-        &mut self.no_fill
+    pub fn get_no_fill_mut(&mut self) -> Option<&mut NoFill> {
+        self.no_fill.as_mut()
     }
 
     pub fn set_no_fill(&mut self, value: NoFill) -> &mut Self {
@@ -98,8 +98,8 @@ impl ShapeProperties {
         self.outline.as_ref()
     }
 
-    pub fn get_outline_mut(&mut self) -> &mut Option<Outline> {
-        &mut self.outline
+    pub fn get_outline_mut(&mut self) -> Option<&mut Outline> {
+        self.outline.as_mut()
     }
 
     pub fn set_outline(&mut self, value: Outline) -> &mut Self {
@@ -111,8 +111,8 @@ impl ShapeProperties {
         self.effect_list.as_ref()
     }
 
-    pub fn get_effect_list_mut(&mut self) -> &mut Option<EffectList> {
-        &mut self.effect_list
+    pub fn get_effect_list_mut(&mut self) -> Option<&mut EffectList> {
+        self.effect_list.as_mut()
     }
 
     pub fn set_effect_list(&mut self, value: EffectList) -> &mut Self {
@@ -124,8 +124,8 @@ impl ShapeProperties {
         self.scene_3d_type.as_ref()
     }
 
-    pub fn get_scene_3d_type_mut(&mut self) -> &mut Option<Scene3DType> {
-        &mut self.scene_3d_type
+    pub fn get_scene_3d_type_mut(&mut self) -> Option<&mut Scene3DType> {
+        self.scene_3d_type.as_mut()
     }
 
     pub fn set_scene_3d_type(&mut self, value: Scene3DType) -> &mut Self {
@@ -137,8 +137,8 @@ impl ShapeProperties {
         self.shape_3d_type.as_ref()
     }
 
-    pub fn get_shape_3d_type_mut(&mut self) -> &mut Option<Shape3DType> {
-        &mut self.shape_3d_type
+    pub fn get_shape_3d_type_mut(&mut self) -> Option<&mut Shape3DType> {
+        self.shape_3d_type.as_mut()
     }
 
     pub fn set_shape_3d_type(&mut self, value: Shape3DType) -> &mut Self {

--- a/src/structs/drawing/charts/shape_properties.rs
+++ b/src/structs/drawing/charts/shape_properties.rs
@@ -29,8 +29,8 @@ pub struct ShapeProperties {
 }
 
 impl ShapeProperties {
-    pub fn get_pattern_fill(&self) -> &Option<PatternFill> {
-        &self.pattern_fill
+    pub fn get_pattern_fill(&self) -> Option<&PatternFill> {
+        self.pattern_fill.as_ref()
     }
 
     pub fn get_pattern_fill_mut(&mut self) -> &mut Option<PatternFill> {
@@ -42,8 +42,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_transform2d(&self) -> &Option<Transform2D> {
-        &self.transform2d
+    pub fn get_transform2d(&self) -> Option<&Transform2D> {
+        self.transform2d.as_ref()
     }
 
     pub fn get_transform2d_mut(&mut self) -> &mut Option<Transform2D> {
@@ -55,8 +55,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_geometry(&self) -> &Option<PresetGeometry> {
-        &self.preset_geometry
+    pub fn get_geometry(&self) -> Option<&PresetGeometry> {
+        self.preset_geometry.as_ref()
     }
 
     pub fn get_geometry_mut(&mut self) -> &mut Option<PresetGeometry> {
@@ -68,8 +68,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_solid_fill(&self) -> &Option<SolidFill> {
-        &self.solid_fill
+    pub fn get_solid_fill(&self) -> Option<&SolidFill> {
+        self.solid_fill.as_ref()
     }
 
     pub fn get_solid_fill_mut(&mut self) -> &mut Option<SolidFill> {
@@ -81,8 +81,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_no_fill(&self) -> &Option<NoFill> {
-        &self.no_fill
+    pub fn get_no_fill(&self) -> Option<&NoFill> {
+        self.no_fill.as_ref()
     }
 
     pub fn get_no_fill_mut(&mut self) -> &mut Option<NoFill> {
@@ -94,8 +94,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_outline(&self) -> &Option<Outline> {
-        &self.outline
+    pub fn get_outline(&self) -> Option<&Outline> {
+        self.outline.as_ref()
     }
 
     pub fn get_outline_mut(&mut self) -> &mut Option<Outline> {
@@ -107,8 +107,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_effect_list(&self) -> &Option<EffectList> {
-        &self.effect_list
+    pub fn get_effect_list(&self) -> Option<&EffectList> {
+        self.effect_list.as_ref()
     }
 
     pub fn get_effect_list_mut(&mut self) -> &mut Option<EffectList> {
@@ -120,8 +120,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_scene_3d_type(&self) -> &Option<Scene3DType> {
-        &self.scene_3d_type
+    pub fn get_scene_3d_type(&self) -> Option<&Scene3DType> {
+        self.scene_3d_type.as_ref()
     }
 
     pub fn get_scene_3d_type_mut(&mut self) -> &mut Option<Scene3DType> {
@@ -133,8 +133,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_shape_3d_type(&self) -> &Option<Shape3DType> {
-        &self.shape_3d_type
+    pub fn get_shape_3d_type(&self) -> Option<&Shape3DType> {
+        self.shape_3d_type.as_ref()
     }
 
     pub fn get_shape_3d_type_mut(&mut self) -> &mut Option<Shape3DType> {

--- a/src/structs/drawing/charts/side_wall.rs
+++ b/src/structs/drawing/charts/side_wall.rs
@@ -15,12 +15,12 @@ pub struct SideWall {
 }
 
 impl SideWall {
-    pub fn get_thickness(&self) -> &Option<Thickness> {
-        &self.thickness
+    pub fn get_thickness(&self) -> Option<&Thickness> {
+        self.thickness.as_ref()
     }
 
-    pub fn get_thickness_mut(&mut self) -> &mut Option<Thickness> {
-        &mut self.thickness
+    pub fn get_thickness_mut(&mut self) -> Option<&mut Thickness> {
+        self.thickness.as_mut()
     }
 
     pub fn set_thickness(&mut self, value: Thickness) -> &mut SideWall {
@@ -28,12 +28,12 @@ impl SideWall {
         self
     }
 
-    pub fn get_shape_properties(&self) -> &Option<ShapeProperties> {
-        &self.shape_properties
+    pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
+        self.shape_properties.as_ref()
     }
 
-    pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
-        &mut self.shape_properties
+    pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
+        self.shape_properties.as_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {

--- a/src/structs/drawing/charts/title.rs
+++ b/src/structs/drawing/charts/title.rs
@@ -17,12 +17,12 @@ pub struct Title {
 }
 
 impl Title {
-    pub fn get_chart_text(&self) -> &Option<ChartText> {
-        &self.chart_text
+    pub fn get_chart_text(&self) -> Option<&ChartText> {
+        self.chart_text.as_ref()
     }
 
-    pub fn get_chart_text_mut(&mut self) -> &mut Option<ChartText> {
-        &mut self.chart_text
+    pub fn get_chart_text_mut(&mut self) -> Option<&mut ChartText> {
+        self.chart_text.as_mut()
     }
 
     pub fn set_chart_text(&mut self, value: ChartText) -> &mut Title {
@@ -30,12 +30,12 @@ impl Title {
         self
     }
 
-    pub fn get_layout(&self) -> &Option<Layout> {
-        &self.layout
+    pub fn get_layout(&self) -> Option<&Layout> {
+        self.layout.as_ref()
     }
 
-    pub fn get_layout_mut(&mut self) -> &mut Option<Layout> {
-        &mut self.layout
+    pub fn get_layout_mut(&mut self) -> Option<&mut Layout> {
+        self.layout.as_mut()
     }
 
     pub fn set_layout(&mut self, value: Layout) -> &mut Title {

--- a/src/structs/drawing/charts/value_axis.rs
+++ b/src/structs/drawing/charts/value_axis.rs
@@ -97,8 +97,8 @@ impl ValueAxis {
         self.major_gridlines.as_ref()
     }
 
-    pub fn get_major_gridlines_mut(&mut self) -> &mut Option<MajorGridlines> {
-        &mut self.major_gridlines
+    pub fn get_major_gridlines_mut(&mut self) -> Option<&mut MajorGridlines> {
+        self.major_gridlines.as_mut()
     }
 
     pub fn set_major_gridlines(&mut self, value: MajorGridlines) -> &mut Self {
@@ -110,8 +110,8 @@ impl ValueAxis {
         self.title.as_ref()
     }
 
-    pub fn get_title_mut(&mut self) -> &mut Option<Title> {
-        &mut self.title
+    pub fn get_title_mut(&mut self) -> Option<&mut Title> {
+        self.title.as_mut()
     }
 
     pub fn set_title(&mut self, value: Title) -> &mut Self {
@@ -214,8 +214,8 @@ impl ValueAxis {
         self.shape_properties.as_ref()
     }
 
-    pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
-        &mut self.shape_properties
+    pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
+        self.shape_properties.as_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {
@@ -227,8 +227,8 @@ impl ValueAxis {
         self.text_properties.as_ref()
     }
 
-    pub fn get_text_properties_mut(&mut self) -> &mut Option<TextProperties> {
-        &mut self.text_properties
+    pub fn get_text_properties_mut(&mut self) -> Option<&mut TextProperties> {
+        self.text_properties.as_mut()
     }
 
     pub fn set_text_properties(&mut self, value: TextProperties) -> &mut Self {

--- a/src/structs/drawing/charts/value_axis.rs
+++ b/src/structs/drawing/charts/value_axis.rs
@@ -93,8 +93,8 @@ impl ValueAxis {
         self
     }
 
-    pub fn get_major_gridlines(&self) -> &Option<MajorGridlines> {
-        &self.major_gridlines
+    pub fn get_major_gridlines(&self) -> Option<&MajorGridlines> {
+        self.major_gridlines.as_ref()
     }
 
     pub fn get_major_gridlines_mut(&mut self) -> &mut Option<MajorGridlines> {
@@ -106,8 +106,8 @@ impl ValueAxis {
         self
     }
 
-    pub fn get_title(&self) -> &Option<Title> {
-        &self.title
+    pub fn get_title(&self) -> Option<&Title> {
+        self.title.as_ref()
     }
 
     pub fn get_title_mut(&mut self) -> &mut Option<Title> {
@@ -210,8 +210,8 @@ impl ValueAxis {
         self
     }
 
-    pub fn get_shape_properties(&self) -> &Option<ShapeProperties> {
-        &self.shape_properties
+    pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
+        self.shape_properties.as_ref()
     }
 
     pub fn get_shape_properties_mut(&mut self) -> &mut Option<ShapeProperties> {
@@ -223,8 +223,8 @@ impl ValueAxis {
         self
     }
 
-    pub fn get_text_properties(&self) -> &Option<TextProperties> {
-        &self.text_properties
+    pub fn get_text_properties(&self) -> Option<&TextProperties> {
+        self.text_properties.as_ref()
     }
 
     pub fn get_text_properties_mut(&mut self) -> &mut Option<TextProperties> {

--- a/src/structs/drawing/charts/view_3d.rs
+++ b/src/structs/drawing/charts/view_3d.rs
@@ -23,8 +23,8 @@ impl View3D {
         self.rotate_x.as_ref()
     }
 
-    pub fn get_rotate_x_mut(&mut self) -> &mut Option<RotateX> {
-        &mut self.rotate_x
+    pub fn get_rotate_x_mut(&mut self) -> Option<&mut RotateX> {
+        self.rotate_x.as_mut()
     }
 
     pub fn set_rotate_x(&mut self, value: RotateX) -> &mut View3D {
@@ -36,8 +36,8 @@ impl View3D {
         self.rotate_y.as_ref()
     }
 
-    pub fn get_rotate_y_mut(&mut self) -> &mut Option<RotateY> {
-        &mut self.rotate_y
+    pub fn get_rotate_y_mut(&mut self) -> Option<&mut RotateY> {
+        self.rotate_y.as_mut()
     }
 
     pub fn set_rotate_y(&mut self, value: RotateY) -> &mut View3D {
@@ -49,8 +49,8 @@ impl View3D {
         self.right_angle_axes.as_ref()
     }
 
-    pub fn get_right_angle_axes_mut(&mut self) -> &mut Option<RightAngleAxes> {
-        &mut self.right_angle_axes
+    pub fn get_right_angle_axes_mut(&mut self) -> Option<&mut RightAngleAxes> {
+        self.right_angle_axes.as_mut()
     }
 
     pub fn set_right_angle_axes(&mut self, value: RightAngleAxes) -> &mut View3D {
@@ -62,8 +62,8 @@ impl View3D {
         self.perspective.as_ref()
     }
 
-    pub fn get_perspective_mut(&mut self) -> &mut Option<Perspective> {
-        &mut self.perspective
+    pub fn get_perspective_mut(&mut self) -> Option<&mut Perspective> {
+        self.perspective.as_mut()
     }
 
     pub fn set_perspective(&mut self, value: Perspective) -> &mut View3D {

--- a/src/structs/drawing/charts/view_3d.rs
+++ b/src/structs/drawing/charts/view_3d.rs
@@ -19,8 +19,8 @@ pub struct View3D {
 }
 
 impl View3D {
-    pub fn get_rotate_x(&self) -> &Option<RotateX> {
-        &self.rotate_x
+    pub fn get_rotate_x(&self) -> Option<&RotateX> {
+        self.rotate_x.as_ref()
     }
 
     pub fn get_rotate_x_mut(&mut self) -> &mut Option<RotateX> {
@@ -32,8 +32,8 @@ impl View3D {
         self
     }
 
-    pub fn get_rotate_y(&self) -> &Option<RotateY> {
-        &self.rotate_y
+    pub fn get_rotate_y(&self) -> Option<&RotateY> {
+        self.rotate_y.as_ref()
     }
 
     pub fn get_rotate_y_mut(&mut self) -> &mut Option<RotateY> {
@@ -45,8 +45,8 @@ impl View3D {
         self
     }
 
-    pub fn get_right_angle_axes(&self) -> &Option<RightAngleAxes> {
-        &self.right_angle_axes
+    pub fn get_right_angle_axes(&self) -> Option<&RightAngleAxes> {
+        self.right_angle_axes.as_ref()
     }
 
     pub fn get_right_angle_axes_mut(&mut self) -> &mut Option<RightAngleAxes> {
@@ -58,8 +58,8 @@ impl View3D {
         self
     }
 
-    pub fn get_perspective(&self) -> &Option<Perspective> {
-        &self.perspective
+    pub fn get_perspective(&self) -> Option<&Perspective> {
+        self.perspective.as_ref()
     }
 
     pub fn get_perspective_mut(&mut self) -> &mut Option<Perspective> {

--- a/src/structs/drawing/color2_type.rs
+++ b/src/structs/drawing/color2_type.rs
@@ -22,8 +22,8 @@ impl Color2Type {
         self.rgb_color_model_hex.as_ref()
     }
 
-    pub fn get_rgb_color_model_hex_mut(&mut self) -> &mut Option<RgbColorModelHex> {
-        &mut self.rgb_color_model_hex
+    pub fn get_rgb_color_model_hex_mut(&mut self) -> Option<&mut RgbColorModelHex> {
+        self.rgb_color_model_hex.as_mut()
     }
 
     pub fn set_system_color(&mut self, value: SystemColor) {
@@ -34,8 +34,8 @@ impl Color2Type {
         self.system_color.as_ref()
     }
 
-    pub fn get_system_color_mut(&mut self) -> &mut Option<SystemColor> {
-        &mut self.system_color
+    pub fn get_system_color_mut(&mut self) -> Option<&mut SystemColor> {
+        self.system_color.as_mut()
     }
 
     pub fn get_val(&self) -> String {

--- a/src/structs/drawing/color2_type.rs
+++ b/src/structs/drawing/color2_type.rs
@@ -18,8 +18,8 @@ impl Color2Type {
         self.rgb_color_model_hex = Some(value);
     }
 
-    pub fn get_rgb_color_model_hex(&self) -> &Option<RgbColorModelHex> {
-        &self.rgb_color_model_hex
+    pub fn get_rgb_color_model_hex(&self) -> Option<&RgbColorModelHex> {
+        self.rgb_color_model_hex.as_ref()
     }
 
     pub fn get_rgb_color_model_hex_mut(&mut self) -> &mut Option<RgbColorModelHex> {
@@ -30,8 +30,8 @@ impl Color2Type {
         self.system_color = Some(value);
     }
 
-    pub fn get_system_color(&self) -> &Option<SystemColor> {
-        &self.system_color
+    pub fn get_system_color(&self) -> Option<&SystemColor> {
+        self.system_color.as_ref()
     }
 
     pub fn get_system_color_mut(&mut self) -> &mut Option<SystemColor> {

--- a/src/structs/drawing/effect_list.rs
+++ b/src/structs/drawing/effect_list.rs
@@ -21,8 +21,8 @@ impl EffectList {
         self.glow.as_ref()
     }
 
-    pub fn get_glow_mut(&mut self) -> &mut Option<Glow> {
-        &mut self.glow
+    pub fn get_glow_mut(&mut self) -> Option<&mut Glow> {
+        self.glow.as_mut()
     }
 
     pub fn set_glow(&mut self, value: Glow) {
@@ -33,8 +33,8 @@ impl EffectList {
         self.outer_shadow.as_ref()
     }
 
-    pub fn get_outer_shadow_mut(&mut self) -> &mut Option<OuterShadow> {
-        &mut self.outer_shadow
+    pub fn get_outer_shadow_mut(&mut self) -> Option<&mut OuterShadow> {
+        self.outer_shadow.as_mut()
     }
 
     pub fn set_outer_shadow(&mut self, value: OuterShadow) {
@@ -45,8 +45,8 @@ impl EffectList {
         self.soft_edge.as_ref()
     }
 
-    pub fn get_soft_edge_mut(&mut self) -> &mut Option<SoftEdge> {
-        &mut self.soft_edge
+    pub fn get_soft_edge_mut(&mut self) -> Option<&mut SoftEdge> {
+        self.soft_edge.as_mut()
     }
 
     pub fn set_soft_edge(&mut self, value: SoftEdge) {

--- a/src/structs/drawing/effect_list.rs
+++ b/src/structs/drawing/effect_list.rs
@@ -17,8 +17,8 @@ pub struct EffectList {
 }
 
 impl EffectList {
-    pub fn get_glow(&self) -> &Option<Glow> {
-        &self.glow
+    pub fn get_glow(&self) -> Option<&Glow> {
+        self.glow.as_ref()
     }
 
     pub fn get_glow_mut(&mut self) -> &mut Option<Glow> {
@@ -29,8 +29,8 @@ impl EffectList {
         self.glow = Some(value);
     }
 
-    pub fn get_outer_shadow(&self) -> &Option<OuterShadow> {
-        &self.outer_shadow
+    pub fn get_outer_shadow(&self) -> Option<&OuterShadow> {
+        self.outer_shadow.as_ref()
     }
 
     pub fn get_outer_shadow_mut(&mut self) -> &mut Option<OuterShadow> {
@@ -41,8 +41,8 @@ impl EffectList {
         self.outer_shadow = Some(value);
     }
 
-    pub fn get_soft_edge(&self) -> &Option<SoftEdge> {
-        &self.soft_edge
+    pub fn get_soft_edge(&self) -> Option<&SoftEdge> {
+        self.soft_edge.as_ref()
     }
 
     pub fn get_soft_edge_mut(&mut self) -> &mut Option<SoftEdge> {

--- a/src/structs/drawing/effect_style.rs
+++ b/src/structs/drawing/effect_style.rs
@@ -21,8 +21,8 @@ impl EffectStyle {
         self.effect_list.as_ref()
     }
 
-    pub fn get_effect_list_mut(&mut self) -> &mut Option<EffectList> {
-        &mut self.effect_list
+    pub fn get_effect_list_mut(&mut self) -> Option<&mut EffectList> {
+        self.effect_list.as_mut()
     }
 
     pub fn set_effect_list(&mut self, value: EffectList) -> &mut Self {
@@ -34,8 +34,8 @@ impl EffectStyle {
         self.scene_3d_type.as_ref()
     }
 
-    pub fn get_scene_3d_type_mut(&mut self) -> &mut Option<Scene3DType> {
-        &mut self.scene_3d_type
+    pub fn get_scene_3d_type_mut(&mut self) -> Option<&mut Scene3DType> {
+        self.scene_3d_type.as_mut()
     }
 
     pub fn set_scene_3d_type(&mut self, value: Scene3DType) -> &mut Self {
@@ -47,8 +47,8 @@ impl EffectStyle {
         self.shape_3d_type.as_ref()
     }
 
-    pub fn get_shape_3d_type_mut(&mut self) -> &mut Option<Shape3DType> {
-        &mut self.shape_3d_type
+    pub fn get_shape_3d_type_mut(&mut self) -> Option<&mut Shape3DType> {
+        self.shape_3d_type.as_mut()
     }
 
     pub fn set_shape_3d_type(&mut self, value: Shape3DType) -> &mut Self {

--- a/src/structs/drawing/effect_style.rs
+++ b/src/structs/drawing/effect_style.rs
@@ -17,8 +17,8 @@ pub struct EffectStyle {
 }
 
 impl EffectStyle {
-    pub fn get_effect_list(&self) -> &Option<EffectList> {
-        &self.effect_list
+    pub fn get_effect_list(&self) -> Option<&EffectList> {
+        self.effect_list.as_ref()
     }
 
     pub fn get_effect_list_mut(&mut self) -> &mut Option<EffectList> {
@@ -30,8 +30,8 @@ impl EffectStyle {
         self
     }
 
-    pub fn get_scene_3d_type(&self) -> &Option<Scene3DType> {
-        &self.scene_3d_type
+    pub fn get_scene_3d_type(&self) -> Option<&Scene3DType> {
+        self.scene_3d_type.as_ref()
     }
 
     pub fn get_scene_3d_type_mut(&mut self) -> &mut Option<Scene3DType> {
@@ -43,8 +43,8 @@ impl EffectStyle {
         self
     }
 
-    pub fn get_shape_3d_type(&self) -> &Option<Shape3DType> {
-        &self.shape_3d_type
+    pub fn get_shape_3d_type(&self) -> Option<&Shape3DType> {
+        self.shape_3d_type.as_ref()
     }
 
     pub fn get_shape_3d_type_mut(&mut self) -> &mut Option<Shape3DType> {

--- a/src/structs/drawing/effect_style.rs
+++ b/src/structs/drawing/effect_style.rs
@@ -103,27 +103,18 @@ impl EffectStyle {
         write_start_tag(writer, "a:effectStyle", vec![], false);
 
         // a:effectLst
-        match &self.effect_list {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.effect_list {
+            v.write_to(writer);
         }
 
         // a:scene3d
-        match &self.scene_3d_type {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.scene_3d_type {
+            v.write_to(writer);
         }
 
         // a:sp3d
-        match &self.shape_3d_type {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.shape_3d_type {
+            v.write_to(writer);
         }
 
         write_end_tag(writer, "a:effectStyle");

--- a/src/structs/drawing/fill_style_list.rs
+++ b/src/structs/drawing/fill_style_list.rs
@@ -14,8 +14,8 @@ pub struct FillStyleList {
 }
 
 impl FillStyleList {
-    pub fn get_solid_fill(&self) -> &Option<SolidFill> {
-        &self.solid_fill
+    pub fn get_solid_fill(&self) -> Option<&SolidFill> {
+        self.solid_fill.as_ref()
     }
 
     pub fn get_solid_fill_mut(&mut self) -> &mut Option<SolidFill> {

--- a/src/structs/drawing/fill_style_list.rs
+++ b/src/structs/drawing/fill_style_list.rs
@@ -18,8 +18,8 @@ impl FillStyleList {
         self.solid_fill.as_ref()
     }
 
-    pub fn get_solid_fill_mut(&mut self) -> &mut Option<SolidFill> {
-        &mut self.solid_fill
+    pub fn get_solid_fill_mut(&mut self) -> Option<&mut SolidFill> {
+        self.solid_fill.as_mut()
     }
 
     pub fn set_solid_fill(&mut self, value: SolidFill) -> &mut Self {

--- a/src/structs/drawing/glow.rs
+++ b/src/structs/drawing/glow.rs
@@ -24,8 +24,8 @@ impl Glow {
         self
     }
 
-    pub fn get_scheme_color(&self) -> &Option<SchemeColor> {
-        &self.scheme_color
+    pub fn get_scheme_color(&self) -> Option<&SchemeColor> {
+        self.scheme_color.as_ref()
     }
 
     pub fn set_scheme_color(&mut self, value: SchemeColor) {

--- a/src/structs/drawing/gradient_fill.rs
+++ b/src/structs/drawing/gradient_fill.rs
@@ -57,8 +57,8 @@ impl GradientFill {
         self.linear_gradient_fill.as_ref()
     }
 
-    pub fn get_linear_gradient_fill_mut(&mut self) -> &mut Option<LinearGradientFill> {
-        &mut self.linear_gradient_fill
+    pub fn get_linear_gradient_fill_mut(&mut self) -> Option<&mut LinearGradientFill> {
+        self.linear_gradient_fill.as_mut()
     }
 
     pub fn set_linear_gradient_fill(&mut self, value: LinearGradientFill) -> &mut GradientFill {
@@ -70,8 +70,8 @@ impl GradientFill {
         self.tile_rectangle.as_ref()
     }
 
-    pub fn get_tile_rectangle_mut(&mut self) -> &mut Option<TileRectangle> {
-        &mut self.tile_rectangle
+    pub fn get_tile_rectangle_mut(&mut self) -> Option<&mut TileRectangle> {
+        self.tile_rectangle.as_mut()
     }
 
     pub fn set_tile_rectangle(&mut self, value: TileRectangle) -> &mut GradientFill {

--- a/src/structs/drawing/gradient_fill.rs
+++ b/src/structs/drawing/gradient_fill.rs
@@ -133,19 +133,13 @@ impl GradientFill {
         let _ = &self.gradient_stop_list.write_to(writer);
 
         // a:lin
-        match &self.linear_gradient_fill {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.linear_gradient_fill {
+            v.write_to(writer);
         }
 
         // a:tileRect
-        match &self.tile_rectangle {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.tile_rectangle {
+            v.write_to(writer);
         }
 
         write_end_tag(writer, "a:gradFill");

--- a/src/structs/drawing/gradient_fill.rs
+++ b/src/structs/drawing/gradient_fill.rs
@@ -53,8 +53,8 @@ impl GradientFill {
         self
     }
 
-    pub fn get_linear_gradient_fill(&self) -> &Option<LinearGradientFill> {
-        &self.linear_gradient_fill
+    pub fn get_linear_gradient_fill(&self) -> Option<&LinearGradientFill> {
+        self.linear_gradient_fill.as_ref()
     }
 
     pub fn get_linear_gradient_fill_mut(&mut self) -> &mut Option<LinearGradientFill> {
@@ -66,8 +66,8 @@ impl GradientFill {
         self
     }
 
-    pub fn get_tile_rectangle(&self) -> &Option<TileRectangle> {
-        &self.tile_rectangle
+    pub fn get_tile_rectangle(&self) -> Option<&TileRectangle> {
+        self.tile_rectangle.as_ref()
     }
 
     pub fn get_tile_rectangle_mut(&mut self) -> &mut Option<TileRectangle> {

--- a/src/structs/drawing/gradient_stop.rs
+++ b/src/structs/drawing/gradient_stop.rs
@@ -29,8 +29,8 @@ impl GradientStop {
         self.scheme_color.as_ref()
     }
 
-    pub fn get_scheme_color_mut(&mut self) -> &mut Option<SchemeColor> {
-        &mut self.scheme_color
+    pub fn get_scheme_color_mut(&mut self) -> Option<&mut SchemeColor> {
+        self.scheme_color.as_mut()
     }
 
     pub fn set_scheme_color(&mut self, value: SchemeColor) -> &mut GradientStop {
@@ -42,8 +42,8 @@ impl GradientStop {
         self.rgb_color_model_hex.as_ref()
     }
 
-    pub fn get_rgb_color_model_hex_mut(&mut self) -> &mut Option<RgbColorModelHex> {
-        &mut self.rgb_color_model_hex
+    pub fn get_rgb_color_model_hex_mut(&mut self) -> Option<&mut RgbColorModelHex> {
+        self.rgb_color_model_hex.as_mut()
     }
 
     pub fn set_rgb_color_model_hex(&mut self, value: RgbColorModelHex) -> &mut GradientStop {

--- a/src/structs/drawing/gradient_stop.rs
+++ b/src/structs/drawing/gradient_stop.rs
@@ -25,8 +25,8 @@ impl GradientStop {
         self
     }
 
-    pub fn get_scheme_color(&self) -> &Option<SchemeColor> {
-        &self.scheme_color
+    pub fn get_scheme_color(&self) -> Option<&SchemeColor> {
+        self.scheme_color.as_ref()
     }
 
     pub fn get_scheme_color_mut(&mut self) -> &mut Option<SchemeColor> {
@@ -38,8 +38,8 @@ impl GradientStop {
         self
     }
 
-    pub fn get_rgb_color_model_hex(&self) -> &Option<RgbColorModelHex> {
-        &self.rgb_color_model_hex
+    pub fn get_rgb_color_model_hex(&self) -> Option<&RgbColorModelHex> {
+        self.rgb_color_model_hex.as_ref()
     }
 
     pub fn get_rgb_color_model_hex_mut(&mut self) -> &mut Option<RgbColorModelHex> {

--- a/src/structs/drawing/graphic_data.rs
+++ b/src/structs/drawing/graphic_data.rs
@@ -43,7 +43,7 @@ impl GraphicData {
                     let relationship = drawing_relationships
                         .unwrap()
                         .get_relationship_by_rid(&chart_id);
-                    let _ = chart::read(relationship.get_raw_file(), &mut self.chart_space);
+                    chart::read(relationship.get_raw_file(), &mut self.chart_space);
                 }
             },
             Event::End(ref e) => {

--- a/src/structs/drawing/light_rig.rs
+++ b/src/structs/drawing/light_rig.rs
@@ -36,8 +36,8 @@ impl LightRig {
         self
     }
 
-    pub fn get_rotation(&self) -> &Option<Rotation> {
-        &self.rotation
+    pub fn get_rotation(&self) -> Option<&Rotation> {
+        self.rotation.as_ref()
     }
 
     pub fn get_rotation_mut(&mut self) -> &mut Option<Rotation> {

--- a/src/structs/drawing/light_rig.rs
+++ b/src/structs/drawing/light_rig.rs
@@ -40,8 +40,8 @@ impl LightRig {
         self.rotation.as_ref()
     }
 
-    pub fn get_rotation_mut(&mut self) -> &mut Option<Rotation> {
-        &mut self.rotation
+    pub fn get_rotation_mut(&mut self) -> Option<&mut Rotation> {
+        self.rotation.as_mut()
     }
 
     pub fn set_rotation(&mut self, value: Rotation) -> &mut Self {

--- a/src/structs/drawing/line_spacing.rs
+++ b/src/structs/drawing/line_spacing.rs
@@ -13,8 +13,8 @@ pub struct LineSpacing {
 }
 
 impl LineSpacing {
-    pub fn get_spacing_percent(&self) -> &Option<SpacingPercent> {
-        &self.spacing_percent
+    pub fn get_spacing_percent(&self) -> Option<&SpacingPercent> {
+        self.spacing_percent.as_ref()
     }
 
     pub fn get_spacing_percent_mut(&mut self) -> &mut Option<SpacingPercent> {

--- a/src/structs/drawing/line_spacing.rs
+++ b/src/structs/drawing/line_spacing.rs
@@ -17,8 +17,8 @@ impl LineSpacing {
         self.spacing_percent.as_ref()
     }
 
-    pub fn get_spacing_percent_mut(&mut self) -> &mut Option<SpacingPercent> {
-        &mut self.spacing_percent
+    pub fn get_spacing_percent_mut(&mut self) -> Option<&mut SpacingPercent> {
+        self.spacing_percent.as_mut()
     }
 
     pub fn set_spacing_percent(&mut self, value: SpacingPercent) -> &mut Self {

--- a/src/structs/drawing/list_style.rs
+++ b/src/structs/drawing/list_style.rs
@@ -17,8 +17,8 @@ impl ListStyle {
         self.effect_list.as_ref()
     }
 
-    pub fn get_effect_list_mut(&mut self) -> &mut Option<EffectList> {
-        &mut self.effect_list
+    pub fn get_effect_list_mut(&mut self) -> Option<&mut EffectList> {
+        self.effect_list.as_mut()
     }
 
     pub fn set_effect_list(&mut self, value: EffectList) {

--- a/src/structs/drawing/list_style.rs
+++ b/src/structs/drawing/list_style.rs
@@ -13,8 +13,8 @@ pub struct ListStyle {
 }
 
 impl ListStyle {
-    pub fn get_effect_list(&self) -> &Option<EffectList> {
-        &self.effect_list
+    pub fn get_effect_list(&self) -> Option<&EffectList> {
+        self.effect_list.as_ref()
     }
 
     pub fn get_effect_list_mut(&mut self) -> &mut Option<EffectList> {

--- a/src/structs/drawing/outer_shadow.rs
+++ b/src/structs/drawing/outer_shadow.rs
@@ -24,8 +24,8 @@ pub struct OuterShadow {
 }
 
 impl OuterShadow {
-    pub fn get_blur_radius(&self) -> &Option<String> {
-        &self.blur_radius
+    pub fn get_blur_radius(&self) -> Option<&String> {
+        self.blur_radius.as_ref()
     }
 
     pub fn set_blur_radius<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -33,8 +33,8 @@ impl OuterShadow {
         self
     }
 
-    pub fn get_horizontal_ratio(&self) -> &Option<String> {
-        &self.horizontal_ratio
+    pub fn get_horizontal_ratio(&self) -> Option<&String> {
+        self.horizontal_ratio.as_ref()
     }
 
     pub fn set_horizontal_ratio<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -42,8 +42,8 @@ impl OuterShadow {
         self
     }
 
-    pub fn get_vertical_ratio(&self) -> &Option<String> {
-        &self.vertical_ratio
+    pub fn get_vertical_ratio(&self) -> Option<&String> {
+        self.vertical_ratio.as_ref()
     }
 
     pub fn set_vertical_ratio<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -51,8 +51,8 @@ impl OuterShadow {
         self
     }
 
-    pub fn get_alignment(&self) -> &Option<String> {
-        &self.alignment
+    pub fn get_alignment(&self) -> Option<&String> {
+        self.alignment.as_ref()
     }
 
     pub fn set_alignment<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -60,8 +60,8 @@ impl OuterShadow {
         self
     }
 
-    pub fn get_direction(&self) -> &Option<String> {
-        &self.direction
+    pub fn get_direction(&self) -> Option<&String> {
+        self.direction.as_ref()
     }
 
     pub fn set_direction<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -69,8 +69,8 @@ impl OuterShadow {
         self
     }
 
-    pub fn get_distance(&self) -> &Option<String> {
-        &self.distance
+    pub fn get_distance(&self) -> Option<&String> {
+        self.distance.as_ref()
     }
 
     pub fn set_distance<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -78,8 +78,8 @@ impl OuterShadow {
         self
     }
 
-    pub fn get_rotate_with_shape(&self) -> &Option<String> {
-        &self.rotate_with_shape
+    pub fn get_rotate_with_shape(&self) -> Option<&String> {
+        self.rotate_with_shape.as_ref()
     }
 
     pub fn set_rotate_with_shape<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -87,8 +87,8 @@ impl OuterShadow {
         self
     }
 
-    pub fn get_preset_color(&self) -> &Option<PresetColor> {
-        &self.preset_color
+    pub fn get_preset_color(&self) -> Option<&PresetColor> {
+        self.preset_color.as_ref()
     }
 
     pub fn get_preset_color_mut(&mut self) -> &mut Option<PresetColor> {
@@ -100,8 +100,8 @@ impl OuterShadow {
         self
     }
 
-    pub fn get_scheme_color(&self) -> &Option<SchemeColor> {
-        &self.scheme_color
+    pub fn get_scheme_color(&self) -> Option<&SchemeColor> {
+        self.scheme_color.as_ref()
     }
 
     pub fn get_scheme_color_mut(&mut self) -> &mut Option<SchemeColor> {
@@ -113,8 +113,8 @@ impl OuterShadow {
         self
     }
 
-    pub fn get_rgb_color_model_hex(&self) -> &Option<RgbColorModelHex> {
-        &self.rgb_color_model_hex
+    pub fn get_rgb_color_model_hex(&self) -> Option<&RgbColorModelHex> {
+        self.rgb_color_model_hex.as_ref()
     }
 
     pub fn get_rgb_color_model_hex_mut(&mut self) -> &mut Option<RgbColorModelHex> {

--- a/src/structs/drawing/outer_shadow.rs
+++ b/src/structs/drawing/outer_shadow.rs
@@ -91,8 +91,8 @@ impl OuterShadow {
         self.preset_color.as_ref()
     }
 
-    pub fn get_preset_color_mut(&mut self) -> &mut Option<PresetColor> {
-        &mut self.preset_color
+    pub fn get_preset_color_mut(&mut self) -> Option<&mut PresetColor> {
+        self.preset_color.as_mut()
     }
 
     pub fn set_preset_color(&mut self, value: PresetColor) -> &mut Self {
@@ -104,8 +104,8 @@ impl OuterShadow {
         self.scheme_color.as_ref()
     }
 
-    pub fn get_scheme_color_mut(&mut self) -> &mut Option<SchemeColor> {
-        &mut self.scheme_color
+    pub fn get_scheme_color_mut(&mut self) -> Option<&mut SchemeColor> {
+        self.scheme_color.as_mut()
     }
 
     pub fn set_scheme_color(&mut self, value: SchemeColor) -> &mut Self {
@@ -117,8 +117,8 @@ impl OuterShadow {
         self.rgb_color_model_hex.as_ref()
     }
 
-    pub fn get_rgb_color_model_hex_mut(&mut self) -> &mut Option<RgbColorModelHex> {
-        &mut self.rgb_color_model_hex
+    pub fn get_rgb_color_model_hex_mut(&mut self) -> Option<&mut RgbColorModelHex> {
+        self.rgb_color_model_hex.as_mut()
     }
 
     pub fn set_rgb_color_model_hex(&mut self, value: RgbColorModelHex) -> &mut Self {

--- a/src/structs/drawing/outer_shadow.rs
+++ b/src/structs/drawing/outer_shadow.rs
@@ -202,72 +202,42 @@ impl OuterShadow {
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:outerShdw
         let mut attributes: Vec<(&str, &str)> = Vec::new();
-        match &self.blur_radius {
-            Some(v) => {
-                attributes.push(("blurRad", v));
-            }
-            None => {}
+        if let Some(v) = &self.blur_radius {
+            attributes.push(("blurRad", v));
         }
-        match &self.distance {
-            Some(v) => {
-                attributes.push(("dist", v));
-            }
-            None => {}
+        if let Some(v) = &self.distance {
+            attributes.push(("dist", v));
         }
-        match &self.direction {
-            Some(v) => {
-                attributes.push(("dir", v));
-            }
-            None => {}
+        if let Some(v) = &self.direction {
+            attributes.push(("dir", v));
         }
-        match &self.horizontal_ratio {
-            Some(v) => {
-                attributes.push(("sx", v));
-            }
-            None => {}
+        if let Some(v) = &self.horizontal_ratio {
+            attributes.push(("sx", v));
         }
-        match &self.vertical_ratio {
-            Some(v) => {
-                attributes.push(("sy", v));
-            }
-            None => {}
+        if let Some(v) = &self.vertical_ratio {
+            attributes.push(("sy", v));
         }
-        match &self.alignment {
-            Some(v) => {
-                attributes.push(("algn", v));
-            }
-            None => {}
+        if let Some(v) = &self.alignment {
+            attributes.push(("algn", v));
         }
-        match &self.rotate_with_shape {
-            Some(v) => {
-                attributes.push(("rotWithShape", v));
-            }
-            None => {}
+        if let Some(v) = &self.rotate_with_shape {
+            attributes.push(("rotWithShape", v));
         }
         write_start_tag(writer, "a:outerShdw", attributes, false);
 
         // a:prstClr
-        match &self.preset_color {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.preset_color {
+            v.write_to(writer);
         }
 
         // a:schemeClr
-        match &self.scheme_color {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.scheme_color {
+            v.write_to(writer);
         }
 
         // a:srgbClr
-        match &self.rgb_color_model_hex {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.rgb_color_model_hex {
+            v.write_to(writer);
         }
 
         write_end_tag(writer, "a:outerShdw");

--- a/src/structs/drawing/outline.rs
+++ b/src/structs/drawing/outline.rs
@@ -43,8 +43,8 @@ impl Outline {
         self
     }
 
-    pub fn get_cap_type(&self) -> &Option<String> {
-        &self.cap_type
+    pub fn get_cap_type(&self) -> Option<&String> {
+        self.cap_type.as_ref()
     }
 
     pub fn set_cap_type<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -52,8 +52,8 @@ impl Outline {
         self
     }
 
-    pub fn get_compound_line_type(&self) -> &Option<String> {
-        &self.compound_line_type
+    pub fn get_compound_line_type(&self) -> Option<&String> {
+        self.compound_line_type.as_ref()
     }
 
     pub fn set_compound_line_type<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -61,8 +61,8 @@ impl Outline {
         self
     }
 
-    pub fn get_solid_fill(&self) -> &Option<SolidFill> {
-        &self.solid_fill
+    pub fn get_solid_fill(&self) -> Option<&SolidFill> {
+        self.solid_fill.as_ref()
     }
 
     pub fn get_solid_fill_mut(&mut self) -> &mut Option<SolidFill> {
@@ -74,8 +74,8 @@ impl Outline {
         self
     }
 
-    pub fn get_gradient_fill(&self) -> &Option<GradientFill> {
-        &self.gradient_fill
+    pub fn get_gradient_fill(&self) -> Option<&GradientFill> {
+        self.gradient_fill.as_ref()
     }
 
     pub fn get_gradient_fill_mut(&mut self) -> &mut Option<GradientFill> {
@@ -87,8 +87,8 @@ impl Outline {
         self
     }
 
-    pub fn get_tail_end(&self) -> &Option<TailEnd> {
-        &self.tail_end
+    pub fn get_tail_end(&self) -> Option<&TailEnd> {
+        self.tail_end.as_ref()
     }
 
     pub fn get_tail_end_mut(&mut self) -> &mut Option<TailEnd> {
@@ -100,8 +100,8 @@ impl Outline {
         self
     }
 
-    pub fn get_no_fill(&self) -> &Option<NoFill> {
-        &self.no_fill
+    pub fn get_no_fill(&self) -> Option<&NoFill> {
+        self.no_fill.as_ref()
     }
 
     pub fn get_no_fill_mut(&mut self) -> &mut Option<NoFill> {
@@ -113,8 +113,8 @@ impl Outline {
         self
     }
 
-    pub fn get_bevel(&self) -> &Option<Bevel> {
-        &self.bevel
+    pub fn get_bevel(&self) -> Option<&Bevel> {
+        self.bevel.as_ref()
     }
 
     pub fn get_bevel_mut(&mut self) -> &mut Option<Bevel> {
@@ -126,8 +126,8 @@ impl Outline {
         self
     }
 
-    pub fn get_preset_dash(&self) -> &Option<PresetDash> {
-        &self.preset_dash
+    pub fn get_preset_dash(&self) -> Option<&PresetDash> {
+        self.preset_dash.as_ref()
     }
 
     pub fn get_preset_dash_mut(&mut self) -> &mut Option<PresetDash> {
@@ -139,8 +139,8 @@ impl Outline {
         self
     }
 
-    pub fn get_miter(&self) -> &Option<Miter> {
-        &self.miter
+    pub fn get_miter(&self) -> Option<&Miter> {
+        self.miter.as_ref()
     }
 
     pub fn get_miter_mut(&mut self) -> &mut Option<Miter> {
@@ -152,8 +152,8 @@ impl Outline {
         self
     }
 
-    pub fn get_round(&self) -> &Option<Round> {
-        &self.round
+    pub fn get_round(&self) -> Option<&Round> {
+        self.round.as_ref()
     }
 
     pub fn get_round_mut(&mut self) -> &mut Option<Round> {

--- a/src/structs/drawing/outline.rs
+++ b/src/structs/drawing/outline.rs
@@ -65,8 +65,8 @@ impl Outline {
         self.solid_fill.as_ref()
     }
 
-    pub fn get_solid_fill_mut(&mut self) -> &mut Option<SolidFill> {
-        &mut self.solid_fill
+    pub fn get_solid_fill_mut(&mut self) -> Option<&mut SolidFill> {
+        self.solid_fill.as_mut()
     }
 
     pub fn set_solid_fill(&mut self, value: SolidFill) -> &mut Self {
@@ -78,8 +78,8 @@ impl Outline {
         self.gradient_fill.as_ref()
     }
 
-    pub fn get_gradient_fill_mut(&mut self) -> &mut Option<GradientFill> {
-        &mut self.gradient_fill
+    pub fn get_gradient_fill_mut(&mut self) -> Option<&mut GradientFill> {
+        self.gradient_fill.as_mut()
     }
 
     pub fn set_gradient_fill(&mut self, value: GradientFill) -> &mut Self {
@@ -91,8 +91,8 @@ impl Outline {
         self.tail_end.as_ref()
     }
 
-    pub fn get_tail_end_mut(&mut self) -> &mut Option<TailEnd> {
-        &mut self.tail_end
+    pub fn get_tail_end_mut(&mut self) -> Option<&mut TailEnd> {
+        self.tail_end.as_mut()
     }
 
     pub fn set_tail_end(&mut self, value: TailEnd) -> &mut Self {
@@ -104,8 +104,8 @@ impl Outline {
         self.no_fill.as_ref()
     }
 
-    pub fn get_no_fill_mut(&mut self) -> &mut Option<NoFill> {
-        &mut self.no_fill
+    pub fn get_no_fill_mut(&mut self) -> Option<&mut NoFill> {
+        self.no_fill.as_mut()
     }
 
     pub fn set_no_fill(&mut self, value: NoFill) -> &mut Self {
@@ -117,8 +117,8 @@ impl Outline {
         self.bevel.as_ref()
     }
 
-    pub fn get_bevel_mut(&mut self) -> &mut Option<Bevel> {
-        &mut self.bevel
+    pub fn get_bevel_mut(&mut self) -> Option<&mut Bevel> {
+        self.bevel.as_mut()
     }
 
     pub fn set_bevel(&mut self, value: Bevel) -> &mut Self {
@@ -130,8 +130,8 @@ impl Outline {
         self.preset_dash.as_ref()
     }
 
-    pub fn get_preset_dash_mut(&mut self) -> &mut Option<PresetDash> {
-        &mut self.preset_dash
+    pub fn get_preset_dash_mut(&mut self) -> Option<&mut PresetDash> {
+        self.preset_dash.as_mut()
     }
 
     pub fn set_preset_dash(&mut self, value: PresetDash) -> &mut Self {
@@ -143,8 +143,8 @@ impl Outline {
         self.miter.as_ref()
     }
 
-    pub fn get_miter_mut(&mut self) -> &mut Option<Miter> {
-        &mut self.miter
+    pub fn get_miter_mut(&mut self) -> Option<&mut Miter> {
+        self.miter.as_mut()
     }
 
     pub fn set_miter(&mut self, value: Miter) -> &mut Self {
@@ -156,8 +156,8 @@ impl Outline {
         self.round.as_ref()
     }
 
-    pub fn get_round_mut(&mut self) -> &mut Option<Round> {
-        &mut self.round
+    pub fn get_round_mut(&mut self) -> Option<&mut Round> {
+        self.round.as_mut()
     }
 
     pub fn set_round(&mut self, value: Round) -> &mut Self {

--- a/src/structs/drawing/paragraph.rs
+++ b/src/structs/drawing/paragraph.rs
@@ -38,12 +38,12 @@ impl Paragraph {
         self.run.push(value);
     }
 
-    pub fn get_end_para_run_properties(&self) -> &Option<RunProperties> {
-        &self.end_para_run_properties
+    pub fn get_end_para_run_properties(&self) -> Option<&RunProperties> {
+        self.end_para_run_properties.as_ref()
     }
 
-    pub fn get_end_para_run_properties_mut(&mut self) -> &mut Option<RunProperties> {
-        &mut self.end_para_run_properties
+    pub fn get_end_para_run_properties_mut(&mut self) -> Option<&mut RunProperties> {
+        self.end_para_run_properties.as_mut()
     }
 
     pub fn set_end_para_run_properties(&mut self, value: RunProperties) -> &mut Paragraph {

--- a/src/structs/drawing/paragraph_properties.rs
+++ b/src/structs/drawing/paragraph_properties.rs
@@ -112,32 +112,27 @@ impl ParagraphProperties {
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
-        let empty_flag = self.default_run_properties.is_none() && self.line_spacing.is_none();
-
         // a:pPr
         let mut attributes: Vec<(&str, &str)> = Vec::new();
-        match &self.right_to_left {
-            Some(v) => {
-                attributes.push(("rtl", v));
-            }
-            None => {}
+        if let Some(v) = &self.right_to_left {
+            attributes.push(("rtl", v));
         }
         if self.alignment.has_value() {
             attributes.push(("algn", self.alignment.get_value_string()));
         }
+
+        let empty_flag = self.default_run_properties.is_none() && self.line_spacing.is_none();
         write_start_tag(writer, "a:pPr", attributes, empty_flag);
 
         if !empty_flag {
             // a:defRPr
-            match &self.default_run_properties {
-                Some(v) => v.write_to_def_rpr(writer),
-                None => {}
+            if let Some(v) = &self.default_run_properties {
+                v.write_to_def_rpr(writer)
             }
 
             // a:lnSpc
-            match &self.line_spacing {
-                Some(v) => v.write_to(writer),
-                None => {}
+            if let Some(v) = &self.line_spacing {
+                v.write_to(writer)
             }
 
             write_end_tag(writer, "a:pPr");

--- a/src/structs/drawing/paragraph_properties.rs
+++ b/src/structs/drawing/paragraph_properties.rs
@@ -19,8 +19,8 @@ pub struct ParagraphProperties {
 }
 
 impl ParagraphProperties {
-    pub fn get_right_to_left(&self) -> &Option<String> {
-        &self.right_to_left
+    pub fn get_right_to_left(&self) -> Option<&String> {
+        self.right_to_left.as_ref()
     }
 
     pub fn set_right_to_left<S: Into<String>>(&mut self, value: S) -> &mut ParagraphProperties {
@@ -37,12 +37,12 @@ impl ParagraphProperties {
         self
     }
 
-    pub fn get_default_run_properties(&self) -> &Option<RunProperties> {
-        &self.default_run_properties
+    pub fn get_default_run_properties(&self) -> Option<&RunProperties> {
+        self.default_run_properties.as_ref()
     }
 
-    pub fn get_default_run_properties_mut(&mut self) -> &mut Option<RunProperties> {
-        &mut self.default_run_properties
+    pub fn get_default_run_properties_mut(&mut self) -> Option<&mut RunProperties> {
+        self.default_run_properties.as_mut()
     }
 
     pub fn set_default_run_properties(&mut self, value: RunProperties) -> &mut ParagraphProperties {
@@ -50,12 +50,12 @@ impl ParagraphProperties {
         self
     }
 
-    pub fn get_line_spacing(&self) -> &Option<LineSpacing> {
-        &self.line_spacing
+    pub fn get_line_spacing(&self) -> Option<&LineSpacing> {
+        self.line_spacing.as_ref()
     }
 
-    pub fn get_line_spacing_mut(&mut self) -> &mut Option<LineSpacing> {
-        &mut self.line_spacing
+    pub fn get_line_spacing_mut(&mut self) -> Option<&mut LineSpacing> {
+        self.line_spacing.as_mut()
     }
 
     pub fn set_line_spacing(&mut self, value: LineSpacing) -> &mut Self {

--- a/src/structs/drawing/preset_color.rs
+++ b/src/structs/drawing/preset_color.rs
@@ -64,9 +64,8 @@ impl PresetColor {
         write_start_tag(writer, "a:prstClr", vec![("val", &self.val)], false);
 
         // a:alpha
-        match &self.alpha {
-            Some(v) => v.write_to(writer),
-            None => {}
+        if let Some(v) = &self.alpha {
+            v.write_to(writer)
         }
 
         write_end_tag(writer, "a:prstClr");

--- a/src/structs/drawing/preset_color.rs
+++ b/src/structs/drawing/preset_color.rs
@@ -22,12 +22,12 @@ impl PresetColor {
         self.val = value.into();
     }
 
-    pub fn get_alpha(&self) -> &Option<Alpha> {
-        &self.alpha
+    pub fn get_alpha(&self) -> Option<&Alpha> {
+        self.alpha.as_ref()
     }
 
-    pub fn get_alpha_mut(&mut self) -> &mut Option<Alpha> {
-        &mut self.alpha
+    pub fn get_alpha_mut(&mut self) -> Option<&mut Alpha> {
+        self.alpha.as_mut()
     }
 
     pub fn set_alpha(&mut self, value: Alpha) {

--- a/src/structs/drawing/rgb_color_model_hex.rs
+++ b/src/structs/drawing/rgb_color_model_hex.rs
@@ -37,8 +37,8 @@ impl RgbColorModelHex {
         self.luminance.as_ref()
     }
 
-    pub fn get_luminance_mut(&mut self) -> &mut Option<PercentageType> {
-        &mut self.luminance
+    pub fn get_luminance_mut(&mut self) -> Option<&mut PercentageType> {
+        self.luminance.as_mut()
     }
 
     pub fn set_luminance(&mut self, value: PercentageType) {
@@ -49,8 +49,8 @@ impl RgbColorModelHex {
         self.luminance_modulation.as_ref()
     }
 
-    pub fn get_luminance_modulation_mut(&mut self) -> &mut Option<PercentageType> {
-        &mut self.luminance_modulation
+    pub fn get_luminance_modulation_mut(&mut self) -> Option<&mut PercentageType> {
+        self.luminance_modulation.as_mut()
     }
 
     pub fn set_luminance_modulation(&mut self, value: PercentageType) {
@@ -61,8 +61,8 @@ impl RgbColorModelHex {
         self.luminance_offset.as_ref()
     }
 
-    pub fn get_luminance_offset_mut(&mut self) -> &mut Option<PercentageType> {
-        &mut self.luminance_offset
+    pub fn get_luminance_offset_mut(&mut self) -> Option<&mut PercentageType> {
+        self.luminance_offset.as_mut()
     }
 
     pub fn set_luminance_offset(&mut self, value: PercentageType) {
@@ -73,8 +73,8 @@ impl RgbColorModelHex {
         self.saturation.as_ref()
     }
 
-    pub fn get_saturation_mut(&mut self) -> &mut Option<PercentageType> {
-        &mut self.saturation
+    pub fn get_saturation_mut(&mut self) -> Option<&mut PercentageType> {
+        self.saturation.as_mut()
     }
 
     pub fn set_saturation(&mut self, value: PercentageType) {
@@ -85,8 +85,8 @@ impl RgbColorModelHex {
         self.saturation_modulation.as_ref()
     }
 
-    pub fn get_saturation_modulation_mut(&mut self) -> &mut Option<PercentageType> {
-        &mut self.saturation_modulation
+    pub fn get_saturation_modulation_mut(&mut self) -> Option<&mut PercentageType> {
+        self.saturation_modulation.as_mut()
     }
 
     pub fn set_saturation_modulation(&mut self, value: PercentageType) {
@@ -97,8 +97,8 @@ impl RgbColorModelHex {
         self.shade.as_ref()
     }
 
-    pub fn get_shade_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {
-        &mut self.shade
+    pub fn get_shade_mut(&mut self) -> Option<&mut PositiveFixedPercentageType> {
+        self.shade.as_mut()
     }
 
     pub fn set_shade(&mut self, value: PositiveFixedPercentageType) {
@@ -109,8 +109,8 @@ impl RgbColorModelHex {
         self.alpha.as_ref()
     }
 
-    pub fn get_alpha_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {
-        &mut self.alpha
+    pub fn get_alpha_mut(&mut self) -> Option<&mut PositiveFixedPercentageType> {
+        self.alpha.as_mut()
     }
 
     pub fn set_alpha(&mut self, value: PositiveFixedPercentageType) {
@@ -121,8 +121,8 @@ impl RgbColorModelHex {
         self.tint.as_ref()
     }
 
-    pub fn get_tint_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {
-        &mut self.tint
+    pub fn get_tint_mut(&mut self) -> Option<&mut PositiveFixedPercentageType> {
+        self.tint.as_mut()
     }
 
     pub fn set_tint(&mut self, value: PositiveFixedPercentageType) {

--- a/src/structs/drawing/rgb_color_model_hex.rs
+++ b/src/structs/drawing/rgb_color_model_hex.rs
@@ -33,8 +33,8 @@ impl RgbColorModelHex {
         self
     }
 
-    pub fn get_luminance(&self) -> &Option<PercentageType> {
-        &self.luminance
+    pub fn get_luminance(&self) -> Option<&PercentageType> {
+        self.luminance.as_ref()
     }
 
     pub fn get_luminance_mut(&mut self) -> &mut Option<PercentageType> {
@@ -45,8 +45,8 @@ impl RgbColorModelHex {
         self.luminance = Some(value);
     }
 
-    pub fn get_luminance_modulation(&self) -> &Option<PercentageType> {
-        &self.luminance_modulation
+    pub fn get_luminance_modulation(&self) -> Option<&PercentageType> {
+        self.luminance_modulation.as_ref()
     }
 
     pub fn get_luminance_modulation_mut(&mut self) -> &mut Option<PercentageType> {
@@ -57,8 +57,8 @@ impl RgbColorModelHex {
         self.luminance_modulation = Some(value);
     }
 
-    pub fn get_luminance_offset(&self) -> &Option<PercentageType> {
-        &self.luminance_offset
+    pub fn get_luminance_offset(&self) -> Option<&PercentageType> {
+        self.luminance_offset.as_ref()
     }
 
     pub fn get_luminance_offset_mut(&mut self) -> &mut Option<PercentageType> {
@@ -69,8 +69,8 @@ impl RgbColorModelHex {
         self.luminance_offset = Some(value);
     }
 
-    pub fn get_saturation(&self) -> &Option<PercentageType> {
-        &self.saturation
+    pub fn get_saturation(&self) -> Option<&PercentageType> {
+        self.saturation.as_ref()
     }
 
     pub fn get_saturation_mut(&mut self) -> &mut Option<PercentageType> {
@@ -81,8 +81,8 @@ impl RgbColorModelHex {
         self.saturation = Some(value);
     }
 
-    pub fn get_saturation_modulation(&self) -> &Option<PercentageType> {
-        &self.saturation_modulation
+    pub fn get_saturation_modulation(&self) -> Option<&PercentageType> {
+        self.saturation_modulation.as_ref()
     }
 
     pub fn get_saturation_modulation_mut(&mut self) -> &mut Option<PercentageType> {
@@ -93,8 +93,8 @@ impl RgbColorModelHex {
         self.saturation_modulation = Some(value);
     }
 
-    pub fn get_shade(&self) -> &Option<PositiveFixedPercentageType> {
-        &self.shade
+    pub fn get_shade(&self) -> Option<&PositiveFixedPercentageType> {
+        self.shade.as_ref()
     }
 
     pub fn get_shade_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {
@@ -105,8 +105,8 @@ impl RgbColorModelHex {
         self.shade = Some(value);
     }
 
-    pub fn get_alpha(&self) -> &Option<PositiveFixedPercentageType> {
-        &self.alpha
+    pub fn get_alpha(&self) -> Option<&PositiveFixedPercentageType> {
+        self.alpha.as_ref()
     }
 
     pub fn get_alpha_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {
@@ -117,8 +117,8 @@ impl RgbColorModelHex {
         self.alpha = Some(value);
     }
 
-    pub fn get_tint(&self) -> &Option<PositiveFixedPercentageType> {
-        &self.tint
+    pub fn get_tint(&self) -> Option<&PositiveFixedPercentageType> {
+        self.tint.as_ref()
     }
 
     pub fn get_tint_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {

--- a/src/structs/drawing/run_properties.rs
+++ b/src/structs/drawing/run_properties.rs
@@ -127,8 +127,8 @@ impl RunProperties {
         self
     }
 
-    pub fn get_solid_fill(&self) -> &Option<SolidFill> {
-        &self.solid_fill
+    pub fn get_solid_fill(&self) -> Option<&SolidFill> {
+        self.solid_fill.as_ref()
     }
 
     pub fn get_solid_fill_mut(&mut self) -> &mut Option<SolidFill> {
@@ -140,8 +140,8 @@ impl RunProperties {
         self
     }
 
-    pub fn get_outline(&self) -> &Option<Outline> {
-        &self.outline
+    pub fn get_outline(&self) -> Option<&Outline> {
+        self.outline.as_ref()
     }
 
     pub fn get_outline_mut(&mut self) -> &mut Option<Outline> {
@@ -153,8 +153,8 @@ impl RunProperties {
         self
     }
 
-    pub fn get_latin_font(&self) -> &Option<TextFontType> {
-        &self.latin_font
+    pub fn get_latin_font(&self) -> Option<&TextFontType> {
+        self.latin_font.as_ref()
     }
 
     pub fn get_latin_font_mut(&mut self) -> &mut Option<TextFontType> {
@@ -166,8 +166,8 @@ impl RunProperties {
         self
     }
 
-    pub fn get_east_asian_font(&self) -> &Option<TextFontType> {
-        &self.east_asian_font
+    pub fn get_east_asian_font(&self) -> Option<&TextFontType> {
+        self.east_asian_font.as_ref()
     }
 
     pub fn get_east_asian_font_mut(&mut self) -> &mut Option<TextFontType> {
@@ -179,8 +179,8 @@ impl RunProperties {
         self
     }
 
-    pub fn get_gradient_fill(&self) -> &Option<GradientFill> {
-        &self.gradient_fill
+    pub fn get_gradient_fill(&self) -> Option<&GradientFill> {
+        self.gradient_fill.as_ref()
     }
 
     pub fn get_gradient_fill_mut(&mut self) -> &mut Option<GradientFill> {
@@ -192,8 +192,8 @@ impl RunProperties {
         self
     }
 
-    pub fn get_no_fill(&self) -> &Option<NoFill> {
-        &self.no_fill
+    pub fn get_no_fill(&self) -> Option<&NoFill> {
+        self.no_fill.as_ref()
     }
 
     pub fn get_no_fill_mut(&mut self) -> &mut Option<NoFill> {
@@ -205,8 +205,8 @@ impl RunProperties {
         self
     }
 
-    pub fn get_effect_list(&self) -> &Option<EffectList> {
-        &self.effect_list
+    pub fn get_effect_list(&self) -> Option<&EffectList> {
+        self.effect_list.as_ref()
     }
 
     pub fn get_effect_list_mut(&mut self) -> &mut Option<EffectList> {

--- a/src/structs/drawing/run_properties.rs
+++ b/src/structs/drawing/run_properties.rs
@@ -131,8 +131,8 @@ impl RunProperties {
         self.solid_fill.as_ref()
     }
 
-    pub fn get_solid_fill_mut(&mut self) -> &mut Option<SolidFill> {
-        &mut self.solid_fill
+    pub fn get_solid_fill_mut(&mut self) -> Option<&mut SolidFill> {
+        self.solid_fill.as_mut()
     }
 
     pub fn set_solid_fill(&mut self, value: SolidFill) -> &mut Self {
@@ -144,8 +144,8 @@ impl RunProperties {
         self.outline.as_ref()
     }
 
-    pub fn get_outline_mut(&mut self) -> &mut Option<Outline> {
-        &mut self.outline
+    pub fn get_outline_mut(&mut self) -> Option<&mut Outline> {
+        self.outline.as_mut()
     }
 
     pub fn set_outline(&mut self, value: Outline) -> &mut Self {
@@ -157,8 +157,8 @@ impl RunProperties {
         self.latin_font.as_ref()
     }
 
-    pub fn get_latin_font_mut(&mut self) -> &mut Option<TextFontType> {
-        &mut self.latin_font
+    pub fn get_latin_font_mut(&mut self) -> Option<&mut TextFontType> {
+        self.latin_font.as_mut()
     }
 
     pub fn set_latin_font(&mut self, value: TextFontType) -> &mut Self {
@@ -170,8 +170,8 @@ impl RunProperties {
         self.east_asian_font.as_ref()
     }
 
-    pub fn get_east_asian_font_mut(&mut self) -> &mut Option<TextFontType> {
-        &mut self.east_asian_font
+    pub fn get_east_asian_font_mut(&mut self) -> Option<&mut TextFontType> {
+        self.east_asian_font.as_mut()
     }
 
     pub fn set_east_asian_font(&mut self, value: TextFontType) -> &mut Self {
@@ -183,8 +183,8 @@ impl RunProperties {
         self.gradient_fill.as_ref()
     }
 
-    pub fn get_gradient_fill_mut(&mut self) -> &mut Option<GradientFill> {
-        &mut self.gradient_fill
+    pub fn get_gradient_fill_mut(&mut self) -> Option<&mut GradientFill> {
+        self.gradient_fill.as_mut()
     }
 
     pub fn set_gradient_fill(&mut self, value: GradientFill) -> &mut Self {
@@ -196,8 +196,8 @@ impl RunProperties {
         self.no_fill.as_ref()
     }
 
-    pub fn get_no_fill_mut(&mut self) -> &mut Option<NoFill> {
-        &mut self.no_fill
+    pub fn get_no_fill_mut(&mut self) -> Option<&mut NoFill> {
+        self.no_fill.as_mut()
     }
 
     pub fn set_no_fill(&mut self, value: NoFill) -> &mut Self {
@@ -209,8 +209,8 @@ impl RunProperties {
         self.effect_list.as_ref()
     }
 
-    pub fn get_effect_list_mut(&mut self) -> &mut Option<EffectList> {
-        &mut self.effect_list
+    pub fn get_effect_list_mut(&mut self) -> Option<&mut EffectList> {
+        self.effect_list.as_mut()
     }
 
     pub fn set_effect_list(&mut self, value: EffectList) -> &mut Self {

--- a/src/structs/drawing/run_properties.rs
+++ b/src/structs/drawing/run_properties.rs
@@ -375,59 +375,38 @@ impl RunProperties {
             write_start_tag(writer, tag_name, attributes, false);
 
             // a:solidFill
-            match &self.solid_fill {
-                Some(v) => {
-                    v.write_to(writer);
-                }
-                None => {}
+            if let Some(v) = &self.solid_fill {
+                v.write_to(writer);
             }
 
             // a:ln
-            match &self.outline {
-                Some(v) => {
-                    v.write_to(writer);
-                }
-                None => {}
+            if let Some(v) = &self.outline {
+                v.write_to(writer);
             }
 
             // a:latin
-            match &self.latin_font {
-                Some(v) => {
-                    v.write_to_latin(writer);
-                }
-                None => {}
+            if let Some(v) = &self.latin_font {
+                v.write_to_latin(writer);
             }
 
             // a:ea
-            match &self.east_asian_font {
-                Some(v) => {
-                    v.write_to_ea(writer);
-                }
-                None => {}
+            if let Some(v) = &self.east_asian_font {
+                v.write_to_ea(writer);
             }
 
             // a:gradFill
-            match &self.gradient_fill {
-                Some(v) => {
-                    v.write_to(writer);
-                }
-                None => {}
+            if let Some(v) = &self.gradient_fill {
+                v.write_to(writer);
             }
 
             // a:noFill
-            match &self.no_fill {
-                Some(v) => {
-                    v.write_to(writer);
-                }
-                None => {}
+            if let Some(v) = &self.no_fill {
+                v.write_to(writer);
             }
 
             // a:effectLst
-            match &self.effect_list {
-                Some(v) => {
-                    v.write_to(writer);
-                }
-                None => {}
+            if let Some(v) = &self.effect_list {
+                v.write_to(writer);
             }
 
             write_end_tag(writer, tag_name);

--- a/src/structs/drawing/scene_3d_type.rs
+++ b/src/structs/drawing/scene_3d_type.rs
@@ -15,8 +15,8 @@ pub struct Scene3DType {
 }
 
 impl Scene3DType {
-    pub fn get_camera(&self) -> &Option<Camera> {
-        &self.camera
+    pub fn get_camera(&self) -> Option<&Camera> {
+        self.camera.as_ref()
     }
 
     pub fn set_camera(&mut self, value: Camera) -> &mut Scene3DType {
@@ -24,8 +24,8 @@ impl Scene3DType {
         self
     }
 
-    pub fn get_light_rig(&self) -> &Option<LightRig> {
-        &self.light_rig
+    pub fn get_light_rig(&self) -> Option<&LightRig> {
+        self.light_rig.as_ref()
     }
 
     pub fn set_light_rig(&mut self, value: LightRig) -> &mut Scene3DType {

--- a/src/structs/drawing/scheme_color.rs
+++ b/src/structs/drawing/scheme_color.rs
@@ -33,8 +33,8 @@ impl SchemeColor {
         self
     }
 
-    pub fn get_luminance(&self) -> &Option<PercentageType> {
-        &self.luminance
+    pub fn get_luminance(&self) -> Option<&PercentageType> {
+        self.luminance.as_ref()
     }
 
     pub fn get_luminance_mut(&mut self) -> &mut Option<PercentageType> {
@@ -45,8 +45,8 @@ impl SchemeColor {
         self.luminance = Some(value);
     }
 
-    pub fn get_luminance_modulation(&self) -> &Option<PercentageType> {
-        &self.luminance_modulation
+    pub fn get_luminance_modulation(&self) -> Option<&PercentageType> {
+        self.luminance_modulation.as_ref()
     }
 
     pub fn get_luminance_modulation_mut(&mut self) -> &mut Option<PercentageType> {
@@ -57,8 +57,8 @@ impl SchemeColor {
         self.luminance_modulation = Some(value);
     }
 
-    pub fn get_luminance_offset(&self) -> &Option<PercentageType> {
-        &self.luminance_offset
+    pub fn get_luminance_offset(&self) -> Option<&PercentageType> {
+        self.luminance_offset.as_ref()
     }
 
     pub fn get_luminance_offset_mut(&mut self) -> &mut Option<PercentageType> {
@@ -69,8 +69,8 @@ impl SchemeColor {
         self.luminance_offset = Some(value);
     }
 
-    pub fn get_saturation(&self) -> &Option<PercentageType> {
-        &self.saturation
+    pub fn get_saturation(&self) -> Option<&PercentageType> {
+        self.saturation.as_ref()
     }
 
     pub fn get_saturation_mut(&mut self) -> &mut Option<PercentageType> {
@@ -81,8 +81,8 @@ impl SchemeColor {
         self.saturation = Some(value);
     }
 
-    pub fn get_saturation_modulation(&self) -> &Option<PercentageType> {
-        &self.saturation_modulation
+    pub fn get_saturation_modulation(&self) -> Option<&PercentageType> {
+        self.saturation_modulation.as_ref()
     }
 
     pub fn get_saturation_modulation_mut(&mut self) -> &mut Option<PercentageType> {
@@ -93,8 +93,8 @@ impl SchemeColor {
         self.saturation_modulation = Some(value);
     }
 
-    pub fn get_shade(&self) -> &Option<PositiveFixedPercentageType> {
-        &self.shade
+    pub fn get_shade(&self) -> Option<&PositiveFixedPercentageType> {
+        self.shade.as_ref()
     }
 
     pub fn get_shade_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {
@@ -105,8 +105,8 @@ impl SchemeColor {
         self.shade = Some(value);
     }
 
-    pub fn get_alpha(&self) -> &Option<PositiveFixedPercentageType> {
-        &self.alpha
+    pub fn get_alpha(&self) -> Option<&PositiveFixedPercentageType> {
+        self.alpha.as_ref()
     }
 
     pub fn get_alpha_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {
@@ -117,8 +117,8 @@ impl SchemeColor {
         self.alpha = Some(value);
     }
 
-    pub fn get_tint(&self) -> &Option<PositiveFixedPercentageType> {
-        &self.tint
+    pub fn get_tint(&self) -> Option<&PositiveFixedPercentageType> {
+        self.tint.as_ref()
     }
 
     pub fn get_tint_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {

--- a/src/structs/drawing/scheme_color.rs
+++ b/src/structs/drawing/scheme_color.rs
@@ -37,8 +37,8 @@ impl SchemeColor {
         self.luminance.as_ref()
     }
 
-    pub fn get_luminance_mut(&mut self) -> &mut Option<PercentageType> {
-        &mut self.luminance
+    pub fn get_luminance_mut(&mut self) -> Option<&mut PercentageType> {
+        self.luminance.as_mut()
     }
 
     pub fn set_luminance(&mut self, value: PercentageType) {
@@ -49,8 +49,8 @@ impl SchemeColor {
         self.luminance_modulation.as_ref()
     }
 
-    pub fn get_luminance_modulation_mut(&mut self) -> &mut Option<PercentageType> {
-        &mut self.luminance_modulation
+    pub fn get_luminance_modulation_mut(&mut self) -> Option<&mut PercentageType> {
+        self.luminance_modulation.as_mut()
     }
 
     pub fn set_luminance_modulation(&mut self, value: PercentageType) {
@@ -61,8 +61,8 @@ impl SchemeColor {
         self.luminance_offset.as_ref()
     }
 
-    pub fn get_luminance_offset_mut(&mut self) -> &mut Option<PercentageType> {
-        &mut self.luminance_offset
+    pub fn get_luminance_offset_mut(&mut self) -> Option<&mut PercentageType> {
+        self.luminance_offset.as_mut()
     }
 
     pub fn set_luminance_offset(&mut self, value: PercentageType) {
@@ -73,8 +73,8 @@ impl SchemeColor {
         self.saturation.as_ref()
     }
 
-    pub fn get_saturation_mut(&mut self) -> &mut Option<PercentageType> {
-        &mut self.saturation
+    pub fn get_saturation_mut(&mut self) -> Option<&mut PercentageType> {
+        self.saturation.as_mut()
     }
 
     pub fn set_saturation(&mut self, value: PercentageType) {
@@ -85,8 +85,8 @@ impl SchemeColor {
         self.saturation_modulation.as_ref()
     }
 
-    pub fn get_saturation_modulation_mut(&mut self) -> &mut Option<PercentageType> {
-        &mut self.saturation_modulation
+    pub fn get_saturation_modulation_mut(&mut self) -> Option<&mut PercentageType> {
+        self.saturation_modulation.as_mut()
     }
 
     pub fn set_saturation_modulation(&mut self, value: PercentageType) {
@@ -97,8 +97,8 @@ impl SchemeColor {
         self.shade.as_ref()
     }
 
-    pub fn get_shade_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {
-        &mut self.shade
+    pub fn get_shade_mut(&mut self) -> Option<&mut PositiveFixedPercentageType> {
+        self.shade.as_mut()
     }
 
     pub fn set_shade(&mut self, value: PositiveFixedPercentageType) {
@@ -109,8 +109,8 @@ impl SchemeColor {
         self.alpha.as_ref()
     }
 
-    pub fn get_alpha_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {
-        &mut self.alpha
+    pub fn get_alpha_mut(&mut self) -> Option<&mut PositiveFixedPercentageType> {
+        self.alpha.as_mut()
     }
 
     pub fn set_alpha(&mut self, value: PositiveFixedPercentageType) {
@@ -121,8 +121,8 @@ impl SchemeColor {
         self.tint.as_ref()
     }
 
-    pub fn get_tint_mut(&mut self) -> &mut Option<PositiveFixedPercentageType> {
-        &mut self.tint
+    pub fn get_tint_mut(&mut self) -> Option<&mut PositiveFixedPercentageType> {
+        self.tint.as_mut()
     }
 
     pub fn set_tint(&mut self, value: PositiveFixedPercentageType) {

--- a/src/structs/drawing/shape_3d_type.rs
+++ b/src/structs/drawing/shape_3d_type.rs
@@ -27,24 +27,24 @@ impl Shape3DType {
         self
     }
 
-    pub fn get_bevel_top(&self) -> &Option<BevelTop> {
-        &self.bevel_top
+    pub fn get_bevel_top(&self) -> Option<&BevelTop> {
+        self.bevel_top.as_ref()
     }
 
-    pub fn get_bevel_top_mut(&mut self) -> &mut Option<BevelTop> {
-        &mut self.bevel_top
+    pub fn get_bevel_top_mut(&mut self) -> Option<&mut BevelTop> {
+        self.bevel_top.as_mut()
     }
 
     pub fn set_bevel_top(&mut self, value: BevelTop) {
         self.bevel_top = Some(value);
     }
 
-    pub fn get_bevel_bottom(&self) -> &Option<BevelBottom> {
-        &self.bevel_bottom
+    pub fn get_bevel_bottom(&self) -> Option<&BevelBottom> {
+        self.bevel_bottom.as_ref()
     }
 
-    pub fn get_bevel_bottom_mut(&mut self) -> &mut Option<BevelBottom> {
-        &mut self.bevel_bottom
+    pub fn get_bevel_bottom_mut(&mut self) -> Option<&mut BevelBottom> {
+        self.bevel_bottom.as_mut()
     }
 
     pub fn set_bevel_bottom(&mut self, value: BevelBottom) {

--- a/src/structs/drawing/solid_fill.rs
+++ b/src/structs/drawing/solid_fill.rs
@@ -15,24 +15,24 @@ pub struct SolidFill {
 }
 
 impl SolidFill {
-    pub fn get_scheme_color(&self) -> &Option<SchemeColor> {
-        &self.scheme_color
+    pub fn get_scheme_color(&self) -> Option<&SchemeColor> {
+        self.scheme_color.as_ref()
     }
 
-    pub fn get_scheme_color_mut(&mut self) -> &mut Option<SchemeColor> {
-        &mut self.scheme_color
+    pub fn get_scheme_color_mut(&mut self) -> Option<&mut SchemeColor> {
+        self.scheme_color.as_mut()
     }
 
     pub fn set_scheme_color(&mut self, value: SchemeColor) {
         self.scheme_color = Some(value);
     }
 
-    pub fn get_rgb_color_model_hex(&self) -> &Option<RgbColorModelHex> {
-        &self.rgb_color_model_hex
+    pub fn get_rgb_color_model_hex(&self) -> Option<&RgbColorModelHex> {
+        self.rgb_color_model_hex.as_ref()
     }
 
-    pub fn get_rgb_color_model_hex_mut(&mut self) -> &mut Option<RgbColorModelHex> {
-        &mut self.rgb_color_model_hex
+    pub fn get_rgb_color_model_hex_mut(&mut self) -> Option<&mut RgbColorModelHex> {
+        self.rgb_color_model_hex.as_mut()
     }
 
     pub fn set_rgb_color_model_hex(&mut self, value: RgbColorModelHex) {

--- a/src/structs/drawing/source_rectangle.rs
+++ b/src/structs/drawing/source_rectangle.rs
@@ -74,21 +74,18 @@ impl SourceRectangle {
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:srcRect
         let mut attributes: Vec<(&str, &str)> = Vec::new();
-        match &self.t {
-            Some(v) => attributes.push(("t", v)),
-            None => {}
+
+        if let Some(v) = &self.t {
+            attributes.push(("t", v))
         }
-        match &self.l {
-            Some(v) => attributes.push(("l", v)),
-            None => {}
+        if let Some(v) = &self.l {
+            attributes.push(("l", v))
         }
-        match &self.r {
-            Some(v) => attributes.push(("r", v)),
-            None => {}
+        if let Some(v) = &self.r {
+            attributes.push(("r", v))
         }
-        match &self.b {
-            Some(v) => attributes.push(("b", v)),
-            None => {}
+        if let Some(v) = &self.b {
+            attributes.push(("b", v))
         }
         write_start_tag(writer, "a:srcRect", attributes, true);
     }

--- a/src/structs/drawing/source_rectangle.rs
+++ b/src/structs/drawing/source_rectangle.rs
@@ -18,32 +18,32 @@ impl SourceRectangle {
         self.t = Some(value.into());
     }
 
-    pub fn get_t(&self) -> &Option<String> {
-        &self.t
+    pub fn get_t(&self) -> Option<&String> {
+        self.t.as_ref()
     }
 
     pub fn set_l<S: Into<String>>(&mut self, value: S) {
         self.l = Some(value.into());
     }
 
-    pub fn get_l(&self) -> &Option<String> {
-        &self.l
+    pub fn get_l(&self) -> Option<&String> {
+        self.l.as_ref()
     }
 
     pub fn set_r<S: Into<String>>(&mut self, value: S) {
         self.r = Some(value.into());
     }
 
-    pub fn get_r(&self) -> &Option<String> {
-        &self.r
+    pub fn get_r(&self) -> Option<&String> {
+        self.r.as_ref()
     }
 
     pub fn set_b<S: Into<String>>(&mut self, value: S) {
         self.b = Some(value.into());
     }
 
-    pub fn get_b(&self) -> &Option<String> {
-        &self.b
+    pub fn get_b(&self) -> Option<&String> {
+        self.b.as_ref()
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/spreadsheet/blip_fill.rs
+++ b/src/structs/drawing/spreadsheet/blip_fill.rs
@@ -29,12 +29,12 @@ impl BlipFill {
         self
     }
 
-    pub fn get_source_rectangle(&self) -> &Option<SourceRectangle> {
-        &self.source_rectangle
+    pub fn get_source_rectangle(&self) -> Option<&SourceRectangle> {
+        self.source_rectangle.as_ref()
     }
 
-    pub fn get_source_rectangle_mut(&mut self) -> &mut Option<SourceRectangle> {
-        &mut self.source_rectangle
+    pub fn get_source_rectangle_mut(&mut self) -> Option<&mut SourceRectangle> {
+        self.source_rectangle.as_mut()
     }
 
     pub fn set_source_rectangle(&mut self, value: SourceRectangle) -> &mut BlipFill {

--- a/src/structs/drawing/spreadsheet/non_visual_connector_shape_drawing_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_connector_shape_drawing_properties.rs
@@ -15,8 +15,8 @@ pub struct NonVisualConnectorShapeDrawingProperties {
 }
 
 impl NonVisualConnectorShapeDrawingProperties {
-    pub fn get_start_connection(&self) -> &Option<StartConnection> {
-        &self.start_connection
+    pub fn get_start_connection(&self) -> Option<&StartConnection> {
+        self.start_connection.as_ref()
     }
 
     pub fn set_start_connection(&mut self, value: StartConnection) {
@@ -27,8 +27,8 @@ impl NonVisualConnectorShapeDrawingProperties {
         self.start_connection = None;
     }
 
-    pub fn get_end_connection(&self) -> &Option<EndConnection> {
-        &self.end_connection
+    pub fn get_end_connection(&self) -> Option<&EndConnection> {
+        self.end_connection.as_ref()
     }
 
     pub fn set_end_connection(&mut self, value: EndConnection) {

--- a/src/structs/drawing/spreadsheet/non_visual_picture_drawing_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_picture_drawing_properties.rs
@@ -23,12 +23,12 @@ impl NonVisualPictureDrawingProperties {
         self.prefer_relative_resize.set_value(value);
     }
 
-    pub fn get_picture_locks(&self) -> &Option<PictureLocks> {
-        &self.picture_locks
+    pub fn get_picture_locks(&self) -> Option<&PictureLocks> {
+        self.picture_locks.as_ref()
     }
 
-    pub fn get_picture_locks_mut(&mut self) -> &mut Option<PictureLocks> {
-        &mut self.picture_locks
+    pub fn get_picture_locks_mut(&mut self) -> Option<&mut PictureLocks> {
+        self.picture_locks.as_mut()
     }
 
     pub fn set_picture_locks(&mut self, value: PictureLocks) {

--- a/src/structs/drawing/spreadsheet/non_visual_picture_drawing_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_picture_drawing_properties.rs
@@ -66,8 +66,6 @@ impl NonVisualPictureDrawingProperties {
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
-        let is_empty = self.picture_locks.is_none();
-
         // xdr:cNvPicPr
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.prefer_relative_resize.has_value() {
@@ -76,18 +74,16 @@ impl NonVisualPictureDrawingProperties {
                 self.prefer_relative_resize.get_value_string(),
             ));
         }
-        write_start_tag(writer, "xdr:cNvPicPr", attributes, is_empty);
 
-        if !is_empty {
-            // a:picLocks
-            match &self.picture_locks {
-                Some(v) => {
-                    v.write_to(writer);
-                }
-                None => {}
+        match &self.picture_locks {
+            Some(v) => {
+                write_start_tag(writer, "xdr:cNvPicPr", attributes, false);
+                v.write_to(writer);
+                write_end_tag(writer, "xdr:cNvPicPr");
             }
-
-            write_end_tag(writer, "xdr:cNvPicPr");
+            None => {
+                write_start_tag(writer, "xdr:cNvPicPr", attributes, true);
+            }
         }
     }
 }

--- a/src/structs/drawing/spreadsheet/one_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/one_cell_anchor.rs
@@ -143,18 +143,14 @@ impl OneCellAnchor {
         let _ = &self.extent.write_to(writer);
 
         // xdr:sp
-        match &self.shape {
-            Some(v) => v.write_to(writer, &0),
-            None => {}
+        if let Some(v) = &self.shape {
+            v.write_to(writer, &0)
         }
 
         // xdr:pic
-        match &self.picture {
-            Some(v) => {
-                v.write_to(writer, r_id);
-                *r_id += 1i32;
-            }
-            None => {}
+        if let Some(v) = &self.picture {
+            v.write_to(writer, r_id);
+            *r_id += 1i32;
         }
 
         // xdr:clientData

--- a/src/structs/drawing/spreadsheet/one_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/one_cell_anchor.rs
@@ -50,8 +50,8 @@ impl OneCellAnchor {
         self.shape.as_ref()
     }
 
-    pub fn get_shape_mut(&mut self) -> &mut Option<Shape> {
-        &mut self.shape
+    pub fn get_shape_mut(&mut self) -> Option<&mut Shape> {
+        self.shape.as_mut()
     }
 
     pub fn set_shape(&mut self, value: Shape) -> &mut OneCellAnchor {
@@ -63,8 +63,8 @@ impl OneCellAnchor {
         self.picture.as_ref()
     }
 
-    pub fn get_picture_mut(&mut self) -> &mut Option<Picture> {
-        &mut self.picture
+    pub fn get_picture_mut(&mut self) -> Option<&mut Picture> {
+        self.picture.as_mut()
     }
 
     pub fn set_picture(&mut self, value: Picture) -> &mut Self {

--- a/src/structs/drawing/spreadsheet/one_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/one_cell_anchor.rs
@@ -46,8 +46,8 @@ impl OneCellAnchor {
         self
     }
 
-    pub fn get_shape(&self) -> &Option<Shape> {
-        &self.shape
+    pub fn get_shape(&self) -> Option<&Shape> {
+        self.shape.as_ref()
     }
 
     pub fn get_shape_mut(&mut self) -> &mut Option<Shape> {
@@ -59,8 +59,8 @@ impl OneCellAnchor {
         self
     }
 
-    pub fn get_picture(&self) -> &Option<Picture> {
-        &self.picture
+    pub fn get_picture(&self) -> Option<&Picture> {
+        self.picture.as_ref()
     }
 
     pub fn get_picture_mut(&mut self) -> &mut Option<Picture> {
@@ -89,13 +89,7 @@ impl OneCellAnchor {
     }
 
     pub(crate) fn is_image(&self) -> bool {
-        match &self.picture {
-            Some(_) => {
-                return true;
-            }
-            None => {}
-        }
-        false
+        self.picture.is_some()
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/spreadsheet/shape.rs
+++ b/src/structs/drawing/spreadsheet/shape.rs
@@ -56,24 +56,24 @@ impl Shape {
         self.shape_properties = value;
     }
 
-    pub fn get_shape_style(&self) -> &Option<ShapeStyle> {
-        &self.shape_style
+    pub fn get_shape_style(&self) -> Option<&ShapeStyle> {
+        self.shape_style.as_ref()
     }
 
-    pub fn get_shape_style_mut(&mut self) -> &mut Option<ShapeStyle> {
-        &mut self.shape_style
+    pub fn get_shape_style_mut(&mut self) -> Option<&mut ShapeStyle> {
+        self.shape_style.as_mut()
     }
 
     pub fn set_shape_style(&mut self, value: ShapeStyle) {
         self.shape_style = Some(value);
     }
 
-    pub fn get_text_body(&self) -> &Option<TextBody> {
-        &self.text_body
+    pub fn get_text_body(&self) -> Option<&TextBody> {
+        self.text_body.as_ref()
     }
 
-    pub fn get_text_body_mut(&mut self) -> &mut Option<TextBody> {
-        &mut self.text_body
+    pub fn get_text_body_mut(&mut self) -> Option<&mut TextBody> {
+        self.text_body.as_mut()
     }
 
     pub fn set_text_body(&mut self, value: TextBody) {

--- a/src/structs/drawing/spreadsheet/shape_properties.rs
+++ b/src/structs/drawing/spreadsheet/shape_properties.rs
@@ -36,8 +36,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_transform2d(&self) -> &Option<Transform2D> {
-        &self.transform2d
+    pub fn get_transform2d(&self) -> Option<&Transform2D> {
+        self.transform2d.as_ref()
     }
 
     pub fn get_transform2d_mut(&mut self) -> &mut Option<Transform2D> {
@@ -49,8 +49,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_solid_fill(&self) -> &Option<SolidFill> {
-        &self.solid_fill
+    pub fn get_solid_fill(&self) -> Option<&SolidFill> {
+        self.solid_fill.as_ref()
     }
 
     pub fn get_solid_fill_mut(&mut self) -> &mut Option<SolidFill> {
@@ -62,8 +62,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_outline(&self) -> &Option<Outline> {
-        &self.outline
+    pub fn get_outline(&self) -> Option<&Outline> {
+        self.outline.as_ref()
     }
 
     pub fn get_outline_mut(&mut self) -> &mut Option<Outline> {
@@ -75,8 +75,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_effect_list(&self) -> &Option<EffectList> {
-        &self.effect_list
+    pub fn get_effect_list(&self) -> Option<&EffectList> {
+        self.effect_list.as_ref()
     }
 
     pub fn get_effect_list_mut(&mut self) -> &mut Option<EffectList> {
@@ -88,8 +88,8 @@ impl ShapeProperties {
         self
     }
 
-    pub fn get_no_fill(&self) -> &Option<NoFill> {
-        &self.no_fill
+    pub fn get_no_fill(&self) -> Option<&NoFill> {
+        self.no_fill.as_ref()
     }
 
     pub fn get_no_fill_mut(&mut self) -> &mut Option<NoFill> {

--- a/src/structs/drawing/spreadsheet/shape_properties.rs
+++ b/src/structs/drawing/spreadsheet/shape_properties.rs
@@ -40,8 +40,8 @@ impl ShapeProperties {
         self.transform2d.as_ref()
     }
 
-    pub fn get_transform2d_mut(&mut self) -> &mut Option<Transform2D> {
-        &mut self.transform2d
+    pub fn get_transform2d_mut(&mut self) -> Option<&mut Transform2D> {
+        self.transform2d.as_mut()
     }
 
     pub fn set_transform2d(&mut self, value: Transform2D) -> &mut ShapeProperties {
@@ -53,8 +53,8 @@ impl ShapeProperties {
         self.solid_fill.as_ref()
     }
 
-    pub fn get_solid_fill_mut(&mut self) -> &mut Option<SolidFill> {
-        &mut self.solid_fill
+    pub fn get_solid_fill_mut(&mut self) -> Option<&mut SolidFill> {
+        self.solid_fill.as_mut()
     }
 
     pub fn set_solid_fill(&mut self, value: SolidFill) -> &mut ShapeProperties {
@@ -66,8 +66,8 @@ impl ShapeProperties {
         self.outline.as_ref()
     }
 
-    pub fn get_outline_mut(&mut self) -> &mut Option<Outline> {
-        &mut self.outline
+    pub fn get_outline_mut(&mut self) -> Option<&mut Outline> {
+        self.outline.as_mut()
     }
 
     pub fn set_outline(&mut self, value: Outline) -> &mut ShapeProperties {
@@ -79,8 +79,8 @@ impl ShapeProperties {
         self.effect_list.as_ref()
     }
 
-    pub fn get_effect_list_mut(&mut self) -> &mut Option<EffectList> {
-        &mut self.effect_list
+    pub fn get_effect_list_mut(&mut self) -> Option<&mut EffectList> {
+        self.effect_list.as_mut()
     }
 
     pub fn set_effect_list(&mut self, value: EffectList) -> &mut ShapeProperties {
@@ -92,8 +92,8 @@ impl ShapeProperties {
         self.no_fill.as_ref()
     }
 
-    pub fn get_no_fill_mut(&mut self) -> &mut Option<NoFill> {
-        &mut self.no_fill
+    pub fn get_no_fill_mut(&mut self) -> Option<&mut NoFill> {
+        self.no_fill.as_mut()
     }
 
     pub fn set_no_fill(&mut self, value: NoFill) -> &mut ShapeProperties {

--- a/src/structs/drawing/spreadsheet/shape_style.rs
+++ b/src/structs/drawing/spreadsheet/shape_style.rs
@@ -16,32 +16,32 @@ pub struct ShapeStyle {
 }
 
 impl ShapeStyle {
-    pub fn get_line_reference(&self) -> &Option<StyleMatrixReferenceType> {
-        &self.line_reference
+    pub fn get_line_reference(&self) -> Option<&StyleMatrixReferenceType> {
+        self.line_reference.as_ref()
     }
 
     pub fn set_line_reference(&mut self, value: StyleMatrixReferenceType) {
         self.line_reference = Some(value);
     }
 
-    pub fn get_fill_reference(&self) -> &Option<StyleMatrixReferenceType> {
-        &self.fill_reference
+    pub fn get_fill_reference(&self) -> Option<&StyleMatrixReferenceType> {
+        self.fill_reference.as_ref()
     }
 
     pub fn set_fill_reference(&mut self, value: StyleMatrixReferenceType) {
         self.fill_reference = Some(value);
     }
 
-    pub fn get_effect_reference(&self) -> &Option<StyleMatrixReferenceType> {
-        &self.effect_reference
+    pub fn get_effect_reference(&self) -> Option<&StyleMatrixReferenceType> {
+        self.effect_reference.as_ref()
     }
 
     pub fn set_effect_reference(&mut self, value: StyleMatrixReferenceType) {
         self.effect_reference = Some(value);
     }
 
-    pub fn get_font_reference(&self) -> &Option<StyleMatrixReferenceType> {
-        &self.font_reference
+    pub fn get_font_reference(&self) -> Option<&StyleMatrixReferenceType> {
+        self.font_reference.as_ref()
     }
 
     pub fn set_font_reference(&mut self, value: StyleMatrixReferenceType) {

--- a/src/structs/drawing/spreadsheet/two_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/two_cell_anchor.rs
@@ -65,8 +65,8 @@ impl TwoCellAnchor {
         self
     }
 
-    pub fn get_graphic_frame(&self) -> &Option<GraphicFrame> {
-        &self.graphic_frame
+    pub fn get_graphic_frame(&self) -> Option<&GraphicFrame> {
+        self.graphic_frame.as_ref()
     }
 
     pub fn get_graphic_frame_mut(&mut self) -> &mut Option<GraphicFrame> {
@@ -78,8 +78,8 @@ impl TwoCellAnchor {
         self
     }
 
-    pub fn get_shape(&self) -> &Option<Shape> {
-        &self.shape
+    pub fn get_shape(&self) -> Option<&Shape> {
+        self.shape.as_ref()
     }
 
     pub fn get_shape_mut(&mut self) -> &mut Option<Shape> {
@@ -91,8 +91,8 @@ impl TwoCellAnchor {
         self
     }
 
-    pub fn get_connection_shape(&self) -> &Option<ConnectionShape> {
-        &self.connection_shape
+    pub fn get_connection_shape(&self) -> Option<&ConnectionShape> {
+        self.connection_shape.as_ref()
     }
 
     pub fn get_connection_shape_mut(&mut self) -> &mut Option<ConnectionShape> {
@@ -104,8 +104,8 @@ impl TwoCellAnchor {
         self
     }
 
-    pub fn get_picture(&self) -> &Option<Picture> {
-        &self.picture
+    pub fn get_picture(&self) -> Option<&Picture> {
+        self.picture.as_ref()
     }
 
     pub fn get_picture_mut(&mut self) -> &mut Option<Picture> {
@@ -163,23 +163,11 @@ impl TwoCellAnchor {
     }
 
     pub(crate) fn is_chart(&self) -> bool {
-        match &self.graphic_frame {
-            Some(_) => {
-                return true;
-            }
-            None => {}
-        }
-        false
+        self.graphic_frame.is_some()
     }
 
     pub(crate) fn is_image(&self) -> bool {
-        match &self.picture {
-            Some(_) => {
-                return true;
-            }
-            None => {}
-        }
-        false
+        self.picture.is_some()
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/spreadsheet/two_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/two_cell_anchor.rs
@@ -69,8 +69,8 @@ impl TwoCellAnchor {
         self.graphic_frame.as_ref()
     }
 
-    pub fn get_graphic_frame_mut(&mut self) -> &mut Option<GraphicFrame> {
-        &mut self.graphic_frame
+    pub fn get_graphic_frame_mut(&mut self) -> Option<&mut GraphicFrame> {
+        self.graphic_frame.as_mut()
     }
 
     pub fn set_graphic_frame(&mut self, value: GraphicFrame) -> &mut Self {
@@ -82,8 +82,8 @@ impl TwoCellAnchor {
         self.shape.as_ref()
     }
 
-    pub fn get_shape_mut(&mut self) -> &mut Option<Shape> {
-        &mut self.shape
+    pub fn get_shape_mut(&mut self) -> Option<&mut Shape> {
+        self.shape.as_mut()
     }
 
     pub fn set_shape(&mut self, value: Shape) -> &mut Self {
@@ -95,8 +95,8 @@ impl TwoCellAnchor {
         self.connection_shape.as_ref()
     }
 
-    pub fn get_connection_shape_mut(&mut self) -> &mut Option<ConnectionShape> {
-        &mut self.connection_shape
+    pub fn get_connection_shape_mut(&mut self) -> Option<&mut ConnectionShape> {
+        self.connection_shape.as_mut()
     }
 
     pub fn set_connection_shape(&mut self, value: ConnectionShape) -> &mut Self {
@@ -108,8 +108,8 @@ impl TwoCellAnchor {
         self.picture.as_ref()
     }
 
-    pub fn get_picture_mut(&mut self) -> &mut Option<Picture> {
-        &mut self.picture
+    pub fn get_picture_mut(&mut self) -> Option<&mut Picture> {
+        self.picture.as_mut()
     }
 
     pub fn set_picture(&mut self, value: Picture) -> &mut Self {

--- a/src/structs/drawing/spreadsheet/two_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/two_cell_anchor.rs
@@ -147,19 +147,14 @@ impl TwoCellAnchor {
     }
 
     pub(crate) fn is_support(&self) -> bool {
-        match &self.graphic_frame {
-            Some(v) => {
-                return v
-                    .get_graphic()
-                    .get_graphic_data()
-                    .get_chart_space()
-                    .get_chart()
-                    .get_plot_area()
-                    .is_support();
-            }
-            None => {}
-        }
-        true
+        self.graphic_frame.as_ref().map_or(true, |v| {
+            v.get_graphic()
+                .get_graphic_data()
+                .get_chart_space()
+                .get_chart()
+                .get_plot_area()
+                .is_support()
+        })
     }
 
     pub(crate) fn is_chart(&self) -> bool {

--- a/src/structs/drawing/stretch.rs
+++ b/src/structs/drawing/stretch.rs
@@ -50,18 +50,15 @@ impl Stretch {
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:stretch
-        if self.fill_rectangle.is_some() {
-            write_start_tag(writer, "a:stretch", vec![], false);
-
-            // a:fillRect
-            match &self.fill_rectangle {
-                Some(v) => v.write_to(writer),
-                None => {}
+        match &self.fill_rectangle {
+            Some(v) => {
+                write_start_tag(writer, "a:stretch", vec![], false);
+                v.write_to(writer);
+                write_end_tag(writer, "a:stretch");
             }
-
-            write_end_tag(writer, "a:stretch");
-        } else {
-            write_start_tag(writer, "a:stretch", vec![], true);
+            None => {
+                write_start_tag(writer, "a:stretch", vec![], true);
+            }
         }
     }
 }

--- a/src/structs/drawing/stretch.rs
+++ b/src/structs/drawing/stretch.rs
@@ -13,12 +13,12 @@ pub struct Stretch {
 }
 
 impl Stretch {
-    pub fn get_fill_rectangle(&self) -> &Option<FillRectangle> {
-        &self.fill_rectangle
+    pub fn get_fill_rectangle(&self) -> Option<&FillRectangle> {
+        self.fill_rectangle.as_ref()
     }
 
-    pub fn get_fill_rectangle_mut(&mut self) -> &mut Option<FillRectangle> {
-        &mut self.fill_rectangle
+    pub fn get_fill_rectangle_mut(&mut self) -> Option<&mut FillRectangle> {
+        self.fill_rectangle.as_mut()
     }
 
     pub fn set_fill_rectangle(&mut self, value: FillRectangle) {

--- a/src/structs/drawing/style_matrix_reference_type.rs
+++ b/src/structs/drawing/style_matrix_reference_type.rs
@@ -22,8 +22,8 @@ impl StyleMatrixReferenceType {
         self.index = value.into();
     }
 
-    pub fn get_scheme_color(&self) -> &Option<SchemeColor> {
-        &self.scheme_color
+    pub fn get_scheme_color(&self) -> Option<&SchemeColor> {
+        self.scheme_color.as_ref()
     }
 
     pub fn set_scheme_color(&mut self, value: SchemeColor) {

--- a/src/structs/drawing/transform2d.rs
+++ b/src/structs/drawing/transform2d.rs
@@ -50,24 +50,24 @@ impl Transform2D {
         self.height = value;
     }
 
-    pub fn get_rot(&self) -> &Option<String> {
-        &self.rot
+    pub fn get_rot(&self) -> Option<&String> {
+        self.rot.as_ref()
     }
 
     pub fn set_rot<S: Into<String>>(&mut self, value: S) {
         self.rot = Some(value.into());
     }
 
-    pub fn get_flip_v(&self) -> &Option<String> {
-        &self.flip_v
+    pub fn get_flip_v(&self) -> Option<&String> {
+        self.flip_v.as_ref()
     }
 
     pub fn set_flip_v<S: Into<String>>(&mut self, value: S) {
         self.flip_v = Some(value.into());
     }
 
-    pub fn get_flip_h(&self) -> &Option<String> {
-        &self.flip_h
+    pub fn get_flip_h(&self) -> Option<&String> {
+        self.flip_h.as_ref()
     }
 
     pub fn set_flip_h<S: Into<String>>(&mut self, value: S) {

--- a/src/structs/drawing/transform2d.rs
+++ b/src/structs/drawing/transform2d.rs
@@ -118,17 +118,14 @@ impl Transform2D {
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:xfrm
         let mut attributes: Vec<(&str, &str)> = Vec::new();
-        match &self.rot {
-            Some(v) => attributes.push(("rot", v)),
-            None => {}
+        if let Some(v) = &self.rot {
+            attributes.push(("rot", v))
         }
-        match &self.flip_h {
-            Some(v) => attributes.push(("flipH", v)),
-            None => {}
+        if let Some(v) = &self.flip_h {
+            attributes.push(("flipH", v))
         }
-        match &self.flip_v {
-            Some(v) => attributes.push(("flipV", v)),
-            None => {}
+        if let Some(v) = &self.flip_v {
+            attributes.push(("flipV", v))
         }
         write_start_tag(writer, "a:xfrm", attributes, false);
 

--- a/src/structs/fill.rs
+++ b/src/structs/fill.rs
@@ -16,8 +16,8 @@ pub struct Fill {
 }
 
 impl Fill {
-    pub fn get_pattern_fill(&self) -> &Option<PatternFill> {
-        &self.pattern_fill
+    pub fn get_pattern_fill(&self) -> Option<&PatternFill> {
+        self.pattern_fill.as_ref()
     }
 
     pub fn get_pattern_fill_mut(&mut self) -> &mut PatternFill {
@@ -35,8 +35,8 @@ impl Fill {
         self
     }
 
-    pub fn get_gradient_fill(&self) -> &Option<GradientFill> {
-        &self.gradient_fill
+    pub fn get_gradient_fill(&self) -> Option<&GradientFill> {
+        self.gradient_fill.as_ref()
     }
 
     pub fn get_gradient_fill_mut(&mut self) -> &mut GradientFill {

--- a/src/structs/fill.rs
+++ b/src/structs/fill.rs
@@ -21,9 +21,8 @@ impl Fill {
     }
 
     pub fn get_pattern_fill_mut(&mut self) -> &mut PatternFill {
-        match &self.pattern_fill {
-            Some(_) => return self.pattern_fill.as_mut().unwrap(),
-            None => {}
+        if let Some(_) = &self.pattern_fill {
+            return self.pattern_fill.as_mut().unwrap();
         }
         self.set_pattern_fill(PatternFill::default());
         self.pattern_fill.as_mut().unwrap()
@@ -40,9 +39,8 @@ impl Fill {
     }
 
     pub fn get_gradient_fill_mut(&mut self) -> &mut GradientFill {
-        match &self.gradient_fill {
-            Some(_) => return self.gradient_fill.as_mut().unwrap(),
-            None => {}
+        if let Some(_) = &self.gradient_fill {
+            return self.gradient_fill.as_mut().unwrap();
         }
         self.set_gradient_fill(GradientFill::default());
         self.gradient_fill.as_mut().unwrap()
@@ -138,19 +136,13 @@ impl Fill {
         write_start_tag(writer, "fill", vec![], false);
 
         // gradientFill
-        match &self.pattern_fill {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.pattern_fill {
+            v.write_to(writer);
         }
 
         // patternFill
-        match &self.gradient_fill {
-            Some(v) => {
-                v.write_to(writer);
-            }
-            None => {}
+        if let Some(v) = &self.gradient_fill {
+            v.write_to(writer);
         }
 
         write_end_tag(writer, "fill");

--- a/src/structs/fill.rs
+++ b/src/structs/fill.rs
@@ -21,7 +21,7 @@ impl Fill {
     }
 
     pub fn get_pattern_fill_mut(&mut self) -> &mut PatternFill {
-        if let Some(_) = &self.pattern_fill {
+        if self.pattern_fill.is_some() {
             return self.pattern_fill.as_mut().unwrap();
         }
         self.set_pattern_fill(PatternFill::default());

--- a/src/structs/image.rs
+++ b/src/structs/image.rs
@@ -60,12 +60,12 @@ pub struct Image {
 /// .change_image("./images/sample1.png");
 /// ```
 impl Image {
-    pub fn get_two_cell_anchor(&self) -> &Option<TwoCellAnchor> {
-        &self.two_cell_anchor
+    pub fn get_two_cell_anchor(&self) -> Option<&TwoCellAnchor> {
+        self.two_cell_anchor.as_ref()
     }
 
-    pub fn get_two_cell_anchor_mut(&mut self) -> &mut Option<TwoCellAnchor> {
-        &mut self.two_cell_anchor
+    pub fn get_two_cell_anchor_mut(&mut self) -> Option<&mut TwoCellAnchor> {
+        self.two_cell_anchor.as_mut()
     }
 
     pub fn set_two_cell_anchor(&mut self, value: TwoCellAnchor) -> &mut Self {
@@ -73,12 +73,12 @@ impl Image {
         self
     }
 
-    pub fn get_one_cell_anchor(&self) -> &Option<OneCellAnchor> {
-        &self.one_cell_anchor
+    pub fn get_one_cell_anchor(&self) -> Option<&OneCellAnchor> {
+        self.one_cell_anchor.as_ref()
     }
 
-    pub fn get_one_cell_anchor_mut(&mut self) -> &mut Option<OneCellAnchor> {
-        &mut self.one_cell_anchor
+    pub fn get_one_cell_anchor_mut(&mut self) -> Option<&mut OneCellAnchor> {
+        self.one_cell_anchor.as_mut()
     }
 
     pub fn set_one_cell_anchor(&mut self, value: OneCellAnchor) -> &mut Self {

--- a/src/structs/image.rs
+++ b/src/structs/image.rs
@@ -96,7 +96,7 @@ impl Image {
 
         let mut file = File::open(path_str).unwrap();
         let mut buf = Vec::new();
-        let _ = file.read_to_end(&mut buf).unwrap();
+        file.read_to_end(&mut buf).unwrap();
 
         let mut picture = Picture::default();
         // filename and filedata.

--- a/src/structs/image.rs
+++ b/src/structs/image.rs
@@ -178,64 +178,41 @@ impl Image {
     }
 
     pub fn get_from_marker_type(&self) -> &MarkerType {
-        match &self.two_cell_anchor {
-            Some(anchor) => {
-                return anchor.get_from_marker();
-            }
-            None => {}
+        if let Some(anchor) = &self.two_cell_anchor {
+            return anchor.get_from_marker();
         }
-        match &self.one_cell_anchor {
-            Some(anchor) => {
-                return anchor.get_from_marker();
-            }
-            None => {}
+        if let Some(anchor) = &self.one_cell_anchor {
+            return anchor.get_from_marker();
         }
         panic!("Not Found MediaObject");
     }
 
     pub fn get_to_marker_type(&self) -> Option<&MarkerType> {
-        match &self.two_cell_anchor {
-            Some(anchor) => {
-                return Some(anchor.get_to_marker());
-            }
-            None => None,
-        }
+        self.two_cell_anchor
+            .as_ref()
+            .map(|anchor| anchor.get_to_marker())
     }
 
     pub(crate) fn get_media_object(&self) -> &MediaObject {
-        match &self.two_cell_anchor {
-            Some(anchor) => match anchor.get_picture() {
-                Some(v) => {
-                    return v.get_blip_fill().get_blip().get_image();
-                }
-                None => {}
-            },
-            None => {}
+        if let Some(anchor) = &self.two_cell_anchor {
+            if let Some(v) = anchor.get_picture() {
+                return v.get_blip_fill().get_blip().get_image();
+            }
         }
-        match &self.one_cell_anchor {
-            Some(anchor) => match anchor.get_picture() {
-                Some(v) => {
-                    return v.get_blip_fill().get_blip().get_image();
-                }
-                None => {}
-            },
-            None => {}
+        if let Some(anchor) = &self.one_cell_anchor {
+            if let Some(v) = anchor.get_picture() {
+                return v.get_blip_fill().get_blip().get_image();
+            }
         }
         panic!("Not Found MediaObject");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, r_id: &mut i32) {
-        match &self.two_cell_anchor {
-            Some(anchor) => {
-                anchor.write_to(writer, r_id, &0);
-            }
-            None => {}
+        if let Some(anchor) = &self.two_cell_anchor {
+            anchor.write_to(writer, r_id, &0);
         }
-        match &self.one_cell_anchor {
-            Some(anchor) => {
-                anchor.write_to(writer, r_id);
-            }
-            None => {}
+        if let Some(anchor) = &self.one_cell_anchor {
+            anchor.write_to(writer, r_id);
         }
     }
 }

--- a/src/structs/merge_cells.rs
+++ b/src/structs/merge_cells.rs
@@ -30,45 +30,27 @@ impl MergeCells {
     }
 
     pub(crate) fn _has_vertical(&self, row_num: &u32) -> bool {
-        for range in self.get_range_collection() {
-            let start_num = match range.get_coordinate_start_row() {
-                Some(v) => v.get_num(),
-                None => {
-                    return true;
-                }
-            };
-            let end_num = match range.get_coordinate_end_row() {
-                Some(v) => v.get_num(),
-                None => {
-                    return true;
-                }
-            };
-            if start_num <= row_num && row_num <= end_num && start_num != end_num {
-                return true;
-            }
-        }
-        false
+        self.get_range_collection().iter().any(|range| {
+            let start_num = range
+                .get_coordinate_start_row()
+                .map_or(true, |v| v.get_num() <= row_num);
+            let end_num = range
+                .get_coordinate_end_row()
+                .map_or(true, |v| v.get_num() >= row_num);
+            start_num && end_num && start_num != end_num
+        })
     }
 
     pub(crate) fn has_horizontal(&self, col_num: &u32) -> bool {
-        for range in self.get_range_collection() {
-            let start_num = match range.get_coordinate_start_col() {
-                Some(v) => v.get_num(),
-                None => {
-                    return true;
-                }
-            };
-            let end_num = match range.get_coordinate_end_col() {
-                Some(v) => v.get_num(),
-                None => {
-                    return true;
-                }
-            };
-            if start_num <= col_num && col_num <= end_num && start_num != end_num {
-                return true;
-            }
-        }
-        false
+        self.get_range_collection().iter().any(|range| {
+            let start_num = range
+                .get_coordinate_start_col()
+                .map_or(true, |v| v.get_num() <= col_num);
+            let end_num = range
+                .get_coordinate_end_col()
+                .map_or(true, |v| v.get_num() >= col_num);
+            start_num && end_num && start_num != end_num
+        })
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/odd_footer.rs
+++ b/src/structs/odd_footer.rs
@@ -28,10 +28,7 @@ impl OddFooter {
     }
 
     pub(crate) fn has_param(&self) -> bool {
-        if self.value.has_value() {
-            return true;
-        }
-        false
+        self.value.has_value()
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/ole_object.rs
+++ b/src/structs/ole_object.rs
@@ -49,12 +49,12 @@ impl OleObject {
         self.object_extension = value.into();
     }
 
-    pub fn get_object_data(&self) -> &Option<Vec<u8>> {
-        &self.object_data
+    pub fn get_object_data(&self) -> Option<&Vec<u8>> {
+        self.object_data.as_ref()
     }
 
-    pub fn get_object_data_mut(&mut self) -> &mut Option<Vec<u8>> {
-        &mut self.object_data
+    pub fn get_object_data_mut(&mut self) -> Option<&mut Vec<u8>> {
+        self.object_data.as_mut()
     }
 
     pub fn set_object_data(&mut self, value: Vec<u8>) -> &mut Self {

--- a/src/structs/page_setup.rs
+++ b/src/structs/page_setup.rs
@@ -85,12 +85,12 @@ impl PageSetup {
         self
     }
 
-    pub fn get_object_data(&self) -> &Option<Vec<u8>> {
-        &self.object_data
+    pub fn get_object_data(&self) -> Option<&Vec<u8>> {
+        self.object_data.as_ref()
     }
 
-    pub fn get_object_data_mut(&mut self) -> &mut Option<Vec<u8>> {
-        &mut self.object_data
+    pub fn get_object_data_mut(&mut self) -> Option<&mut Vec<u8>> {
+        self.object_data.as_mut()
     }
 
     pub fn set_object_data(&mut self, value: Vec<u8>) -> &mut Self {
@@ -99,31 +99,14 @@ impl PageSetup {
     }
 
     pub(crate) fn has_param(&self) -> bool {
-        if self.paper_size.has_value() {
-            return true;
-        }
-        if self.orientation.has_value() {
-            return true;
-        }
-        if self.scale.has_value() {
-            return true;
-        }
-        if self.fit_to_height.has_value() {
-            return true;
-        }
-        if self.fit_to_width.has_value() {
-            return true;
-        }
-        if self.horizontal_dpi.has_value() {
-            return true;
-        }
-        if self.vertical_dpi.has_value() {
-            return true;
-        }
-        if self.object_data.is_some() {
-            return true;
-        }
-        false
+        self.paper_size.has_value()
+            || self.orientation.has_value()
+            || self.scale.has_value()
+            || self.fit_to_height.has_value()
+            || self.fit_to_width.has_value()
+            || self.horizontal_dpi.has_value()
+            || self.vertical_dpi.has_value()
+            || self.object_data.is_some()
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/pattern_fill.rs
+++ b/src/structs/pattern_fill.rs
@@ -38,8 +38,8 @@ impl PatternFill {
         self
     }
 
-    pub fn get_foreground_color(&self) -> &Option<Color> {
-        &self.foreground_color
+    pub fn get_foreground_color(&self) -> Option<&Color> {
+        self.foreground_color.as_ref()
     }
 
     pub fn get_foreground_color_mut(&mut self) -> &mut Color {
@@ -57,8 +57,8 @@ impl PatternFill {
         self
     }
 
-    pub fn get_background_color(&self) -> &Option<Color> {
-        &self.background_color
+    pub fn get_background_color(&self) -> Option<&Color> {
+        self.background_color.as_ref()
     }
 
     pub fn get_background_color_mut(&mut self) -> &mut Color {

--- a/src/structs/range.rs
+++ b/src/structs/range.rs
@@ -70,36 +70,36 @@ impl Range {
         result
     }
 
-    pub fn get_coordinate_start_col(&self) -> &Option<ColumnReference> {
-        &self.coordinate_start_col
+    pub fn get_coordinate_start_col(&self) -> Option<&ColumnReference> {
+        self.coordinate_start_col.as_ref()
     }
 
-    pub fn get_coordinate_start_col_mut(&mut self) -> &mut Option<ColumnReference> {
-        &mut self.coordinate_start_col
+    pub fn get_coordinate_start_col_mut(&mut self) -> Option<&mut ColumnReference> {
+        self.coordinate_start_col.as_mut()
     }
 
-    pub fn get_coordinate_start_row(&self) -> &Option<RowReference> {
-        &self.coordinate_start_row
+    pub fn get_coordinate_start_row(&self) -> Option<&RowReference> {
+        self.coordinate_start_row.as_ref()
     }
 
-    pub fn get_coordinate_start_row_mut(&mut self) -> &mut Option<RowReference> {
-        &mut self.coordinate_start_row
+    pub fn get_coordinate_start_row_mut(&mut self) -> Option<&mut RowReference> {
+        self.coordinate_start_row.as_mut()
     }
 
-    pub fn get_coordinate_end_col(&self) -> &Option<ColumnReference> {
-        &self.coordinate_end_col
+    pub fn get_coordinate_end_col(&self) -> Option<&ColumnReference> {
+        self.coordinate_end_col.as_ref()
     }
 
-    pub fn get_coordinate_end_col_mut(&mut self) -> &mut Option<ColumnReference> {
-        &mut self.coordinate_end_col
+    pub fn get_coordinate_end_col_mut(&mut self) -> Option<&mut ColumnReference> {
+        self.coordinate_end_col.as_mut()
     }
 
-    pub fn get_coordinate_end_row(&self) -> &Option<RowReference> {
-        &self.coordinate_end_row
+    pub fn get_coordinate_end_row(&self) -> Option<&RowReference> {
+        self.coordinate_end_row.as_ref()
     }
 
-    pub fn get_coordinate_end_row_mut(&mut self) -> &mut Option<RowReference> {
-        &mut self.coordinate_end_row
+    pub fn get_coordinate_end_row_mut(&mut self) -> Option<&mut RowReference> {
+        self.coordinate_end_row.as_mut()
     }
 
     pub(crate) fn get_coordinate_start(&self) -> String {

--- a/src/structs/raw/raw_relationships.rs
+++ b/src/structs/raw/raw_relationships.rs
@@ -104,7 +104,7 @@ impl RawRelationships {
 
         let mut writer = Writer::new(io::Cursor::new(Vec::new()));
         // XML header
-        let _ = writer.write_event(Event::Decl(BytesDecl::new(
+        writer.write_event(Event::Decl(BytesDecl::new(
             "1.0",
             Some("UTF-8"),
             Some("yes"),

--- a/src/structs/selection.rs
+++ b/src/structs/selection.rs
@@ -26,12 +26,12 @@ impl Selection {
         self
     }
 
-    pub fn get_active_cell(&self) -> &Option<Coordinate> {
-        &self.active_cell
+    pub fn get_active_cell(&self) -> Option<&Coordinate> {
+        self.active_cell.as_ref()
     }
 
-    pub fn get_active_cell_mut(&mut self) -> &mut Option<Coordinate> {
-        &mut self.active_cell
+    pub fn get_active_cell_mut(&mut self) -> Option<&mut Coordinate> {
+        self.active_cell.as_mut()
     }
 
     pub fn set_active_cell(&mut self, value: Coordinate) -> &mut Self {

--- a/src/structs/shared_string_item.rs
+++ b/src/structs/shared_string_item.rs
@@ -21,12 +21,12 @@ pub(crate) struct SharedStringItem {
 }
 
 impl SharedStringItem {
-    pub(crate) fn get_text(&self) -> &Option<Text> {
-        &self.text
+    pub(crate) fn get_text(&self) -> Option<&Text> {
+        self.text.as_ref()
     }
 
-    pub(crate) fn _get_text_mut(&mut self) -> &mut Option<Text> {
-        &mut self.text
+    pub(crate) fn _get_text_mut(&mut self) -> Option<&mut Text> {
+        self.text.as_mut()
     }
 
     pub(crate) fn set_text(&mut self, value: Text) -> &mut Self {
@@ -39,12 +39,12 @@ impl SharedStringItem {
         self
     }
 
-    pub(crate) fn get_rich_text(&self) -> &Option<RichText> {
-        &self.rich_text
+    pub(crate) fn get_rich_text(&self) -> Option<&RichText> {
+        self.rich_text.as_ref()
     }
 
-    pub(crate) fn get_rich_text_mut(&mut self) -> &mut Option<RichText> {
-        &mut self.rich_text
+    pub(crate) fn get_rich_text_mut(&mut self) -> Option<&mut RichText> {
+        self.rich_text.as_mut()
     }
 
     pub(crate) fn set_rich_text(&mut self, value: RichText) -> &mut Self {

--- a/src/structs/sheet_view.rs
+++ b/src/structs/sheet_view.rs
@@ -46,12 +46,12 @@ impl SheetView {
         self
     }
 
-    pub fn get_pane(&self) -> &Option<Pane> {
-        &self.pane
+    pub fn get_pane(&self) -> Option<&Pane> {
+        self.pane.as_ref()
     }
 
-    pub fn get_pane_mut(&mut self) -> &mut Option<Pane> {
-        &mut self.pane
+    pub fn get_pane_mut(&mut self) -> Option<&mut Pane> {
+        self.pane.as_mut()
     }
 
     pub fn set_pane(&mut self, value: Pane) -> &mut Self {

--- a/src/structs/spreadsheet.rs
+++ b/src/structs/spreadsheet.rs
@@ -246,9 +246,9 @@ impl Spreadsheet {
 
     /// Get Macros Code.
     /// # Return value
-    /// * `&Option<Vec<u8>>` - Macros Code Raw Data.
-    pub fn get_macros_code(&self) -> &Option<Vec<u8>> {
-        &self.macros_code
+    /// * `Option<&Vec<u8>>` - Macros Code Raw Data.
+    pub fn get_macros_code(&self) -> Option<&Vec<u8>> {
+        self.macros_code.as_ref()
     }
 
     /// Set Macros Code.
@@ -609,12 +609,9 @@ impl Spreadsheet {
     /// (This method is crate only.)
     /// Has Defined Names.
     pub(crate) fn has_defined_names(&self) -> bool {
-        for sheet in self.get_sheet_collection_no_check() {
-            if sheet.has_defined_names() {
-                return true;
-            }
-        }
-        false
+        self.get_sheet_collection_no_check()
+            .iter()
+            .any(|sheet| sheet.has_defined_names())
     }
 
     pub(crate) fn get_backup_context_types(&self) -> &Vec<(String, String)> {
@@ -667,8 +664,8 @@ impl Spreadsheet {
         self
     }
 
-    pub fn get_workbook_protection(&self) -> &Option<WorkbookProtection> {
-        &self.workbook_protection
+    pub fn get_workbook_protection(&self) -> Option<&WorkbookProtection> {
+        self.workbook_protection.as_ref()
     }
 
     pub fn get_workbook_protection_mut(&mut self) -> &mut WorkbookProtection {

--- a/src/structs/style.rs
+++ b/src/structs/style.rs
@@ -63,8 +63,8 @@ pub struct Style {
     protection: Option<Protection>,
 }
 impl Style {
-    pub fn get_font(&self) -> &Option<Font> {
-        &self.font
+    pub fn get_font(&self) -> Option<&Font> {
+        self.font.as_ref()
     }
 
     pub fn get_font_mut(&mut self) -> &mut Font {
@@ -86,8 +86,8 @@ impl Style {
         self
     }
 
-    pub fn get_fill(&self) -> &Option<Fill> {
-        &self.fill
+    pub fn get_fill(&self) -> Option<&Fill> {
+        self.fill.as_ref()
     }
 
     pub fn get_fill_mut(&mut self) -> &mut Fill {
@@ -99,14 +99,9 @@ impl Style {
         self
     }
 
-    pub fn get_background_color(&self) -> &Option<Color> {
-        match self.get_fill() {
-            Some(fill) => match fill.get_pattern_fill() {
-                Some(pattern_fill) => pattern_fill.get_foreground_color(),
-                _ => &None,
-            },
-            _ => &None,
-        }
+    pub fn get_background_color(&self) -> Option<&Color> {
+        self.get_fill()
+            .and_then(|fill| fill.get_pattern_fill()?.get_foreground_color())
     }
 
     pub fn set_background_color<S: Into<String>>(&mut self, color: S) -> &mut Self {
@@ -152,8 +147,8 @@ impl Style {
         self
     }
 
-    pub fn get_borders(&self) -> &Option<Borders> {
-        &self.borders
+    pub fn get_borders(&self) -> Option<&Borders> {
+        self.borders.as_ref()
     }
 
     pub fn get_borders_mut(&mut self) -> &mut Borders {
@@ -175,8 +170,8 @@ impl Style {
         self
     }
 
-    pub fn get_alignment(&self) -> &Option<Alignment> {
-        &self.alignment
+    pub fn get_alignment(&self) -> Option<&Alignment> {
+        self.alignment.as_ref()
     }
 
     pub fn get_alignment_mut(&mut self) -> &mut Alignment {
@@ -198,8 +193,8 @@ impl Style {
         self
     }
 
-    pub fn get_numbering_format(&self) -> &Option<NumberingFormat> {
-        &self.numbering_format
+    pub fn get_numbering_format(&self) -> Option<&NumberingFormat> {
+        self.numbering_format.as_ref()
     }
 
     pub fn get_numbering_format_mut(&mut self) -> &mut NumberingFormat {
@@ -217,7 +212,7 @@ impl Style {
         self
     }
 
-    pub fn get_number_format(&self) -> &Option<NumberingFormat> {
+    pub fn get_number_format(&self) -> Option<&NumberingFormat> {
         self.get_numbering_format()
     }
 
@@ -242,8 +237,8 @@ impl Style {
         self
     }
 
-    pub fn get_protection(&self) -> &Option<Protection> {
-        &self.protection
+    pub fn get_protection(&self) -> Option<&Protection> {
+        self.protection.as_ref()
     }
 
     pub fn get_protection_mut(&mut self) -> &mut Protection {

--- a/src/structs/stylesheet.rs
+++ b/src/structs/stylesheet.rs
@@ -301,19 +301,19 @@ impl Stylesheet {
         cell_format.set_border_id(border_id);
         cell_format.set_format_id(format_id);
 
-        if let Some(_) = style.get_numbering_format() {
+        if style.get_numbering_format().is_some() {
             cell_format.set_apply_number_format(true);
         }
 
-        if let Some(_) = style.get_font() {
+        if style.get_font().is_some() {
             cell_format.set_apply_font(true);
         }
 
-        if let Some(_) = style.get_fill() {
+        if style.get_fill().is_some() {
             cell_format.set_apply_fill(true);
         }
 
-        if let Some(_) = style.get_borders() {
+        if style.get_borders().is_some() {
             cell_format.set_apply_border(true);
         }
 

--- a/src/structs/table.rs
+++ b/src/structs/table.rs
@@ -33,10 +33,9 @@ impl Table {
     }
 
     pub fn is_ok(&self) -> bool {
-        if self.name.is_empty() || self.display_name.is_empty() {
-            return false;
-        }
-        !(self.area.0.get_col_num() == &0
+        !(self.name.is_empty()
+            || self.display_name.is_empty()
+            || self.area.0.get_col_num() == &0
             || self.area.0.get_row_num() == &0
             || self.area.1.get_col_num() == &0
             || self.area.1.get_row_num() == &0

--- a/src/structs/text_element.rs
+++ b/src/structs/text_element.rs
@@ -30,7 +30,7 @@ impl TextElement {
     }
 
     pub fn get_run_properties_mut(&mut self) -> &mut Font {
-        if let Some(_) = &self.run_properties {
+        if self.run_properties.is_some() {
             return self.run_properties.as_mut().unwrap();
         }
         self.set_run_properties(Font::get_default_value());

--- a/src/structs/text_element.rs
+++ b/src/structs/text_element.rs
@@ -30,16 +30,15 @@ impl TextElement {
     }
 
     pub fn get_run_properties_mut(&mut self) -> &mut Font {
-        match &self.run_properties {
-            Some(_) => return self.run_properties.as_mut().unwrap(),
-            None => {}
+        if let Some(_) = &self.run_properties {
+            return self.run_properties.as_mut().unwrap();
         }
         self.set_run_properties(Font::get_default_value());
         self.run_properties.as_mut().unwrap()
     }
 
-    pub(crate) fn get_run_properties_crate(&mut self) -> &mut Option<Font> {
-        &mut self.run_properties
+    pub(crate) fn get_run_properties_crate(&mut self) -> Option<&mut Font> {
+        self.run_properties.as_mut()
     }
 
     pub fn set_run_properties(&mut self, value: Font) -> &mut Self {

--- a/src/structs/text_element.rs
+++ b/src/structs/text_element.rs
@@ -25,8 +25,8 @@ impl TextElement {
         self
     }
 
-    pub fn get_run_properties(&self) -> &Option<Font> {
-        &self.run_properties
+    pub fn get_run_properties(&self) -> Option<&Font> {
+        self.run_properties.as_ref()
     }
 
     pub fn get_run_properties_mut(&mut self) -> &mut Font {
@@ -46,7 +46,7 @@ impl TextElement {
         self
     }
 
-    pub fn get_font(&self) -> &Option<Font> {
+    pub fn get_font(&self) -> Option<&Font> {
         self.get_run_properties()
     }
 

--- a/src/structs/true_false_blank_value.rs
+++ b/src/structs/true_false_blank_value.rs
@@ -3,8 +3,8 @@ pub struct TrueFalseBlankValue {
     value: Option<bool>,
 }
 impl TrueFalseBlankValue {
-    pub(crate) fn get_value(&self) -> &Option<bool> {
-        &self.value
+    pub(crate) fn get_value(&self) -> Option<&bool> {
+        self.value.as_ref()
     }
 
     pub(crate) fn _get_value_string(&self) -> &str {

--- a/src/structs/vml/shape.rs
+++ b/src/structs/vml/shape.rs
@@ -112,8 +112,8 @@ impl Shape {
         self
     }
 
-    pub fn get_fill(&self) -> &Option<Fill> {
-        &self.fill
+    pub fn get_fill(&self) -> Option<&Fill> {
+        self.fill.as_ref()
     }
 
     pub fn get_fill_mut(&mut self) -> &mut Option<Fill> {
@@ -125,8 +125,8 @@ impl Shape {
         self
     }
 
-    pub fn get_image_data(&self) -> &Option<ImageData> {
-        &self.image_data
+    pub fn get_image_data(&self) -> Option<&ImageData> {
+        self.image_data.as_ref()
     }
 
     pub fn get_image_data_mut(&mut self) -> &mut Option<ImageData> {
@@ -138,8 +138,8 @@ impl Shape {
         self
     }
 
-    pub fn get_stroke(&self) -> &Option<Stroke> {
-        &self.stroke
+    pub fn get_stroke(&self) -> Option<&Stroke> {
+        self.stroke.as_ref()
     }
 
     pub fn get_stroke_mut(&mut self) -> &mut Option<Stroke> {
@@ -151,8 +151,8 @@ impl Shape {
         self
     }
 
-    pub fn get_shadow(&self) -> &Option<Shadow> {
-        &self.shadow
+    pub fn get_shadow(&self) -> Option<&Shadow> {
+        self.shadow.as_ref()
     }
 
     pub fn get_shadow_mut(&mut self) -> &mut Option<Shadow> {
@@ -164,8 +164,8 @@ impl Shape {
         self
     }
 
-    pub fn get_path(&self) -> &Option<Path> {
-        &self.path
+    pub fn get_path(&self) -> Option<&Path> {
+        self.path.as_ref()
     }
 
     pub fn get_path_mut(&mut self) -> &mut Option<Path> {
@@ -177,8 +177,8 @@ impl Shape {
         self
     }
 
-    pub fn get_text_box(&self) -> &Option<TextBox> {
-        &self.text_box
+    pub fn get_text_box(&self) -> Option<&TextBox> {
+        self.text_box.as_ref()
     }
 
     pub fn get_text_box_mut(&mut self) -> &mut Option<TextBox> {

--- a/src/structs/vml/shape.rs
+++ b/src/structs/vml/shape.rs
@@ -116,8 +116,8 @@ impl Shape {
         self.fill.as_ref()
     }
 
-    pub fn get_fill_mut(&mut self) -> &mut Option<Fill> {
-        &mut self.fill
+    pub fn get_fill_mut(&mut self) -> Option<&mut Fill> {
+        self.fill.as_mut()
     }
 
     pub fn set_fill(&mut self, value: Fill) -> &mut Self {
@@ -129,8 +129,8 @@ impl Shape {
         self.image_data.as_ref()
     }
 
-    pub fn get_image_data_mut(&mut self) -> &mut Option<ImageData> {
-        &mut self.image_data
+    pub fn get_image_data_mut(&mut self) -> Option<&mut ImageData> {
+        self.image_data.as_mut()
     }
 
     pub fn set_image_data(&mut self, value: ImageData) -> &mut Self {
@@ -142,8 +142,8 @@ impl Shape {
         self.stroke.as_ref()
     }
 
-    pub fn get_stroke_mut(&mut self) -> &mut Option<Stroke> {
-        &mut self.stroke
+    pub fn get_stroke_mut(&mut self) -> Option<&mut Stroke> {
+        self.stroke.as_mut()
     }
 
     pub fn set_stroke(&mut self, value: Stroke) -> &mut Self {
@@ -155,8 +155,8 @@ impl Shape {
         self.shadow.as_ref()
     }
 
-    pub fn get_shadow_mut(&mut self) -> &mut Option<Shadow> {
-        &mut self.shadow
+    pub fn get_shadow_mut(&mut self) -> Option<&mut Shadow> {
+        self.shadow.as_mut()
     }
 
     pub fn set_shadow(&mut self, value: Shadow) -> &mut Self {
@@ -168,8 +168,8 @@ impl Shape {
         self.path.as_ref()
     }
 
-    pub fn get_path_mut(&mut self) -> &mut Option<Path> {
-        &mut self.path
+    pub fn get_path_mut(&mut self) -> Option<&mut Path> {
+        self.path.as_mut()
     }
 
     pub fn set_path(&mut self, value: Path) -> &mut Self {
@@ -181,8 +181,8 @@ impl Shape {
         self.text_box.as_ref()
     }
 
-    pub fn get_text_box_mut(&mut self) -> &mut Option<TextBox> {
-        &mut self.text_box
+    pub fn get_text_box_mut(&mut self) -> Option<&mut TextBox> {
+        self.text_box.as_mut()
     }
 
     pub fn set_text_box(&mut self, value: TextBox) -> &mut Self {

--- a/src/structs/vml/spreadsheet/auto_fill.rs
+++ b/src/structs/vml/spreadsheet/auto_fill.rs
@@ -12,7 +12,7 @@ pub struct AutoFill {
 }
 
 impl AutoFill {
-    pub fn get_value(&self) -> &Option<bool> {
+    pub fn get_value(&self) -> Option<&bool> {
         self.value.get_value()
     }
 

--- a/src/structs/vml/spreadsheet/auto_size_picture.rs
+++ b/src/structs/vml/spreadsheet/auto_size_picture.rs
@@ -12,7 +12,7 @@ pub struct AutoSizePicture {
 }
 
 impl AutoSizePicture {
-    pub fn get_value(&self) -> &Option<bool> {
+    pub fn get_value(&self) -> Option<&bool> {
         self.value.get_value()
     }
 

--- a/src/structs/vml/spreadsheet/client_data.rs
+++ b/src/structs/vml/spreadsheet/client_data.rs
@@ -40,12 +40,12 @@ impl ClientData {
         self
     }
 
-    pub fn get_move_with_cells(&self) -> &Option<MoveWithCells> {
-        &self.move_with_cells
+    pub fn get_move_with_cells(&self) -> Option<&MoveWithCells> {
+        self.move_with_cells.as_ref()
     }
 
-    pub fn get_move_with_cells_mut(&mut self) -> &mut Option<MoveWithCells> {
-        &mut self.move_with_cells
+    pub fn get_move_with_cells_mut(&mut self) -> Option<&mut MoveWithCells> {
+        self.move_with_cells.as_mut()
     }
 
     pub fn set_move_with_cells(&mut self, value: MoveWithCells) -> &mut Self {
@@ -53,12 +53,12 @@ impl ClientData {
         self
     }
 
-    pub fn get_resize_with_cells(&self) -> &Option<ResizeWithCells> {
-        &self.resize_with_cells
+    pub fn get_resize_with_cells(&self) -> Option<&ResizeWithCells> {
+        self.resize_with_cells.as_ref()
     }
 
-    pub fn get_resize_with_cells_mut(&mut self) -> &mut Option<ResizeWithCells> {
-        &mut self.resize_with_cells
+    pub fn get_resize_with_cells_mut(&mut self) -> Option<&mut ResizeWithCells> {
+        self.resize_with_cells.as_mut()
     }
 
     pub fn set_resize_with_cells(&mut self, value: ResizeWithCells) -> &mut Self {
@@ -79,12 +79,12 @@ impl ClientData {
         self
     }
 
-    pub fn get_auto_fill(&self) -> &Option<AutoFill> {
-        &self.auto_fill
+    pub fn get_auto_fill(&self) -> Option<&AutoFill> {
+        self.auto_fill.as_ref()
     }
 
-    pub fn get_auto_fill_mut(&mut self) -> &mut Option<AutoFill> {
-        &mut self.auto_fill
+    pub fn get_auto_fill_mut(&mut self) -> Option<&mut AutoFill> {
+        self.auto_fill.as_mut()
     }
 
     pub fn set_auto_fill(&mut self, value: AutoFill) -> &mut Self {
@@ -92,12 +92,12 @@ impl ClientData {
         self
     }
 
-    pub fn get_comment_row_target(&self) -> &Option<CommentRowTarget> {
-        &self.comment_row_target
+    pub fn get_comment_row_target(&self) -> Option<&CommentRowTarget> {
+        self.comment_row_target.as_ref()
     }
 
-    pub fn get_comment_row_target_mut(&mut self) -> &mut Option<CommentRowTarget> {
-        &mut self.comment_row_target
+    pub fn get_comment_row_target_mut(&mut self) -> Option<&mut CommentRowTarget> {
+        self.comment_row_target.as_mut()
     }
 
     pub fn set_comment_row_target(&mut self, value: CommentRowTarget) -> &mut Self {
@@ -105,12 +105,12 @@ impl ClientData {
         self
     }
 
-    pub fn get_comment_column_target(&self) -> &Option<CommentColumnTarget> {
-        &self.comment_column_target
+    pub fn get_comment_column_target(&self) -> Option<&CommentColumnTarget> {
+        self.comment_column_target.as_ref()
     }
 
-    pub fn get_comment_column_target_mut(&mut self) -> &mut Option<CommentColumnTarget> {
-        &mut self.comment_column_target
+    pub fn get_comment_column_target_mut(&mut self) -> Option<&mut CommentColumnTarget> {
+        self.comment_column_target.as_mut()
     }
 
     pub fn set_comment_column_target(&mut self, value: CommentColumnTarget) -> &mut Self {
@@ -118,12 +118,12 @@ impl ClientData {
         self
     }
 
-    pub fn get_visible(&self) -> &Option<Visible> {
-        &self.visible
+    pub fn get_visible(&self) -> Option<&Visible> {
+        self.visible.as_ref()
     }
 
-    pub fn get_visible_mut(&mut self) -> &mut Option<Visible> {
-        &mut self.visible
+    pub fn get_visible_mut(&mut self) -> Option<&mut Visible> {
+        self.visible.as_mut()
     }
 
     pub fn set_visible(&mut self, value: Visible) -> &mut Self {
@@ -131,12 +131,12 @@ impl ClientData {
         self
     }
 
-    pub fn get_clipboard_format(&self) -> &Option<ClipboardFormat> {
-        &self.clipboard_format
+    pub fn get_clipboard_format(&self) -> Option<&ClipboardFormat> {
+        self.clipboard_format.as_ref()
     }
 
-    pub fn get_clipboard_format_mut(&mut self) -> &mut Option<ClipboardFormat> {
-        &mut self.clipboard_format
+    pub fn get_clipboard_format_mut(&mut self) -> Option<&mut ClipboardFormat> {
+        self.clipboard_format.as_mut()
     }
 
     pub fn set_clipboard_format(&mut self, value: ClipboardFormat) -> &mut Self {
@@ -144,12 +144,12 @@ impl ClientData {
         self
     }
 
-    pub fn get_auto_size_picture(&self) -> &Option<AutoSizePicture> {
-        &self.auto_size_picture
+    pub fn get_auto_size_picture(&self) -> Option<&AutoSizePicture> {
+        self.auto_size_picture.as_ref()
     }
 
-    pub fn get_auto_size_picture_mut(&mut self) -> &mut Option<AutoSizePicture> {
-        &mut self.auto_size_picture
+    pub fn get_auto_size_picture_mut(&mut self) -> Option<&mut AutoSizePicture> {
+        self.auto_size_picture.as_mut()
     }
 
     pub fn set_auto_size_picture(&mut self, value: AutoSizePicture) -> &mut Self {

--- a/src/structs/vml/spreadsheet/move_with_cells.rs
+++ b/src/structs/vml/spreadsheet/move_with_cells.rs
@@ -12,7 +12,7 @@ pub struct MoveWithCells {
 }
 
 impl MoveWithCells {
-    pub fn get_value(&self) -> &Option<bool> {
+    pub fn get_value(&self) -> Option<&bool> {
         self.value.get_value()
     }
 

--- a/src/structs/vml/spreadsheet/resize_with_cells.rs
+++ b/src/structs/vml/spreadsheet/resize_with_cells.rs
@@ -12,7 +12,7 @@ pub struct ResizeWithCells {
 }
 
 impl ResizeWithCells {
-    pub fn get_value(&self) -> &Option<bool> {
+    pub fn get_value(&self) -> Option<&bool> {
         self.value.get_value()
     }
 

--- a/src/structs/vml/spreadsheet/visible.rs
+++ b/src/structs/vml/spreadsheet/visible.rs
@@ -12,7 +12,7 @@ pub struct Visible {
 }
 
 impl Visible {
-    pub fn get_value(&self) -> &Option<bool> {
+    pub fn get_value(&self) -> Option<&bool> {
         self.value.get_value()
     }
 

--- a/src/structs/worksheet.rs
+++ b/src/structs/worksheet.rs
@@ -567,13 +567,13 @@ impl Worksheet {
     // Auto Filter
     // ************************
     // Get Auto Filter (Option).
-    pub fn get_auto_filter(&self) -> &Option<AutoFilter> {
-        &self.auto_filter
+    pub fn get_auto_filter(&self) -> Option<&AutoFilter> {
+        self.auto_filter.as_ref()
     }
 
     // Get Auto Filter (Option) in mutable.
-    pub fn get_auto_filter_mut(&mut self) -> &mut Option<AutoFilter> {
-        &mut self.auto_filter
+    pub fn get_auto_filter_mut(&mut self) -> Option<&mut AutoFilter> {
+        self.auto_filter.as_mut()
     }
 
     // Set Auto Filter.
@@ -1215,8 +1215,8 @@ impl Worksheet {
     }
 
     /// Get Code Name.
-    pub fn get_code_name(&self) -> &Option<String> {
-        &self.code_name
+    pub fn get_code_name(&self) -> Option<&String> {
+        self.code_name.as_ref()
     }
 
     /// Set Code Name.
@@ -1284,8 +1284,8 @@ impl Worksheet {
     }
 
     /// Get Tab Color.
-    pub fn get_tab_color(&self) -> &Option<Color> {
-        &self.tab_color
+    pub fn get_tab_color(&self) -> Option<&Color> {
+        self.tab_color.as_ref()
     }
 
     /// Get Tab Color in mutable.
@@ -1549,12 +1549,12 @@ impl Worksheet {
         &mut self.tables
     }
 
-    pub fn get_data_validations(&self) -> &Option<DataValidations> {
-        &self.data_validations
+    pub fn get_data_validations(&self) -> Option<&DataValidations> {
+        self.data_validations.as_ref()
     }
 
-    pub fn get_data_validations_mut(&mut self) -> &mut Option<DataValidations> {
-        &mut self.data_validations
+    pub fn get_data_validations_mut(&mut self) -> Option<&mut DataValidations> {
+        self.data_validations.as_mut()
     }
 
     pub fn set_data_validations(&mut self, value: DataValidations) -> &mut Self {
@@ -1756,8 +1756,8 @@ impl Worksheet {
         self
     }
 
-    pub fn get_sheet_protection(&self) -> &Option<SheetProtection> {
-        &self.sheet_protection
+    pub fn get_sheet_protection(&self) -> Option<&SheetProtection> {
+        self.sheet_protection.as_ref()
     }
 
     pub fn get_sheet_protection_mut(&mut self) -> &mut SheetProtection {

--- a/src/structs/worksheet.rs
+++ b/src/structs/worksheet.rs
@@ -504,15 +504,12 @@ impl Worksheet {
     pub(crate) fn get_hyperlink_collection_to_hashmap(&self) -> HashMap<String, &Hyperlink> {
         let mut result: HashMap<String, &Hyperlink> = HashMap::new();
         for cell in self.cell_collection.get_collection() {
-            match cell.get_hyperlink() {
-                Some(hyperlink) => {
-                    let coordition = coordinate_from_index(
-                        cell.get_coordinate().get_col_num(),
-                        cell.get_coordinate().get_row_num(),
-                    );
-                    result.insert(coordition, hyperlink);
-                }
-                None => {}
+            if let Some(hyperlink) = cell.get_hyperlink() {
+                let coordition = coordinate_from_index(
+                    cell.get_coordinate().get_col_num(),
+                    cell.get_coordinate().get_row_num(),
+                );
+                result.insert(coordition, hyperlink);
             }
         }
         result
@@ -996,16 +993,13 @@ impl Worksheet {
             }
 
             // auto filter
-            match self.get_auto_filter_mut() {
-                Some(v) => {
-                    v.get_range_mut().adjustment_insert_coordinate(
-                        root_col_num,
-                        offset_col_num,
-                        root_row_num,
-                        offset_row_num,
-                    );
-                }
-                None => {}
+            if let Some(v) = self.get_auto_filter_mut() {
+                v.get_range_mut().adjustment_insert_coordinate(
+                    root_col_num,
+                    offset_col_num,
+                    root_row_num,
+                    offset_row_num,
+                );
             };
         }
     }
@@ -1061,123 +1055,118 @@ impl Worksheet {
             self.get_row_dimensions_crate_mut()
                 .adjustment_remove_coordinate(root_row_num, offset_row_num);
         }
-        if offset_col_num != &0 || offset_row_num != &0 {
-            // defined_names
-            let title = self.title.clone();
-            self.defined_names.retain(|x| {
-                !(x.get_address_obj().is_remove(
+
+        if (offset_col_num == &0 && offset_row_num == &0) {
+            return;
+        }
+
+        // defined_names
+        let title = self.title.clone();
+        self.defined_names.retain(|x| {
+            !(x.get_address_obj().is_remove(
+                &title,
+                root_col_num,
+                offset_col_num,
+                root_row_num,
+                offset_row_num,
+            ))
+        });
+        for defined_name in &mut self.defined_names {
+            defined_name
+                .get_address_obj_mut()
+                .adjustment_remove_coordinate(
                     &title,
                     root_col_num,
                     offset_col_num,
                     root_row_num,
                     offset_row_num,
-                ))
-            });
-            for defined_name in &mut self.defined_names {
-                defined_name
-                    .get_address_obj_mut()
-                    .adjustment_remove_coordinate(
-                        &title,
-                        root_col_num,
-                        offset_col_num,
-                        root_row_num,
-                        offset_row_num,
-                    );
-            }
-
-            // cell
-            self.get_cell_collection_crate_mut()
-                .adjustment_remove_coordinate(
-                    root_col_num,
-                    offset_col_num,
-                    root_row_num,
-                    offset_row_num,
                 );
+        }
 
-            // comments
-            self.comments.retain(|x| {
-                !(x.get_coordinate().is_remove(
-                    root_col_num,
-                    offset_col_num,
-                    root_row_num,
-                    offset_row_num,
-                ))
-            });
-            for comment in &mut self.comments {
-                comment.adjustment_remove_coordinate(
-                    root_col_num,
-                    offset_col_num,
-                    root_row_num,
-                    offset_row_num,
-                );
-            }
+        // cell
+        self.get_cell_collection_crate_mut()
+            .adjustment_remove_coordinate(
+                root_col_num,
+                offset_col_num,
+                root_row_num,
+                offset_row_num,
+            );
 
-            // conditional styles
-            for conditional_styles in &mut self.conditional_formatting_collection {
-                conditional_styles
-                    .get_sequence_of_references_mut()
-                    .get_range_collection_mut()
-                    .retain(|x| {
-                        !(x.is_remove(root_col_num, offset_col_num, root_row_num, offset_row_num))
-                    });
-            }
-            self.conditional_formatting_collection.retain(|x| {
-                !x.get_sequence_of_references()
-                    .get_range_collection()
-                    .is_empty()
-            });
-            for conditional_styles in &mut self.conditional_formatting_collection {
-                for range in conditional_styles
-                    .get_sequence_of_references_mut()
-                    .get_range_collection_mut()
-                {
-                    range.adjustment_remove_coordinate(
-                        root_col_num,
-                        offset_col_num,
-                        root_row_num,
-                        offset_row_num,
-                    );
-                }
-            }
+        // comments
+        self.comments.retain(|x| {
+            !(x.get_coordinate().is_remove(
+                root_col_num,
+                offset_col_num,
+                root_row_num,
+                offset_row_num,
+            ))
+        });
+        for comment in &mut self.comments {
+            comment.adjustment_remove_coordinate(
+                root_col_num,
+                offset_col_num,
+                root_row_num,
+                offset_row_num,
+            );
+        }
 
-            // merge cells
-            self.get_merge_cells_mut().retain(|x| {
-                !(x.is_remove(root_col_num, offset_col_num, root_row_num, offset_row_num))
-            });
-            for merge_cell in self.get_merge_cells_mut() {
-                merge_cell.adjustment_remove_coordinate(
+        // conditional styles
+        for conditional_styles in &mut self.conditional_formatting_collection {
+            conditional_styles
+                .get_sequence_of_references_mut()
+                .get_range_collection_mut()
+                .retain(|x| {
+                    !(x.is_remove(root_col_num, offset_col_num, root_row_num, offset_row_num))
+                });
+        }
+        self.conditional_formatting_collection.retain(|x| {
+            !x.get_sequence_of_references()
+                .get_range_collection()
+                .is_empty()
+        });
+        for conditional_styles in &mut self.conditional_formatting_collection {
+            for range in conditional_styles
+                .get_sequence_of_references_mut()
+                .get_range_collection_mut()
+            {
+                range.adjustment_remove_coordinate(
                     root_col_num,
                     offset_col_num,
                     root_row_num,
                     offset_row_num,
                 );
             }
+        }
 
-            // auto filter
-            let is_remove = match self.get_auto_filter() {
-                Some(v) => v.get_range().is_remove(
-                    root_col_num,
-                    offset_col_num,
-                    root_row_num,
-                    offset_row_num,
-                ),
-                None => false,
-            };
-            if is_remove {
+        // merge cells
+        self.get_merge_cells_mut()
+            .retain(|x| !(x.is_remove(root_col_num, offset_col_num, root_row_num, offset_row_num)));
+        for merge_cell in self.get_merge_cells_mut() {
+            merge_cell.adjustment_remove_coordinate(
+                root_col_num,
+                offset_col_num,
+                root_row_num,
+                offset_row_num,
+            );
+        }
+
+        // auto filter
+        if let Some(v) = self.get_auto_filter() {
+            if v.get_range()
+                .is_remove(root_col_num, offset_col_num, root_row_num, offset_row_num)
+            {
                 self.remove_auto_filter();
             }
-            match self.get_auto_filter_mut() {
-                Some(v) => {
-                    v.get_range_mut().adjustment_remove_coordinate(
-                        root_col_num,
-                        offset_col_num,
-                        root_row_num,
-                        offset_row_num,
-                    );
-                }
-                None => {}
-            };
         }
+
+        if let Some(v) = self.get_auto_filter_mut() {
+            v.get_range_mut().adjustment_remove_coordinate(
+                root_col_num,
+                offset_col_num,
+                root_row_num,
+                offset_row_num,
+            );
+        };
     }
 
     /// (This method is crate only.)
@@ -1290,12 +1279,7 @@ impl Worksheet {
 
     /// Get Tab Color in mutable.
     pub fn get_tab_color_mut(&mut self) -> &mut Color {
-        match &self.tab_color {
-            Some(_) => return self.tab_color.as_mut().unwrap(),
-            None => {}
-        }
-        self.set_tab_color(Color::default());
-        self.tab_color.as_mut().unwrap()
+        self.tab_color.get_or_insert_with(|| Color::default())
     }
 
     /// Set Tab Color.

--- a/src/structs/writer_manager.rs
+++ b/src/structs/writer_manager.rs
@@ -45,8 +45,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
         target: &str,
         writer: Writer<Cursor<Vec<u8>>>,
     ) -> Result<(), XlsxError> {
-        let is_match = self.check_file_exist(target);
-        if !is_match {
+        if !self.check_file_exist(target) {
             make_file_from_writer(target, &mut self.arv, writer, None, &self.is_light)?;
             self.files.push(target.to_string());
         }
@@ -54,8 +53,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
     }
 
     pub(crate) fn add_bin(&mut self, target: &str, data: &[u8]) -> Result<(), XlsxError> {
-        let is_match = self.check_file_exist(target);
-        if !is_match {
+        if !self.check_file_exist(target) {
             make_file_from_bin(target, &mut self.arv, data, None, &self.is_light)?;
             self.files.push(target.to_string());
         }
@@ -84,8 +82,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
         loop {
             index += 1;
             let file_path = format!("{}/drawing{}.xml", PKG_DRAWINGS, index);
-            let is_match = self.check_file_exist(&file_path);
-            if !is_match {
+            if !self.check_file_exist(&file_path) {
                 self.add_writer(&file_path, writer)?;
                 return Ok(index);
             }
@@ -100,8 +97,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
         loop {
             index += 1;
             let file_path = format!("{}/vmlDrawing{}.vml", PKG_DRAWINGS, index);
-            let is_match = self.check_file_exist(&file_path);
-            if !is_match {
+            if !self.check_file_exist(&file_path) {
                 self.add_writer(&file_path, writer)?;
                 return Ok(index);
             }
@@ -116,8 +112,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
         loop {
             index += 1;
             let file_path = format!("xl/comments{}.xml", index);
-            let is_match = self.check_file_exist(&file_path);
-            if !is_match {
+            if !self.check_file_exist(&file_path) {
                 self.add_writer(&file_path, writer)?;
                 return Ok(index);
             }
@@ -132,8 +127,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
         loop {
             index += 1;
             let file_path = format!("{}/chart{}.xml", PKG_CHARTS, index);
-            let is_match = self.check_file_exist(&file_path);
-            if !is_match {
+            if !self.check_file_exist(&file_path) {
                 self.add_writer(&file_path, writer)?;
                 return Ok(index);
             }
@@ -145,8 +139,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
         loop {
             index += 1;
             let file_path = format!("{}/oleObject{}.bin", PKG_EMBEDDINGS, index);
-            let is_match = self.check_file_exist(&file_path);
-            if !is_match {
+            if !self.check_file_exist(&file_path) {
                 self.add_bin(&file_path, writer)?;
                 return Ok(index);
             }
@@ -158,8 +151,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
         loop {
             index += 1;
             let file_path = format!("{}/Microsoft_Excel_Worksheet{}.xlsx", PKG_EMBEDDINGS, index);
-            let is_match = self.check_file_exist(&file_path);
-            if !is_match {
+            if !self.check_file_exist(&file_path) {
                 self.add_bin(&file_path, writer)?;
                 return Ok(index);
             }
@@ -171,8 +163,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
         loop {
             index += 1;
             let file_path = format!("{}/printerSettings{}.bin", PKG_PRNTR_SETTINGS, index);
-            let is_match = self.check_file_exist(&file_path);
-            if !is_match {
+            if !self.check_file_exist(&file_path) {
                 self.add_bin(&file_path, writer)?;
                 return Ok(index);
             }

--- a/src/writer/driver.rs
+++ b/src/writer/driver.rs
@@ -18,9 +18,9 @@ pub(crate) fn write_start_tag<'a, S>(
     elem.extend_attributes(attributes);
 
     if empty_flag {
-        let _ = writer.write_event(Event::Empty(elem));
+        writer.write_event(Event::Empty(elem));
     } else {
-        let _ = writer.write_event(Event::Start(elem));
+        writer.write_event(Event::Start(elem));
     }
 }
 
@@ -28,21 +28,21 @@ pub(crate) fn write_end_tag<'a, S>(writer: &mut Writer<Cursor<Vec<u8>>>, tag_nam
 where
     S: Into<Cow<'a, str>>,
 {
-    let _ = writer.write_event(Event::End(BytesEnd::new(tag_name.into())));
+    writer.write_event(Event::End(BytesEnd::new(tag_name.into())));
 }
 
 pub(crate) fn write_text_node<'a, S>(writer: &mut Writer<Cursor<Vec<u8>>>, data: S)
 where
     S: Into<Cow<'a, str>>,
 {
-    let _ = writer.write_event(Event::Text(BytesText::new(&data.into())));
+    writer.write_event(Event::Text(BytesText::new(&data.into())));
 }
 
 pub(crate) fn write_text_node_no_escape<'a, S>(writer: &mut Writer<Cursor<Vec<u8>>>, data: S)
 where
     S: Into<Cow<'a, str>>,
 {
-    let _ = writer.get_mut().write(data.into().as_bytes());
+    writer.get_mut().write(data.into().as_bytes());
 }
 
 pub(crate) fn write_new_line(writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/writer/xlsx.rs
+++ b/src/writer/xlsx.rs
@@ -390,7 +390,7 @@ pub fn set_password<P: AsRef<Path>>(
 ) -> Result<(), XlsxError> {
     let mut file = File::open(from_path).unwrap();
     let mut buffer = Vec::new();
-    let _ = file.read_to_end(&mut buffer).unwrap();
+    file.read_to_end(&mut buffer).unwrap();
 
     // set password
     encrypt(&to_path, &buffer, password);

--- a/src/writer/xlsx/chart.rs
+++ b/src/writer/xlsx/chart.rs
@@ -14,7 +14,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 ) -> Result<String, XlsxError> {
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/comment.rs
+++ b/src/writer/xlsx/comment.rs
@@ -17,7 +17,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/content_types.rs
+++ b/src/writer/xlsx/content_types.rs
@@ -15,7 +15,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     let is_light = *writer_mng.get_is_light();
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/doc_props_app.rs
+++ b/src/writer/xlsx/doc_props_app.rs
@@ -14,7 +14,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 ) -> Result<(), XlsxError> {
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/doc_props_core.rs
+++ b/src/writer/xlsx/doc_props_core.rs
@@ -14,7 +14,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 ) -> Result<(), XlsxError> {
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/drawing.rs
+++ b/src/writer/xlsx/drawing.rs
@@ -17,7 +17,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/drawing_rels.rs
+++ b/src/writer/xlsx/drawing_rels.rs
@@ -18,7 +18,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/embeddings.rs
+++ b/src/writer/xlsx/embeddings.rs
@@ -12,12 +12,12 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     let mut excel_no_list: Vec<String> = Vec::new();
     for ole_object in worksheet.get_ole_objects().get_ole_object() {
         if ole_object.is_bin() {
-            let writer = ole_object.get_object_data().as_ref().unwrap();
+            let writer = ole_object.get_object_data().unwrap();
             let file_no = writer_mng.add_file_at_ole_object(writer)?;
             ole_object_no_list.push(file_no.to_string());
         }
         if ole_object.is_xlsx() {
-            let writer = ole_object.get_object_data().as_ref().unwrap();
+            let writer = ole_object.get_object_data().unwrap();
             let file_no = writer_mng.add_file_at_excel(writer)?;
             excel_no_list.push(file_no.to_string());
         }

--- a/src/writer/xlsx/printer_settings.rs
+++ b/src/writer/xlsx/printer_settings.rs
@@ -8,11 +8,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     worksheet: &Worksheet,
     writer_mng: &mut WriterManager<W>,
 ) -> Result<String, XlsxError> {
-    let writer = worksheet
-        .get_page_setup()
-        .get_object_data()
-        .as_ref()
-        .unwrap();
+    let writer = worksheet.get_page_setup().get_object_data().unwrap();
 
     let file_no = writer_mng.add_file_at_printer_settings(writer)?;
     Ok(file_no.to_string())

--- a/src/writer/xlsx/rels.rs
+++ b/src/writer/xlsx/rels.rs
@@ -14,7 +14,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 ) -> Result<(), XlsxError> {
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/shared_strings.rs
+++ b/src/writer/xlsx/shared_strings.rs
@@ -25,7 +25,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/styles.rs
+++ b/src/writer/xlsx/styles.rs
@@ -13,7 +13,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 ) -> Result<(), XlsxError> {
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/table.rs
+++ b/src/writer/xlsx/table.rs
@@ -17,7 +17,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
         let mut writer = Writer::new(io::Cursor::new(Vec::new()));
 
         // XML header
-        let _ = writer.write_event(Event::Decl(BytesDecl::new(
+        writer.write_event(Event::Decl(BytesDecl::new(
             "1.0",
             Some("UTF-8"),
             Some("yes"),

--- a/src/writer/xlsx/theme.rs
+++ b/src/writer/xlsx/theme.rs
@@ -14,7 +14,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 ) -> Result<(), XlsxError> {
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/vba_project_bin.rs
+++ b/src/writer/xlsx/vba_project_bin.rs
@@ -13,6 +13,6 @@ pub(crate) fn write<W: io::Seek + io::Write>(
         true => {}
         false => return Ok(()),
     }
-    let writer = spreadsheet.get_macros_code().as_ref().unwrap();
+    let writer = spreadsheet.get_macros_code().unwrap();
     writer_mng.add_bin(PKG_VBA_PROJECT, writer)
 }

--- a/src/writer/xlsx/vml_drawing_rels.rs
+++ b/src/writer/xlsx/vml_drawing_rels.rs
@@ -17,7 +17,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/vml_drawing_rels.rs
+++ b/src/writer/xlsx/vml_drawing_rels.rs
@@ -29,18 +29,15 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     let mut r_id = 1;
     for ole_object in worksheet.get_ole_objects().get_ole_object() {
-        match ole_object.get_shape().get_image_data() {
-            Some(v) => {
-                is_write = write_relationship(
-                    &mut writer,
-                    &r_id,
-                    IMAGE_NS,
-                    format!("../media/{}", v.get_image_name()).as_str(),
-                    "",
-                );
-                r_id += 1;
-            }
-            None => {}
+        if let Some(v) = ole_object.get_shape().get_image_data() {
+            is_write = write_relationship(
+                &mut writer,
+                &r_id,
+                IMAGE_NS,
+                format!("../media/{}", v.get_image_name()).as_str(),
+                "",
+            );
+            r_id += 1;
         }
     }
 

--- a/src/writer/xlsx/workbook.rs
+++ b/src/writer/xlsx/workbook.rs
@@ -52,11 +52,8 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     write_start_tag(&mut writer, "workbookPr", attributes, true);
 
     // workbookProtection
-    match spreadsheet.get_workbook_protection() {
-        Some(v) => {
-            v.write_to(&mut writer);
-        }
-        None => {}
+    if let Some(v) = spreadsheet.get_workbook_protection() {
+        v.write_to(&mut writer);
     }
 
     // bookViews

--- a/src/writer/xlsx/workbook.rs
+++ b/src/writer/xlsx/workbook.rs
@@ -14,7 +14,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 ) -> Result<(), XlsxError> {
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/workbook_rels.rs
+++ b/src/writer/xlsx/workbook_rels.rs
@@ -16,7 +16,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     let is_light = *writer_mng.get_is_light();
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),

--- a/src/writer/xlsx/worksheet.rs
+++ b/src/writer/xlsx/worksheet.rs
@@ -127,11 +127,15 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
         // row loop
         for row in &row_dimensions {
-            let cells_in_row: Vec<&Cell> = cells_iter
-                .by_ref()
-                .take_while(|&cell| row.get_row_num() == cell.get_coordinate().get_row_num())
-                .map(|&x| x)
-                .collect();
+            let mut cells_in_row: Vec<&Cell> = Vec::new();
+
+            while let Some(cell) = cells_iter.peek() {
+                if row.get_row_num() != cell.get_coordinate().get_row_num() {
+                    break;
+                }
+
+                cells_in_row.push(cells_iter.next().unwrap());
+            }
 
             // row
             if cells_in_row.is_empty() {

--- a/src/writer/xlsx/worksheet.rs
+++ b/src/writer/xlsx/worksheet.rs
@@ -162,24 +162,18 @@ pub(crate) fn write<W: io::Seek + io::Write>(
         }
 
         // sheetProtection
-        match worksheet.get_sheet_protection() {
-            Some(v) => {
-                v.write_to(&mut writer);
-            }
-            None => {}
+        if let Some(v) = worksheet.get_sheet_protection() {
+            v.write_to(&mut writer);
         }
 
         // autoFilter
-        match worksheet.get_auto_filter() {
-            Some(v) => {
-                write_start_tag(
-                    &mut writer,
-                    "autoFilter",
-                    vec![("ref", &v.get_range().get_range())],
-                    true,
-                );
-            }
-            None => {}
+        if let Some(v) = worksheet.get_auto_filter() {
+            write_start_tag(
+                &mut writer,
+                "autoFilter",
+                vec![("ref", &v.get_range().get_range())],
+                true,
+            );
         }
 
         // mergeCells
@@ -194,11 +188,8 @@ pub(crate) fn write<W: io::Seek + io::Write>(
         }
 
         // dataValidations
-        match worksheet.get_data_validations() {
-            Some(v) => {
-                v.write_to(&mut writer);
-            }
-            None => {}
+        if let Some(v) = worksheet.get_data_validations() {
+            v.write_to(&mut writer);
         }
 
         let mut r_id = 1;

--- a/src/writer/xlsx/worksheet_rels.rs
+++ b/src/writer/xlsx/worksheet_rels.rs
@@ -25,7 +25,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
     let mut writer = Writer::new(io::Cursor::new(Vec::new()));
     // XML header
-    let _ = writer.write_event(Event::Decl(BytesDecl::new(
+    writer.write_event(Event::Decl(BytesDecl::new(
         "1.0",
         Some("UTF-8"),
         Some("yes"),


### PR DESCRIPTION
**Alert this is a breaking change**

- The `&Option<T>` in the library has been changed to `Option<&T>` similarly for mutable case for better memory management and general uniformity in the code base.
- Changed the unnecessary `match` statements to `if let` syntax for better readability.
- Removed unnecessary `let _ =` and making code more idiomatic.
- Also changed unnecessary `if let Some(_)` pattern to `is_some()` function
- Also sprinkled in some general improvements.