### PR TITLE
fix(theme): add `sysClr` branch for `Start` event

### DIFF
--- a/src/structs/drawing/color2_type.rs
+++ b/src/structs/drawing/color2_type.rs
@@ -71,10 +71,18 @@ impl Color2Type {
                 }
             },
             Event::Start(ref e) => {
-                if e.name().into_inner() == b"a:srgbClr" {
+                match e.name().into_inner() {
+                b"a:srgbClr" => {
                     let mut obj = RgbColorModelHex::default();
                     obj.set_attributes(reader, e, false);
                     self.rgb_color_model_hex = Some(obj);
+                }
+                b"a:sysClr" => {
+                    let mut obj = SystemColor::default();
+                    obj.set_attributes(reader, e);
+                    self.system_color = Some(obj);
+                }
+                _ => (),
                 }
             },
             Event::End(ref e) => {


### PR DESCRIPTION
In the current implimentation, the only matching for `a:sysClr` is `Event::Empty`, which means a tag like `<a:sysClr ... />`, with no explicit closing tag. However, there are implementations where there are closing tags, `<a:sysClr ... ></a:sysClr>`.

```xml
<a:clrScheme name="New Office">
            <a:dk1>
                <a:sysClr val="windowText" lastClr="000000"></a:sysClr>
            </a:dk1>
            <a:lt1>
                <a:sysClr val="window" lastClr="FFFFFF"></a:sysClr>
            </a:lt1>
            <a:dk2>
                <a:srgbClr val="44546A"></a:srgbClr>
            </a:dk2>
            <a:lt2>
                <a:srgbClr val="E7E6E6"></a:srgbClr>
            </a:lt2>
            <a:accent1>
                <a:srgbClr val="5B9BD5"></a:srgbClr>
            </a:accent1>
            <a:accent2>
                <a:srgbClr val="ED7D31"></a:srgbClr>
            </a:accent2>
            <a:accent3>
                <a:srgbClr val="A5A5A5"></a:srgbClr>
            </a:accent3>
            <a:accent4>
                <a:srgbClr val="FFC000"></a:srgbClr>
            </a:accent4>
            <a:accent5>
                <a:srgbClr val="4472C4"></a:srgbClr>
            </a:accent5>
            <a:accent6>
                <a:srgbClr val="70AD47"></a:srgbClr>
            </a:accent6>
            <a:hlink>
                <a:srgbClr val="0563C1"></a:srgbClr>
            </a:hlink>
            <a:folHlink>
                <a:srgbClr val="954F72"></a:srgbClr>
            </a:folHlink>
        </a:clrScheme>
```

This pull request adds a branch in `Event::Start` that would cover this scenario, matching the `srgbClr` equivalent that already existed.