### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,14 +19,8 @@ jobs:
     - name: Install Rust
       run: rustup component add rustfmt clippy
 
-    - name: Build
-      run: cargo build
-
-    - name: Lint (clippy)
-      run: cargo clippy -- -D warnings
-
-    - name: Lint (rustfmt)
-      run: cargo fmt --all -- --check
-
-    - name: Tests
-      run: cargo test
+    - name: Run Lint & Tests
+      run: |
+        cargo clippy -- -D warnings
+        cargo fmt --all -- --check
+        cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust
       run: rustup component add rustfmt clippy


### PR DESCRIPTION
* Updates `actions/checkout@v3` which gets rid of a warning message about Node versions 
![Screenshot 2024-02-12 at 6 52 38 PM](https://github.com/MathNya/umya-spreadsheet/assets/227510/a1ab38ce-5d1c-4d52-a5b8-bf0af4d2a27b)
* Combines the 3 separate build steps into one so they share the same build (quicker)