### PR TITLE
some improvement changes

### DIFF
--- a/src/structs/cell_style.rs
+++ b/src/structs/cell_style.rs
@@ -56,7 +56,7 @@ impl CellStyle {
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // cellStyle
         let mut attributes: Vec<(&str, &str)> = Vec::new();
-        attributes.push(("name", self.name.get_value_string()));
+        attributes.push(("name", self.name.get_value_str()));
         let format_id = self.format_id.get_value_string();
         attributes.push(("xfId", &format_id));
         let builtin_id = self.builtin_id.get_value_string();

--- a/src/structs/color.rs
+++ b/src/structs/color.rs
@@ -260,7 +260,7 @@ impl Color {
         } else if self.indexed.has_value() {
             attributes.push(("indexed", &indexed));
         } else if self.argb.has_value() {
-            attributes.push(("rgb", self.argb.get_value_string()));
+            attributes.push(("rgb", self.argb.get_value_str()));
         }
         let tint = self.tint.get_value_string();
         if self.tint.has_value() {

--- a/src/structs/conditional_format_value_object.rs
+++ b/src/structs/conditional_format_value_object.rs
@@ -64,7 +64,7 @@ impl ConditionalFormatValueObject {
         if self.r#type.has_value() {
             attributes.push(("type", ctype));
         }
-        let val = self.val.get_value_string();
+        let val = self.val.get_value_str();
         if self.val.has_value() {
             attributes.push(("val", val));
         }

--- a/src/structs/custom_properties/custom_document_property.rs
+++ b/src/structs/custom_properties/custom_document_property.rs
@@ -128,11 +128,11 @@ impl CustomDocumentProperty {
         attributes.push(("pid", &pid_str));
 
         if self.name.has_value() {
-            attributes.push(("name", self.name.get_value_string()));
+            attributes.push(("name", self.name.get_value_str()));
         }
 
         if self.link_target.has_value() {
-            attributes.push(("linkTarget", self.link_target.get_value_string()));
+            attributes.push(("linkTarget", self.link_target.get_value_str()));
         }
 
         write_start_tag(writer, "property", attributes, !is_inner);

--- a/src/structs/data_validation.rs
+++ b/src/structs/data_validation.rs
@@ -223,11 +223,11 @@ impl DataValidation {
         }
 
         if self.prompt_title.has_value() {
-            attributes.push(("promptTitle", self.prompt_title.get_value_string()));
+            attributes.push(("promptTitle", self.prompt_title.get_value_str()));
         }
 
         if self.prompt.has_value() {
-            attributes.push(("prompt", self.prompt.get_value_string()));
+            attributes.push(("prompt", self.prompt.get_value_str()));
         }
 
         let sequence_of_references = &self.sequence_of_references.get_sqref();
@@ -239,12 +239,12 @@ impl DataValidation {
         if is_inner {
             if self.formula1.has_value() {
                 write_start_tag(writer, "formula1", vec![], false);
-                write_text_node(writer, self.formula1.get_value_string());
+                write_text_node(writer, self.formula1.get_value_str());
                 write_end_tag(writer, "formula1");
             }
             if self.formula2.has_value() {
                 write_start_tag(writer, "formula2", vec![], false);
-                write_text_node(writer, self.formula2.get_value_string());
+                write_text_node(writer, self.formula2.get_value_str());
                 write_end_tag(writer, "formula2");
             }
             write_end_tag(writer, "dataValidation");

--- a/src/structs/defined_name.rs
+++ b/src/structs/defined_name.rs
@@ -18,7 +18,7 @@ pub struct DefinedName {
 }
 impl DefinedName {
     pub fn get_name(&self) -> &str {
-        &self.name.get_value_string()
+        &self.name.get_value_str()
     }
 
     pub(crate) fn set_name<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -28,7 +28,7 @@ impl DefinedName {
 
     pub fn get_address(&self) -> String {
         if self.string_value.has_value() {
-            return self.string_value.get_value_string().to_string();
+            return self.string_value.get_value_str().to_string();
         }
         let mut result: Vec<String> = Vec::new();
         for row in &self.address {

--- a/src/structs/drawing/charts/editing_language.rs
+++ b/src/structs/drawing/charts/editing_language.rs
@@ -34,7 +34,7 @@ impl EditingLanguage {
         write_start_tag(
             writer,
             "c:lang",
-            vec![("val", self.val.get_value_string())],
+            vec![("val", self.val.get_value_str())],
             true,
         );
     }

--- a/src/structs/drawing/charts/formula.rs
+++ b/src/structs/drawing/charts/formula.rs
@@ -27,7 +27,7 @@ impl Formula {
 
     pub fn get_address_str(&self) -> String {
         if self.string_value.has_value() {
-            return self.string_value.get_value_string().to_string();
+            return self.string_value.get_value_str().to_string();
         }
         self.address.get_address()
     }

--- a/src/structs/drawing/charts/numbering_format.rs
+++ b/src/structs/drawing/charts/numbering_format.rs
@@ -49,7 +49,7 @@ impl NumberingFormat {
             writer,
             "c:numFmt",
             vec![
-                ("formatCode", self.format_code.get_value_string()),
+                ("formatCode", self.format_code.get_value_str()),
                 ("sourceLinked", self.source_linked.get_value_string()),
             ],
             true,

--- a/src/structs/drawing/color_scheme.rs
+++ b/src/structs/drawing/color_scheme.rs
@@ -259,7 +259,7 @@ impl ColorScheme {
         // a:clrScheme
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.name.has_value() {
-            attributes.push(("name", self.name.get_value_string()));
+            attributes.push(("name", self.name.get_value_str()));
         }
         write_start_tag(writer, "a:clrScheme", attributes, false);
 

--- a/src/structs/drawing/font_scheme.rs
+++ b/src/structs/drawing/font_scheme.rs
@@ -86,7 +86,7 @@ impl FontScheme {
         // a:fontScheme
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.name.has_value() {
-            attributes.push(("name", self.name.get_value_string()));
+            attributes.push(("name", self.name.get_value_str()));
         }
         write_start_tag(writer, "a:fontScheme", attributes, false);
 

--- a/src/structs/drawing/format_scheme.rs
+++ b/src/structs/drawing/format_scheme.rs
@@ -127,7 +127,7 @@ impl FormatScheme {
         // a:fmtScheme
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.name.has_value() {
-            attributes.push(("name", self.name.get_value_string()));
+            attributes.push(("name", self.name.get_value_str()));
         }
         write_start_tag(writer, "a:fmtScheme", attributes, false);
 

--- a/src/structs/drawing/rgb_color_model_hex.rs
+++ b/src/structs/drawing/rgb_color_model_hex.rs
@@ -214,7 +214,7 @@ impl RgbColorModelHex {
             write_start_tag(
                 writer,
                 "a:srgbClr",
-                vec![("val", (self.val.get_value_string()))],
+                vec![("val", (self.val.get_value_str()))],
                 false,
             );
 
@@ -263,7 +263,7 @@ impl RgbColorModelHex {
             write_start_tag(
                 writer,
                 "a:srgbClr",
-                vec![("val", (self.val.get_value_string()))],
+                vec![("val", (self.val.get_value_str()))],
                 true,
             );
         }

--- a/src/structs/drawing/run_properties.rs
+++ b/src/structs/drawing/run_properties.rs
@@ -47,7 +47,7 @@ impl RunProperties {
     }
 
     pub fn get_kumimoji(&self) -> &str {
-        self.kumimoji.get_value_string()
+        self.kumimoji.get_value_str()
     }
 
     pub fn set_kumimoji<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -56,7 +56,7 @@ impl RunProperties {
     }
 
     pub fn get_language(&self) -> &str {
-        self.language.get_value_string()
+        self.language.get_value_str()
     }
 
     pub fn set_language<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -65,7 +65,7 @@ impl RunProperties {
     }
 
     pub fn get_alternative_language(&self) -> &str {
-        self.alternative_language.get_value_string()
+        self.alternative_language.get_value_str()
     }
 
     pub fn set_alternative_language<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -74,7 +74,7 @@ impl RunProperties {
     }
 
     pub fn get_bold(&self) -> &str {
-        self.bold.get_value_string()
+        self.bold.get_value_str()
     }
 
     pub fn set_bold<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -83,7 +83,7 @@ impl RunProperties {
     }
 
     pub fn get_sz(&self) -> &str {
-        self.sz.get_value_string()
+        self.sz.get_value_str()
     }
 
     pub fn set_sz<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -92,7 +92,7 @@ impl RunProperties {
     }
 
     pub fn get_italic(&self) -> &str {
-        self.italic.get_value_string()
+        self.italic.get_value_str()
     }
 
     pub fn set_italic<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -119,7 +119,7 @@ impl RunProperties {
     }
 
     pub fn get_strike(&self) -> &str {
-        self.strike.get_value_string()
+        self.strike.get_value_str()
     }
 
     pub fn set_strike<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -338,22 +338,22 @@ impl RunProperties {
     fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, tag_name: &str) {
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.kumimoji.has_value() {
-            attributes.push(("kumimoji", self.kumimoji.get_value_string()))
+            attributes.push(("kumimoji", self.kumimoji.get_value_str()))
         }
         if self.language.has_value() {
-            attributes.push(("lang", self.language.get_value_string()))
+            attributes.push(("lang", self.language.get_value_str()))
         }
         if self.alternative_language.has_value() {
-            attributes.push(("altLang", self.alternative_language.get_value_string()))
+            attributes.push(("altLang", self.alternative_language.get_value_str()))
         }
         if self.sz.has_value() {
-            attributes.push(("sz", self.sz.get_value_string()))
+            attributes.push(("sz", self.sz.get_value_str()))
         }
         if self.bold.has_value() {
-            attributes.push(("b", self.bold.get_value_string()))
+            attributes.push(("b", self.bold.get_value_str()))
         }
         if self.italic.has_value() {
-            attributes.push(("i", self.italic.get_value_string()))
+            attributes.push(("i", self.italic.get_value_str()))
         }
         if self.capital.has_value() {
             attributes.push(("cap", self.capital.get_value_string()));
@@ -363,7 +363,7 @@ impl RunProperties {
             attributes.push(("spc", &spc));
         }
         if self.strike.has_value() {
-            attributes.push(("strike", self.strike.get_value_string()));
+            attributes.push(("strike", self.strike.get_value_str()));
         }
         if self.solid_fill.is_some()
             || self.outline.is_some()

--- a/src/structs/drawing/spreadsheet/graphic_frame.rs
+++ b/src/structs/drawing/spreadsheet/graphic_frame.rs
@@ -114,7 +114,7 @@ impl GraphicFrame {
         write_start_tag(
             writer,
             "xdr:graphicFrame",
-            vec![("macro", self.r#macro.get_value_string())],
+            vec![("macro", self.r#macro.get_value_str())],
             false,
         );
 

--- a/src/structs/drawing/spreadsheet/non_visual_drawing_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_drawing_properties.rs
@@ -76,7 +76,7 @@ impl NonVisualDrawingProperties {
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         let id = self.id.get_value_string();
         attributes.push(("id", &id));
-        attributes.push(("name", self.name.get_value_string()));
+        attributes.push(("name", self.name.get_value_str()));
         if self.hidden.has_value() {
             attributes.push(("hidden", self.hidden.get_value_string()));
         }

--- a/src/structs/drawing/supplemental_font.rs
+++ b/src/structs/drawing/supplemental_font.rs
@@ -47,8 +47,8 @@ impl SupplementalFont {
             writer,
             "a:font",
             vec![
-                ("script", self.script.get_value_string()),
-                ("typeface", self.typeface.get_value_string()),
+                ("script", self.script.get_value_str()),
+                ("typeface", self.typeface.get_value_str()),
             ],
             true,
         );

--- a/src/structs/drawing/system_color.rs
+++ b/src/structs/drawing/system_color.rs
@@ -49,7 +49,7 @@ impl SystemColor {
         if self.val.has_value() {
             attributes.push(("val", val));
         }
-        let last_color = self.last_color.get_value_string();
+        let last_color = self.last_color.get_value_str();
         if self.last_color.has_value() {
             attributes.push(("lastClr", last_color));
         }

--- a/src/structs/drawing/tail_end.rs
+++ b/src/structs/drawing/tail_end.rs
@@ -61,13 +61,13 @@ impl TailEnd {
         // a:tailEnd
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.t_type.has_value() {
-            attributes.push(("type", (self.t_type.get_value_string())));
+            attributes.push(("type", (self.t_type.get_value_str())));
         }
         if self.width.has_value() {
-            attributes.push(("w", (self.width.get_value_string())));
+            attributes.push(("w", (self.width.get_value_str())));
         }
         if self.length.has_value() {
-            attributes.push(("len", (self.length.get_value_string())));
+            attributes.push(("len", (self.length.get_value_str())));
         }
         write_start_tag(writer, "a:tailEnd", attributes, true);
     }

--- a/src/structs/drawing/text_font_type.rs
+++ b/src/structs/drawing/text_font_type.rs
@@ -85,16 +85,16 @@ impl TextFontType {
     fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, tab_name: &str) {
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.typeface.has_value() {
-            attributes.push(("typeface", self.typeface.get_value_string()));
+            attributes.push(("typeface", self.typeface.get_value_str()));
         }
         if self.pitch_family.has_value() {
-            attributes.push(("pitchFamily", self.pitch_family.get_value_string()));
+            attributes.push(("pitchFamily", self.pitch_family.get_value_str()));
         }
         if self.charset.has_value() {
-            attributes.push(("charset", self.charset.get_value_string()));
+            attributes.push(("charset", self.charset.get_value_str()));
         }
         if self.panose.has_value() {
-            attributes.push(("panose", self.panose.get_value_string()));
+            attributes.push(("panose", self.panose.get_value_str()));
         }
         write_start_tag(writer, tab_name, attributes, true);
     }

--- a/src/structs/drawing/theme.rs
+++ b/src/structs/drawing/theme.rs
@@ -553,7 +553,7 @@ impl Theme {
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         attributes.push(("xmlns:a", DRAWINGML_MAIN_NS));
         if self.name.has_value() {
-            attributes.push(("name", self.name.get_value_string()));
+            attributes.push(("name", self.name.get_value_str()));
         }
         write_start_tag(writer, "a:theme", attributes, false);
 

--- a/src/structs/font_name.rs
+++ b/src/structs/font_name.rs
@@ -36,7 +36,7 @@ impl FontName {
             write_start_tag(
                 writer,
                 tag_name,
-                vec![("val", self.val.get_value_string())],
+                vec![("val", self.val.get_value_str())],
                 true,
             );
         }

--- a/src/structs/formula.rs
+++ b/src/structs/formula.rs
@@ -26,7 +26,7 @@ impl Formula {
 
     pub fn get_address_str(&self) -> String {
         if self.string_value.has_value() {
-            return self.string_value.get_value_string().to_string();
+            return self.string_value.get_value_str().to_string();
         }
         self.address.get_address()
     }

--- a/src/structs/odd_footer.rs
+++ b/src/structs/odd_footer.rs
@@ -54,7 +54,7 @@ impl OddFooter {
         if self.has_param() {
             // oddFooter
             write_start_tag(writer, "oddFooter", vec![], false);
-            write_text_node(writer, self.value.get_value_string());
+            write_text_node(writer, self.value.get_value_str());
             write_end_tag(writer, "oddFooter");
         }
     }

--- a/src/structs/odd_header.rs
+++ b/src/structs/odd_header.rs
@@ -54,7 +54,7 @@ impl OddHeader {
         if self.has_param() {
             // oddHeader
             write_start_tag(writer, "oddHeader", vec![], false);
-            write_text_node(writer, self.value.get_value_string());
+            write_text_node(writer, self.value.get_value_str());
             write_end_tag(writer, "oddHeader");
         }
     }

--- a/src/structs/ole_object.rs
+++ b/src/structs/ole_object.rs
@@ -175,7 +175,7 @@ impl OleObject {
         write_start_tag(
             writer,
             "mc:Choice",
-            vec![("Requires", self.requires.get_value_string())],
+            vec![("Requires", self.requires.get_value_str())],
             false,
         );
 
@@ -183,7 +183,7 @@ impl OleObject {
         let r_id_str = format!("rId{}", r_id);
         let shape_id_str = format!("{}", ole_id);
         let attributes = vec![
-            ("progId", self.prog_id.get_value_string()),
+            ("progId", self.prog_id.get_value_str()),
             ("shapeId", shape_id_str.as_str()),
             ("r:id", r_id_str.as_str()),
         ];
@@ -204,7 +204,7 @@ impl OleObject {
         // oleObject
         let r_id_str = format!("rId{}", r_id);
         let attributes = vec![
-            ("progId", self.prog_id.get_value_string()),
+            ("progId", self.prog_id.get_value_str()),
             ("shapeId", shape_id_str.as_str()),
             ("r:id", r_id_str.as_str()),
         ];

--- a/src/structs/properties.rs
+++ b/src/structs/properties.rs
@@ -54,7 +54,7 @@ impl Default for Properties {
 }
 impl Properties {
     pub fn get_creator(&self) -> &str {
-        &self.creator.get_value_string()
+        &self.creator.get_value_str()
     }
 
     pub fn set_creator<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -63,7 +63,7 @@ impl Properties {
     }
 
     pub fn get_last_modified_by(&self) -> &str {
-        &self.last_modified_by.get_value_string()
+        &self.last_modified_by.get_value_str()
     }
 
     pub fn set_last_modified_by<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -72,7 +72,7 @@ impl Properties {
     }
 
     pub fn get_created(&self) -> &str {
-        &self.created.get_value_string()
+        &self.created.get_value_str()
     }
 
     pub fn set_created<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -81,7 +81,7 @@ impl Properties {
     }
 
     pub fn get_modified(&self) -> &str {
-        &self.modified.get_value_string()
+        &self.modified.get_value_str()
     }
 
     pub fn set_modified<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -90,7 +90,7 @@ impl Properties {
     }
 
     pub fn get_title(&self) -> &str {
-        &self.title.get_value_string()
+        &self.title.get_value_str()
     }
 
     pub fn set_title<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -99,7 +99,7 @@ impl Properties {
     }
 
     pub fn get_description(&self) -> &str {
-        &self.description.get_value_string()
+        &self.description.get_value_str()
     }
 
     pub fn set_description<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -108,7 +108,7 @@ impl Properties {
     }
 
     pub fn get_subject(&self) -> &str {
-        &self.subject.get_value_string()
+        &self.subject.get_value_str()
     }
 
     pub fn set_subject<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -117,7 +117,7 @@ impl Properties {
     }
 
     pub fn get_keywords(&self) -> &str {
-        &self.keywords.get_value_string()
+        &self.keywords.get_value_str()
     }
 
     pub fn set_keywords<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -126,7 +126,7 @@ impl Properties {
     }
 
     pub fn get_revision(&self) -> &str {
-        &self.revision.get_value_string()
+        &self.revision.get_value_str()
     }
 
     pub fn set_revision<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -135,7 +135,7 @@ impl Properties {
     }
 
     pub fn get_category(&self) -> &str {
-        &self.category.get_value_string()
+        &self.category.get_value_str()
     }
 
     pub fn set_category<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -144,7 +144,7 @@ impl Properties {
     }
 
     pub fn get_version(&self) -> &str {
-        &self.version.get_value_string()
+        &self.version.get_value_str()
     }
 
     pub fn set_version<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -153,7 +153,7 @@ impl Properties {
     }
 
     pub fn get_manager(&self) -> &str {
-        &self.manager.get_value_string()
+        &self.manager.get_value_str()
     }
 
     pub fn set_manager<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -162,7 +162,7 @@ impl Properties {
     }
 
     pub fn get_company(&self) -> &str {
-        &self.company.get_value_string()
+        &self.company.get_value_str()
     }
 
     pub fn set_company<S: Into<String>>(&mut self, value: S) -> &mut Self {
@@ -282,49 +282,49 @@ impl Properties {
         // dc:title
         if self.title.has_value() {
             write_start_tag(writer, "dc:title", vec![], false);
-            write_text_node(writer, self.title.get_value_string());
+            write_text_node(writer, self.title.get_value_str());
             write_end_tag(writer, "dc:title");
         }
 
         // dc:subject
         if self.subject.has_value() {
             write_start_tag(writer, "dc:subject", vec![], false);
-            write_text_node(writer, self.subject.get_value_string());
+            write_text_node(writer, self.subject.get_value_str());
             write_end_tag(writer, "dc:subject");
         }
 
         // dc:creator
         if self.creator.has_value() {
             write_start_tag(writer, "dc:creator", vec![], false);
-            write_text_node(writer, self.creator.get_value_string());
+            write_text_node(writer, self.creator.get_value_str());
             write_end_tag(writer, "dc:creator");
         }
 
         // cp:keywords
         if self.keywords.has_value() {
             write_start_tag(writer, "cp:keywords", vec![], false);
-            write_text_node(writer, self.keywords.get_value_string());
+            write_text_node(writer, self.keywords.get_value_str());
             write_end_tag(writer, "cp:keywords");
         }
 
         // dc:description
         if self.description.has_value() {
             write_start_tag(writer, "dc:description", vec![], false);
-            write_text_node(writer, self.description.get_value_string());
+            write_text_node(writer, self.description.get_value_str());
             write_end_tag(writer, "dc:description");
         }
 
         // cp:lastModifiedBy
         if self.last_modified_by.has_value() {
             write_start_tag(writer, "cp:lastModifiedBy", vec![], false);
-            write_text_node(writer, self.last_modified_by.get_value_string());
+            write_text_node(writer, self.last_modified_by.get_value_str());
             write_end_tag(writer, "cp:lastModifiedBy");
         }
 
         // cp:revision
         if self.revision.has_value() {
             write_start_tag(writer, "cp:revision", vec![], false);
-            write_text_node(writer, self.revision.get_value_string());
+            write_text_node(writer, self.revision.get_value_str());
             write_end_tag(writer, "cp:revision");
         }
 
@@ -336,7 +336,7 @@ impl Properties {
                 vec![("xsi:type", "dcterms:W3CDTF")],
                 false,
             );
-            write_text_node(writer, self.created.get_value_string());
+            write_text_node(writer, self.created.get_value_str());
             write_end_tag(writer, "dcterms:created");
         }
 
@@ -348,21 +348,21 @@ impl Properties {
                 vec![("xsi:type", "dcterms:W3CDTF")],
                 false,
             );
-            write_text_node(writer, self.modified.get_value_string());
+            write_text_node(writer, self.modified.get_value_str());
             write_end_tag(writer, "dcterms:modified");
         }
 
         // cp:category
         if self.category.has_value() {
             write_start_tag(writer, "cp:category", vec![], false);
-            write_text_node(writer, self.category.get_value_string());
+            write_text_node(writer, self.category.get_value_str());
             write_end_tag(writer, "cp:category");
         }
 
         // cp:version
         if self.version.has_value() {
             write_start_tag(writer, "cp:version", vec![], false);
-            write_text_node(writer, self.version.get_value_string());
+            write_text_node(writer, self.version.get_value_str());
             write_end_tag(writer, "cp:version");
         }
 

--- a/src/structs/s_byte_value.rs
+++ b/src/structs/s_byte_value.rs
@@ -4,10 +4,7 @@ pub struct SByteValue {
 }
 impl SByteValue {
     pub(crate) fn get_value(&self) -> &i8 {
-        match &self.value {
-            Some(v) => v,
-            None => &0,
-        }
+        self.value.as_ref().unwrap_or(&0)
     }
 
     pub(crate) fn get_value_string(&self) -> String {

--- a/src/structs/sequence_of_references.rs
+++ b/src/structs/sequence_of_references.rs
@@ -23,23 +23,18 @@ impl SequenceOfReferences {
     }
 
     pub fn set_sqref<S: Into<String>>(&mut self, value: S) {
-        let org_value = value.into();
-        let range_collection: Vec<&str> = org_value.split(' ').collect();
-        for range_value in range_collection {
+        value.into().split(' ').for_each(|range_value| {
             let mut range = Range::default();
             range.set_range(range_value);
             self.range_collection.push(range);
-        }
+        });
     }
 
     pub fn get_sqref(&self) -> String {
-        let mut result = String::from("");
-        for range in &self.range_collection {
-            if !result.is_empty() {
-                result = format!("{} ", result);
-            }
-            result = format!("{}{}", result, range.get_range());
-        }
-        result
+        self.range_collection
+            .iter()
+            .map(|range| range.get_range())
+            .collect::<Vec<String>>()
+            .join(" ")
     }
 }

--- a/src/structs/shared_string_item.rs
+++ b/src/structs/shared_string_item.rs
@@ -61,22 +61,12 @@ impl SharedStringItem {
         let mut h = AHasher::default();
         let content = format!(
             "{}{}",
-            match &self.text {
-                Some(v) => {
-                    v.get_hash_code()
-                }
-                None => {
-                    String::from("NONE")
-                }
-            },
-            match &self.rich_text {
-                Some(v) => {
-                    v.get_hash_code()
-                }
-                None => {
-                    String::from("NONE")
-                }
-            }
+            self.text
+                .as_ref()
+                .map_or(String::from("NONE"), |v| v.get_hash_code()),
+            self.rich_text
+                .as_ref()
+                .map_or(String::from("NONE"), |v| v.get_hash_code())
         );
         h.write(content.as_bytes());
         h.finish()

--- a/src/structs/shared_string_table.rs
+++ b/src/structs/shared_string_table.rs
@@ -1,9 +1,8 @@
-use crate::drawing::charts::View3D;
-
 // sst
 use super::drawing::Theme;
 use super::CellValue;
 use super::SharedStringItem;
+use drawing::charts::View3D;
 use hashbrown::HashMap;
 use helper::const_str::*;
 use quick_xml::events::{BytesStart, Event};

--- a/src/structs/sheet_protection.rs
+++ b/src/structs/sheet_protection.rs
@@ -267,20 +267,20 @@ impl SheetProtection {
         // sheetProtection
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.algorithm_name.has_value() {
-            attributes.push(("algorithmName", self.algorithm_name.get_value_string()));
+            attributes.push(("algorithmName", self.algorithm_name.get_value_str()));
         }
         if self.hash_value.has_value() {
-            attributes.push(("hashValue", self.hash_value.get_value_string()));
+            attributes.push(("hashValue", self.hash_value.get_value_str()));
         }
         if self.salt_value.has_value() {
-            attributes.push(("saltValue", self.salt_value.get_value_string()));
+            attributes.push(("saltValue", self.salt_value.get_value_str()));
         }
         let spin_count = self.spin_count.get_value_string();
         if self.spin_count.has_value() {
             attributes.push(("spinCount", &spin_count));
         }
         if self.password.has_value() {
-            attributes.push(("password", self.password.get_value_string()));
+            attributes.push(("password", self.password.get_value_str()));
         }
         if self.sheet.has_value() {
             attributes.push(("sheet", self.sheet.get_value_string()));

--- a/src/structs/sheet_view.rs
+++ b/src/structs/sheet_view.rs
@@ -208,7 +208,7 @@ impl SheetView {
         if self.zoom_scale_sheet_layout_view.has_value() {
             attributes.push(("zoomScaleSheetLayoutView", &zoom_scale_sheet_layout_view));
         }
-        let top_left_cell = self.top_left_cell.get_value_string();
+        let top_left_cell = self.top_left_cell.get_value_str();
         if self.top_left_cell.has_value() {
             attributes.push(("topLeftCell", &top_left_cell));
         }

--- a/src/structs/spreadsheet.rs
+++ b/src/structs/spreadsheet.rs
@@ -610,19 +610,13 @@ impl Spreadsheet {
     pub(crate) fn get_pivot_caches(&self) -> Vec<(String, String, String)> {
         let mut result: Vec<(String, String, String)> = Vec::new();
         for (val1, val2, val3) in &self.pivot_caches {
+            let val3_up = format!("xl/{}", &val3);
             for worksheet in self.get_sheet_collection_no_check() {
                 for pivot_cache_definition in worksheet.get_pivot_cache_definition_collection() {
-                    let val3_up = format!("xl/{}", val3);
-                    if val3_up.as_str() == pivot_cache_definition {
-                        let mut is_new = true;
-                        for (_, _, r_val3) in &result {
-                            if r_val3 == val3 {
-                                is_new = false;
-                            }
-                        }
-                        if is_new {
-                            result.push((val1.clone(), val2.clone(), val3.clone()));
-                        }
+                    if val3_up.as_str() == pivot_cache_definition
+                        && !result.iter().any(|(_, _, r_val3)| r_val3 == val3)
+                    {
+                        result.push((val1.clone(), val2.clone(), val3.clone()));
                     }
                 }
             }

--- a/src/structs/string_value.rs
+++ b/src/structs/string_value.rs
@@ -4,13 +4,10 @@ pub struct StringValue {
 }
 impl StringValue {
     pub(crate) fn get_value(&self) -> &str {
-        match &self.value {
-            Some(v) => v,
-            None => "",
-        }
+        self.value.as_deref().unwrap_or("")
     }
 
-    pub(crate) fn get_value_string(&self) -> &str {
+    pub(crate) fn get_value_str(&self) -> &str {
         self.get_value()
     }
 
@@ -34,7 +31,7 @@ impl StringValue {
 
     pub(crate) fn get_hash_string(&self) -> &str {
         if self.has_value() {
-            return self.get_value_string();
+            return self.get_value_str();
         }
         "empty!!"
     }

--- a/src/structs/to_marker.rs
+++ b/src/structs/to_marker.rs
@@ -58,19 +58,11 @@ impl ToMarker {
     }
 
     pub(crate) fn _adjustment_remove_row(&mut self, num_rows: &usize) {
-        self.row = if &self.row > num_rows {
-            self.row - num_rows
-        } else {
-            1
-        };
+        self.row = self.row.saturating_sub(*num_rows).max(1);
     }
 
     pub(crate) fn _adjustment_remove_column(&mut self, num_cols: &usize) {
-        self.col = if &self.col > num_cols {
-            self.col - num_cols
-        } else {
-            1
-        };
+        self.col = self.col.saturating_sub(*num_cols).max(1);
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/true_false_blank_value.rs
+++ b/src/structs/true_false_blank_value.rs
@@ -7,30 +7,13 @@ impl TrueFalseBlankValue {
         self.value.as_ref()
     }
 
-    pub(crate) fn _get_value_string(&self) -> &str {
-        match self.get_value() {
-            Some(v) => {
-                if !*v {
-                    "f"
-                } else {
-                    "t"
-                }
-            }
-            None => "",
-        }
+    pub(crate) fn _get_value_str(&self) -> &str {
+        self.get_value().map_or("", |v| if *v { "t" } else { "f" })
     }
 
     pub(crate) fn get_value_string2(&self) -> &str {
-        match self.get_value() {
-            Some(v) => {
-                if !*v {
-                    "False"
-                } else {
-                    "True"
-                }
-            }
-            None => "",
-        }
+        self.get_value()
+            .map_or("", |v| if *v { "True" } else { "False" })
     }
 
     pub(crate) fn set_value(&mut self, value: bool) -> &mut Self {
@@ -49,7 +32,7 @@ impl TrueFalseBlankValue {
 
     pub(crate) fn _get_hash_string(&self) -> &str {
         if self.has_value() {
-            return self._get_value_string();
+            return self._get_value_str();
         }
         "empty!!"
     }

--- a/src/structs/true_false_value.rs
+++ b/src/structs/true_false_value.rs
@@ -5,18 +5,11 @@ pub struct TrueFalseValue {
 }
 impl TrueFalseValue {
     pub(crate) fn get_value(&self) -> &bool {
-        match &self.value {
-            Some(v) => v,
-            None => &self.value_default,
-        }
+        self.value.as_ref().unwrap_or(&self.value_default)
     }
 
     pub(crate) fn get_value_string(&self) -> &str {
-        if !*self.get_value() {
-            "f"
-        } else {
-            "t"
-        }
+        self.value.as_ref().map_or("f", |b| "t")
     }
 
     pub(crate) fn set_value(&mut self, value: bool) -> &mut Self {

--- a/src/structs/u_int16_value.rs
+++ b/src/structs/u_int16_value.rs
@@ -4,10 +4,7 @@ pub struct UInt16Value {
 }
 impl UInt16Value {
     pub(crate) fn get_value(&self) -> &u16 {
-        match &self.value {
-            Some(v) => v,
-            None => &0,
-        }
+        self.value.as_ref().unwrap_or(&0)
     }
 
     pub(crate) fn get_value_string(&self) -> String {

--- a/src/structs/u_int32_value.rs
+++ b/src/structs/u_int32_value.rs
@@ -4,10 +4,7 @@ pub struct UInt32Value {
 }
 impl UInt32Value {
     pub(crate) fn get_value(&self) -> &u32 {
-        match &self.value {
-            Some(v) => v,
-            None => &0,
-        }
+        self.value.as_ref().unwrap_or(&0)
     }
 
     pub(crate) fn get_value_string(&self) -> String {

--- a/src/structs/vml/fill.rs
+++ b/src/structs/vml/fill.rs
@@ -67,16 +67,16 @@ impl Fill {
         // v:fill
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.color.has_value() {
-            attributes.push(("color", self.color.get_value_string()));
+            attributes.push(("color", self.color.get_value_str()));
         }
         if self.color_2.has_value() {
-            attributes.push(("color2", self.color_2.get_value_string()));
+            attributes.push(("color2", self.color_2.get_value_str()));
         }
         if self.on.has_value() {
             attributes.push(("on", self.on.get_value_string()));
         }
         if self.focus_size.has_value() {
-            attributes.push(("focussize", self.focus_size.get_value_string()));
+            attributes.push(("focussize", self.focus_size.get_value_str()));
         }
         write_start_tag(writer, "v:fill", attributes, true);
     }

--- a/src/structs/vml/shadow.rs
+++ b/src/structs/vml/shadow.rs
@@ -58,7 +58,7 @@ impl Shadow {
             attributes.push(("on", self.on.get_value_string()));
         }
         if self.color.has_value() {
-            attributes.push(("color", self.color.get_value_string()));
+            attributes.push(("color", self.color.get_value_str()));
         }
         if self.obscured.has_value() {
             attributes.push(("obscured", self.obscured.get_value_string()));

--- a/src/structs/vml/shape.rs
+++ b/src/structs/vml/shape.rs
@@ -300,25 +300,25 @@ impl Shape {
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         attributes.push(("id", &id_str));
         if self.r_type.has_value() {
-            attributes.push(("type", self.r_type.get_value_string()));
+            attributes.push(("type", self.r_type.get_value_str()));
         }
         if self.style.has_value() {
-            attributes.push(("style", self.style.get_value_string()));
+            attributes.push(("style", self.style.get_value_str()));
         }
         if self.filled.has_value() {
             attributes.push(("filled", self.filled.get_value_string()));
         }
         if self.fill_color.has_value() {
-            attributes.push(("fillcolor", self.fill_color.get_value_string()));
+            attributes.push(("fillcolor", self.fill_color.get_value_str()));
         }
         if self.stroked.has_value() {
             attributes.push(("stroked", self.stroked.get_value_string()));
         }
         if self.stroke_color.has_value() {
-            attributes.push(("strokecolor", self.stroke_color.get_value_string()));
+            attributes.push(("strokecolor", self.stroke_color.get_value_str()));
         }
         if self.stroke_weight.has_value() {
-            attributes.push(("strokeweight", self.stroke_weight.get_value_string()));
+            attributes.push(("strokeweight", self.stroke_weight.get_value_str()));
         }
         if self.inset_mode.has_value() {
             attributes.push(("o:insetmode", self.inset_mode.get_value_string()));
@@ -328,7 +328,7 @@ impl Shape {
             attributes.push(("o:spt", &optional_number_str));
         }
         if self.coordinate_size.has_value() {
-            attributes.push(("coordsize", self.coordinate_size.get_value_string()));
+            attributes.push(("coordsize", self.coordinate_size.get_value_str()));
         }
         write_start_tag(writer, "v:shape", attributes, false);
 

--- a/src/structs/vml/stroke.rs
+++ b/src/structs/vml/stroke.rs
@@ -55,13 +55,13 @@ impl Stroke {
         // v:stroke
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.color.has_value() {
-            attributes.push(("color", self.color.get_value_string()));
+            attributes.push(("color", self.color.get_value_str()));
         }
         if self.color_2.has_value() {
-            attributes.push(("color2", self.color_2.get_value_string()));
+            attributes.push(("color2", self.color_2.get_value_str()));
         }
         if self.dash_style.has_value() {
-            attributes.push(("dashstyle", self.dash_style.get_value_string()));
+            attributes.push(("dashstyle", self.dash_style.get_value_str()));
         }
         write_start_tag(writer, "v:stroke", attributes, true);
     }

--- a/src/structs/vml/text_box.rs
+++ b/src/structs/vml/text_box.rs
@@ -63,10 +63,10 @@ impl TextBox {
         // v:textbox
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         if self.style.has_value() {
-            attributes.push(("style", self.style.get_value_string()));
+            attributes.push(("style", self.style.get_value_str()));
         }
         write_start_tag(writer, "v:textbox", attributes, false);
-        write_text_node_no_escape(writer, self.innder.get_value_string());
+        write_text_node_no_escape(writer, self.innder.get_value_str());
         write_end_tag(writer, "v:textbox");
     }
 }

--- a/src/structs/workbook_protection.rs
+++ b/src/structs/workbook_protection.rs
@@ -191,19 +191,19 @@ impl WorkbookProtection {
         if self.workbook_algorithm_name.has_value() {
             attributes.push((
                 "workbookAlgorithmName",
-                self.workbook_algorithm_name.get_value_string(),
+                self.workbook_algorithm_name.get_value_str(),
             ));
         }
         if self.workbook_hash_value.has_value() {
             attributes.push((
                 "workbookHashValue",
-                self.workbook_hash_value.get_value_string(),
+                self.workbook_hash_value.get_value_str(),
             ));
         }
         if self.workbook_salt_value.has_value() {
             attributes.push((
                 "workbookSaltValue",
-                self.workbook_salt_value.get_value_string(),
+                self.workbook_salt_value.get_value_str(),
             ));
         }
         let workbook_spin_count = self.workbook_spin_count.get_value_string();
@@ -211,27 +211,24 @@ impl WorkbookProtection {
             attributes.push(("workbookSpinCount", &workbook_spin_count));
         }
         if self.workbook_password.has_value() {
-            attributes.push((
-                "workbookPassword",
-                self.workbook_password.get_value_string(),
-            ));
+            attributes.push(("workbookPassword", self.workbook_password.get_value_str()));
         }
         if self.revisions_algorithm_name.has_value() {
             attributes.push((
                 "revisionsAlgorithmName",
-                self.revisions_algorithm_name.get_value_string(),
+                self.revisions_algorithm_name.get_value_str(),
             ));
         }
         if self.revisions_hash_value.has_value() {
             attributes.push((
                 "revisionsHashValue",
-                self.revisions_hash_value.get_value_string(),
+                self.revisions_hash_value.get_value_str(),
             ));
         }
         if self.revisions_salt_value.has_value() {
             attributes.push((
                 "revisionsSaltValue",
-                self.revisions_salt_value.get_value_string(),
+                self.revisions_salt_value.get_value_str(),
             ));
         }
         let revisions_spin_count = self.revisions_spin_count.get_value_string();
@@ -239,10 +236,7 @@ impl WorkbookProtection {
             attributes.push(("revisionsSpinCount", &revisions_spin_count));
         }
         if self.revisions_password.has_value() {
-            attributes.push((
-                "revisionsPassword",
-                self.revisions_password.get_value_string(),
-            ));
+            attributes.push(("revisionsPassword", self.revisions_password.get_value_str()));
         }
         if self.lock_revision.has_value() {
             attributes.push(("lockRevision", self.lock_revision.get_value_string()));

--- a/src/structs/worksheet.rs
+++ b/src/structs/worksheet.rs
@@ -564,13 +564,13 @@ impl Worksheet {
     // Auto Filter
     // ************************
     // Get Auto Filter (Option).
-    pub fn get_auto_filter(&self) -> &Option<AutoFilter> {
-        &self.auto_filter
+    pub fn get_auto_filter(&self) -> Option<&AutoFilter> {
+        self.auto_filter.as_ref()
     }
 
     // Get Auto Filter (Option) in mutable.
-    pub fn get_auto_filter_mut(&mut self) -> &mut Option<AutoFilter> {
-        &mut self.auto_filter
+    pub fn get_auto_filter_mut(&mut self) -> Option<&mut AutoFilter> {
+        self.auto_filter.as_mut()
     }
 
     // Set Auto Filter.
@@ -1211,8 +1211,8 @@ impl Worksheet {
     }
 
     /// Get Code Name.
-    pub fn get_code_name(&self) -> &Option<String> {
-        &self.code_name
+    pub fn get_code_name(&self) -> Option<&String> {
+        self.code_name.as_ref()
     }
 
     /// Set Code Name.
@@ -1280,8 +1280,8 @@ impl Worksheet {
     }
 
     /// Get Tab Color.
-    pub fn get_tab_color(&self) -> &Option<Color> {
-        &self.tab_color
+    pub fn get_tab_color(&self) -> Option<&Color> {
+        self.tab_color.as_ref()
     }
 
     /// Get Tab Color in mutable.
@@ -1544,12 +1544,12 @@ impl Worksheet {
         &mut self.tables
     }
 
-    pub fn get_data_validations(&self) -> &Option<DataValidations> {
-        &self.data_validations
+    pub fn get_data_validations(&self) -> Option<&DataValidations> {
+        self.data_validations.as_ref()
     }
 
-    pub fn get_data_validations_mut(&mut self) -> &mut Option<DataValidations> {
-        &mut self.data_validations
+    pub fn get_data_validations_mut(&mut self) -> Option<&mut DataValidations> {
+        self.data_validations.as_mut()
     }
 
     pub fn set_data_validations(&mut self, value: DataValidations) -> &mut Self {
@@ -1753,8 +1753,8 @@ impl Worksheet {
         self
     }
 
-    pub fn get_sheet_protection(&self) -> &Option<SheetProtection> {
-        &self.sheet_protection
+    pub fn get_sheet_protection(&self) -> Option<&SheetProtection> {
+        self.sheet_protection.as_ref()
     }
 
     pub fn get_sheet_protection_mut(&mut self) -> &mut SheetProtection {


### PR DESCRIPTION
@MathNya
In tradition with the previous PR's this PR is also a slight refactor and slight improvement.

- Some `&Option<T>` changed to `Option<&T>` similarly for mutable case. I think these were spared during the previous purge. (As always a **disclaimer for breaking change**)
- In `src/structs/string_value.rs`, `get_value_string()` was renamed to `get_value_str()` to properly indicate its return type.(**NOT** a breaking change)
- Some idiomatic changes
- In `src/structs/spreadsheet.rs` the function `get_pivot_caches()` changed so that it is shortcircuiting. Noticable speed bump is observed.