### PR TITLE
fix(color): add return to `get_argb_with_theme`

### DIFF
--- a/src/structs/color.rs
+++ b/src/structs/color.rs
@@ -117,7 +117,7 @@ impl Color {
     /// ```
     pub fn get_argb_with_theme(&self, theme: &Theme) -> Cow<'static, str> {
         if self.indexed.has_value() {
-            self.get_argb();
+            return self.get_argb().to_owned().into();
         }
         if self.theme_index.has_value() {
             match theme


### PR DESCRIPTION
If the cell had an indexed color , and `get_value` for `StringValue` has `None`, and thus defaulted to `""` in the `unwrap_or("")`, then it would return `""`. The check for an indexed color was done, the value just wasn't returned. This pull request adds it.