### PR TITLE
Allow to change `codeName` attribute in `workbookPr`

### DIFF
--- a/src/structs/spreadsheet.rs
+++ b/src/structs/spreadsheet.rs
@@ -22,6 +22,7 @@ pub struct Spreadsheet {
     properties: Properties,
     work_sheet_collection: Vec<Worksheet>,
     macros_code: Option<Vec<u8>>,
+    code_name: Option<String>,
     ribbon_xml_data: Option<String>,
     theme: Theme,
     stylesheet: Stylesheet,
@@ -270,6 +271,27 @@ impl Spreadsheet {
     /// Has Macros Code
     pub fn get_has_macros(&self) -> bool {
         self.macros_code.is_some()
+    }
+
+    /// Set codeName property of workbook
+    /// 
+    /// May be useful when importing VBA/macros code from another workbook
+    /// and only used when writing book with macros code 
+    /// 
+    /// Default one is `ThisWorkbook`. 
+    /// 
+    /// Excel often uses `Workbook________` (8 underscores).
+    pub fn set_code_name<S: ToString>(&mut self, codename: S) -> &mut Self {
+        self.code_name = Some(codename.to_string());
+        self
+    }
+
+    /// Get codeName property of workbook
+    /// 
+    /// Must to be the same in workbook with VBA/macros code from this workbook
+    /// for that code in Workbook object to work out of the box without adjustments
+    pub fn get_code_name(&self) -> Option<&str> {
+        self.code_name.as_deref()
     }
 
     /// (This method is crate only.)

--- a/src/writer/xlsx/workbook.rs
+++ b/src/writer/xlsx/workbook.rs
@@ -47,7 +47,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     attributes.push(("filterPrivacy", "1"));
     //attributes.push(("defaultThemeVersion", "124226"));
     if spreadsheet.get_has_macros() {
-        attributes.push(("codeName", "ThisWorkbook"));
+        attributes.push(("codeName", &spreadsheet.get_code_name().unwrap_or("ThisWorkbook")));
     }
     write_start_tag(&mut writer, "workbookPr", attributes, true);
 


### PR DESCRIPTION
Add a way to change workbook `codeName` attribute when saving spreadsheet. This allows to use dumped `vbaProject` code in `Workbook` object as-is.

Example with default `codeName` :
![image](https://github.com/MathNya/umya-spreadsheet/assets/77514082/a972741d-b578-4f51-897e-1eb5e5b13a3d)
Notice that there are `Workbook________` (imported code) and `Workbook________1` (new) objects. And imported code is in first one, which is not active, so user needs to manually copy code. 

If we change codeName to `Workbook________`:
![image](https://github.com/MathNya/umya-spreadsheet/assets/77514082/22abe888-04a5-43a6-bff6-fac76d0eea40)
No  `Workbook________1` entry and code now is working out of the box.