### PR TITLE
`StringValue` utilization and other minor changes

### DIFF
--- a/src/helper/date.rs
+++ b/src/helper/date.rs
@@ -32,12 +32,11 @@ pub fn excel_to_date_time_object(
     let part_day = part_day * 60f64 - minutes;
     let seconds = (part_day * 60f64).round();
 
-    base_date += Duration::days(days as i64);
-    base_date += Duration::hours(hours as i64);
-    base_date += Duration::minutes(minutes as i64);
-    base_date += Duration::seconds(seconds as i64);
-
     base_date
+        + Duration::days(days as i64)
+        + Duration::hours(hours as i64)
+        + Duration::minutes(minutes as i64)
+        + Duration::seconds(seconds as i64)
 }
 
 fn get_default_timezone() -> String {

--- a/src/helper/formula.rs
+++ b/src/helper/formula.rs
@@ -15,17 +15,17 @@ pub fn adjustment_insert_formula_coordinate(
         let caps_string = caps.get(0).unwrap().as_str().to_string();
         let split_str: Vec<&str> = caps_string.split('!').collect();
         let with_wksheet: bool;
-        let wksheet: String;
-        let range: String;
+        let wksheet: &str;
+        let range: &str;
 
         if split_str.len() == 2 {
             with_wksheet = true;
-            wksheet = split_str.first().unwrap().to_string();
-            range = split_str.get(1).unwrap().to_string();
+            wksheet = split_str.first().unwrap();
+            range = split_str.get(1).unwrap();
         } else {
             with_wksheet = false;
-            wksheet = self_worksheet_name.to_string();
-            range = split_str.first().unwrap().to_string();
+            wksheet = self_worksheet_name;
+            range = split_str.first().unwrap();
         }
 
         if wksheet != worksheet_name {

--- a/src/helper/html.rs
+++ b/src/helper/html.rs
@@ -110,7 +110,7 @@ fn make_rich_text(html_flat_data_list: &Vec<HtmlFlatData>, method: &AnalysisMeth
     let mut result = RichText::default();
 
     for html_flat_data in html_flat_data_list {
-        let mut font_name: Option<String> = method.font_name(html_flat_data);
+        let mut font_name: Option<&str> = method.font_name(html_flat_data);
         let mut size: Option<f64> = method.size(html_flat_data);
         let mut color: Option<String> = method.color(html_flat_data);
         let mut is_bold: bool = method.is_bold(html_flat_data);
@@ -184,10 +184,11 @@ impl HfdElement {
         self.name == name
     }
 
-    pub fn get_by_name_and_attribute(&self, name: &str, attribute: &str) -> Option<String> {
+    pub fn get_by_name_and_attribute(&self, name: &str, attribute: &str) -> Option<&str> {
         self.attributes
             .get(attribute)
-            .and_then(|v| (self.name == name).then(|| v.to_string()))
+            .and_then(|v| (self.name == name).then(|| v))
+            .map(|x| x.as_str())
     }
 
     pub fn contains_class(&self, class: &str) -> bool {
@@ -197,7 +198,7 @@ impl HfdElement {
 
 pub trait AnalysisMethod {
     fn is_tag(&self, html_flat_data: &HtmlFlatData, tag: &str) -> bool;
-    fn font_name(&self, html_flat_data: &HtmlFlatData) -> Option<String>;
+    fn font_name<'a>(&'a self, html_flat_data: &'a HtmlFlatData) -> Option<&'a str>;
     fn size(&self, html_flat_data: &HtmlFlatData) -> Option<f64>;
     fn color(&self, html_flat_data: &HtmlFlatData) -> Option<String>;
     fn is_bold(&self, html_flat_data: &HtmlFlatData) -> bool;
@@ -211,7 +212,7 @@ pub trait AnalysisMethod {
 #[derive(Clone, Default, Debug)]
 struct DataAnalysis {}
 impl AnalysisMethod for DataAnalysis {
-    fn font_name(&self, html_flat_data: &HtmlFlatData) -> Option<String> {
+    fn font_name<'a>(&'a self, html_flat_data: &'a HtmlFlatData) -> Option<&str> {
         html_flat_data
             .element
             .iter()

--- a/src/structs/border.rs
+++ b/src/structs/border.rs
@@ -146,7 +146,7 @@ impl Border {
 
         if !empty_flag {
             // color
-            let _ = &self.color.write_to_color(writer);
+            self.color.write_to_color(writer);
 
             write_end_tag(writer, tag_name);
         }

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -395,7 +395,7 @@ impl Cell {
 
         write_start_tag(writer, "c", attributes, false);
         // f
-        match self.cell_value.formula.get_value() {
+        match &self.cell_value.formula {
             Some(v) => {
                 write_start_tag(writer, "f", self.get_formula_attributes(), false);
                 write_text_node(writer, v);

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -395,7 +395,7 @@ impl Cell {
 
         write_start_tag(writer, "c", attributes, false);
         // f
-        match &self.cell_value.formula {
+        match self.cell_value.formula.get_value() {
             Some(v) => {
                 write_start_tag(writer, "f", self.get_formula_attributes(), false);
                 write_text_node(writer, v);

--- a/src/structs/cell_value.rs
+++ b/src/structs/cell_value.rs
@@ -1,7 +1,6 @@
 use super::RichText;
 use super::SharedStringItem;
 use super::Text;
-use crate::StringValue;
 use helper::formula::*;
 use std::borrow::Cow;
 use structs::CellRawValue;
@@ -10,7 +9,7 @@ use traits::AdjustmentCoordinateWith2Sheet;
 #[derive(Clone, Default, Debug, PartialEq, PartialOrd)]
 pub struct CellValue {
     pub(crate) raw_value: CellRawValue,
-    pub(crate) formula: StringValue,
+    pub(crate) formula: Option<String>,
     pub(crate) formula_attributes: Vec<(String, String)>,
 }
 impl CellValue {
@@ -123,12 +122,12 @@ impl CellValue {
     }
 
     pub fn set_formula<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.formula.set_value(value);
+        self.formula = Some(value.into());
         self
     }
 
     pub fn remove_formula(&mut self) -> &mut Self {
-        self.formula.remove_value();
+        self.formula = None;
         self.formula_attributes.clear();
         self
     }
@@ -149,11 +148,11 @@ impl CellValue {
     }
 
     pub fn is_formula(&self) -> bool {
-        self.formula.has_value()
+        self.formula.is_some()
     }
 
     pub fn get_formula(&self) -> &str {
-        self.formula.get_value_str()
+        self.formula.as_deref().unwrap_or("")
     }
 
     pub(crate) fn guess_typed_data(value: &str) -> CellRawValue {
@@ -209,7 +208,7 @@ impl AdjustmentCoordinateWith2Sheet for CellValue {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        if let Some(v) = self.formula.get_value() {
+        if let Some(v) = &self.formula {
             let formula = adjustment_insert_formula_coordinate(
                 v,
                 root_col_num,
@@ -219,7 +218,7 @@ impl AdjustmentCoordinateWith2Sheet for CellValue {
                 sheet_name,
                 self_sheet_name,
             );
-            self.formula.set_value(formula);
+            self.formula = Some(formula);
         }
     }
 
@@ -232,7 +231,7 @@ impl AdjustmentCoordinateWith2Sheet for CellValue {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        if let Some(v) = self.formula.get_value() {
+        if let Some(v) = &self.formula {
             let formula = adjustment_remove_formula_coordinate(
                 v,
                 root_col_num,
@@ -242,7 +241,7 @@ impl AdjustmentCoordinateWith2Sheet for CellValue {
                 sheet_name,
                 self_sheet_name,
             );
-            self.formula.set_value(formula);
+            self.formula = Some(formula);
         }
     }
 }

--- a/src/structs/cell_value.rs
+++ b/src/structs/cell_value.rs
@@ -1,6 +1,7 @@
 use super::RichText;
 use super::SharedStringItem;
 use super::Text;
+use crate::StringValue;
 use helper::formula::*;
 use std::borrow::Cow;
 use structs::CellRawValue;
@@ -9,7 +10,7 @@ use traits::AdjustmentCoordinateWith2Sheet;
 #[derive(Clone, Default, Debug, PartialEq, PartialOrd)]
 pub struct CellValue {
     pub(crate) raw_value: CellRawValue,
-    pub(crate) formula: Option<String>,
+    pub(crate) formula: StringValue,
     pub(crate) formula_attributes: Vec<(String, String)>,
 }
 impl CellValue {
@@ -122,12 +123,12 @@ impl CellValue {
     }
 
     pub fn set_formula<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.formula = Some(value.into());
+        self.formula.set_value(value);
         self
     }
 
     pub fn remove_formula(&mut self) -> &mut Self {
-        self.formula = None;
+        self.formula.remove_value();
         self.formula_attributes.clear();
         self
     }
@@ -148,11 +149,11 @@ impl CellValue {
     }
 
     pub fn is_formula(&self) -> bool {
-        self.formula.is_some()
+        self.formula.has_value()
     }
 
     pub fn get_formula(&self) -> &str {
-        self.formula.as_deref().unwrap_or("")
+        self.formula.get_value_str()
     }
 
     pub(crate) fn guess_typed_data(value: &str) -> CellRawValue {
@@ -208,7 +209,7 @@ impl AdjustmentCoordinateWith2Sheet for CellValue {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        if let Some(v) = &self.formula {
+        if let Some(v) = self.formula.get_value() {
             let formula = adjustment_insert_formula_coordinate(
                 v,
                 root_col_num,
@@ -218,7 +219,7 @@ impl AdjustmentCoordinateWith2Sheet for CellValue {
                 sheet_name,
                 self_sheet_name,
             );
-            self.formula = Some(formula);
+            self.formula.set_value(formula);
         }
     }
 
@@ -231,7 +232,7 @@ impl AdjustmentCoordinateWith2Sheet for CellValue {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        if let Some(v) = &self.formula {
+        if let Some(v) = self.formula.get_value() {
             let formula = adjustment_remove_formula_coordinate(
                 v,
                 root_col_num,
@@ -241,7 +242,7 @@ impl AdjustmentCoordinateWith2Sheet for CellValue {
                 sheet_name,
                 self_sheet_name,
             );
-            self.formula = Some(formula);
+            self.formula.set_value(formula);
         }
     }
 }

--- a/src/structs/colors.rs
+++ b/src/structs/colors.rs
@@ -55,7 +55,7 @@ impl Colors {
         write_start_tag(writer, "colors", vec![], false);
 
         // mruColors
-        let _ = &self.mru_colors.write_to(writer);
+        self.mru_colors.write_to(writer);
 
         write_end_tag(writer, "colors");
     }

--- a/src/structs/drawing/background_color.rs
+++ b/src/structs/drawing/background_color.rs
@@ -57,7 +57,7 @@ impl BackgroundColor {
         write_start_tag(writer, "a:bgClr", vec![], false);
 
         // a:schemeClr
-        let _ = &self.scheme_color.write_to(writer);
+        self.scheme_color.write_to(writer);
 
         write_end_tag(writer, "a:bgClr");
     }

--- a/src/structs/drawing/blip_fill.rs
+++ b/src/structs/drawing/blip_fill.rs
@@ -126,7 +126,7 @@ impl BlipFill {
         write_start_tag(writer, "a:blipFill", attributes, false);
 
         // a:blip
-        let _ = &self.blip.write_to(writer, rel_list);
+        self.blip.write_to(writer, rel_list);
 
         // a:srcRect
         if let Some(v) = &self.source_rectangle {
@@ -134,7 +134,7 @@ impl BlipFill {
         }
 
         // a:stretch
-        let _ = &self.stretch.write_to(writer);
+        self.stretch.write_to(writer);
 
         write_end_tag(writer, "a:blipFill");
     }

--- a/src/structs/drawing/body_properties.rs
+++ b/src/structs/drawing/body_properties.rs
@@ -3,6 +3,7 @@ use super::super::EnumValue;
 use super::super::Int32Value;
 use super::ShapeAutoFit;
 use super::TextWrappingValues;
+use crate::StringValue;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -12,10 +13,10 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct BodyProperties {
-    vert_overflow: Option<String>,
-    horz_overflow: Option<String>,
-    rtl_col: Option<String>,
-    anchor: Option<String>,
+    vert_overflow: StringValue,
+    horz_overflow: StringValue,
+    rtl_col: StringValue,
+    anchor: StringValue,
     wrap: EnumValue<TextWrappingValues>,
     left_inset: Int32Value,
     top_inset: Int32Value,
@@ -25,39 +26,39 @@ pub struct BodyProperties {
 }
 
 impl BodyProperties {
-    pub fn get_vert_overflow(&self) -> Option<&String> {
-        self.vert_overflow.as_ref()
+    pub fn get_vert_overflow(&self) -> Option<&str> {
+        self.vert_overflow.get_value()
     }
 
     pub fn set_vert_overflow<S: Into<String>>(&mut self, value: S) -> &mut BodyProperties {
-        self.vert_overflow = Some(value.into());
+        self.vert_overflow.set_value(value);
         self
     }
 
-    pub fn get_horz_overflow(&self) -> Option<&String> {
-        self.horz_overflow.as_ref()
+    pub fn get_horz_overflow(&self) -> Option<&str> {
+        self.horz_overflow.get_value()
     }
 
     pub fn set_horz_overflow<S: Into<String>>(&mut self, value: S) -> &mut BodyProperties {
-        self.horz_overflow = Some(value.into());
+        self.horz_overflow.set_value(value);
         self
     }
 
-    pub fn get_rtl_col(&self) -> Option<&String> {
-        self.rtl_col.as_ref()
+    pub fn get_rtl_col(&self) -> Option<&str> {
+        self.rtl_col.get_value()
     }
 
     pub fn set_rtl_col<S: Into<String>>(&mut self, value: S) -> &mut BodyProperties {
-        self.rtl_col = Some(value.into());
+        self.rtl_col.set_value(value);
         self
     }
 
-    pub fn get_anchor(&self) -> Option<&String> {
-        self.anchor.as_ref()
+    pub fn get_anchor(&self) -> Option<&str> {
+        self.anchor.get_value()
     }
 
     pub fn set_anchor<S: Into<String>>(&mut self, value: S) -> &mut BodyProperties {
-        self.anchor = Some(value.into());
+        self.anchor.set_value(value);
         self
     }
 
@@ -181,16 +182,16 @@ impl BodyProperties {
 
         // a:bodyPr
         let mut attributes: Vec<(&str, &str)> = Vec::new();
-        if let Some(v) = &self.vert_overflow {
+        if let Some(v) = self.vert_overflow.get_value() {
             attributes.push(("vertOverflow", v));
         }
-        if let Some(v) = &self.horz_overflow {
+        if let Some(v) = self.horz_overflow.get_value() {
             attributes.push(("horzOverflow", v));
         }
-        if let Some(v) = &self.rtl_col {
+        if let Some(v) = self.rtl_col.get_value() {
             attributes.push(("rtlCol", v));
         }
-        if let Some(v) = &self.anchor {
+        if let Some(v) = self.anchor.get_value() {
             attributes.push(("anchor", v));
         }
         if self.wrap.has_value() {

--- a/src/structs/drawing/color_scheme.rs
+++ b/src/structs/drawing/color_scheme.rs
@@ -264,40 +264,40 @@ impl ColorScheme {
         write_start_tag(writer, "a:clrScheme", attributes, false);
 
         // a:dk1
-        let _ = &self.dk1.write_to_dk1(writer);
+        self.dk1.write_to_dk1(writer);
 
         // a:lt1
-        let _ = &self.lt1.write_to_lt1(writer);
+        self.lt1.write_to_lt1(writer);
 
         // a:dk2
-        let _ = &self.dk2.write_to_dk2(writer);
+        self.dk2.write_to_dk2(writer);
 
         // a:lt2
-        let _ = &self.lt2.write_to_lt2(writer);
+        self.lt2.write_to_lt2(writer);
 
         // a:accent1
-        let _ = &self.accent1.write_to_accent1(writer);
+        self.accent1.write_to_accent1(writer);
 
         // a:accent2
-        let _ = &self.accent2.write_to_accent2(writer);
+        self.accent2.write_to_accent2(writer);
 
         // a:accent3
-        let _ = &self.accent3.write_to_accent3(writer);
+        self.accent3.write_to_accent3(writer);
 
         // a:accent4
-        let _ = &self.accent4.write_to_accent4(writer);
+        self.accent4.write_to_accent4(writer);
 
         // a:accent5
-        let _ = &self.accent5.write_to_accent5(writer);
+        self.accent5.write_to_accent5(writer);
 
         // a:accent6
-        let _ = &self.accent6.write_to_accent6(writer);
+        self.accent6.write_to_accent6(writer);
 
         // a:hlink
-        let _ = &self.hlink.write_to_hlink(writer);
+        self.hlink.write_to_hlink(writer);
 
         // a:folHlink
-        let _ = &self.fol_hlink.write_to_fol_hlink(writer);
+        self.fol_hlink.write_to_fol_hlink(writer);
 
         write_end_tag(writer, "a:clrScheme");
     }

--- a/src/structs/drawing/font_scheme.rs
+++ b/src/structs/drawing/font_scheme.rs
@@ -91,10 +91,10 @@ impl FontScheme {
         write_start_tag(writer, "a:fontScheme", attributes, false);
 
         // a:majorFont
-        let _ = &self.major_font.write_to_major_font(writer);
+        self.major_font.write_to_major_font(writer);
 
         // a:minorFont
-        let _ = &self.minor_font.write_to_minor_font(writer);
+        self.minor_font.write_to_minor_font(writer);
 
         write_end_tag(writer, "a:fontScheme");
     }

--- a/src/structs/drawing/foreground_color.rs
+++ b/src/structs/drawing/foreground_color.rs
@@ -57,7 +57,7 @@ impl ForegroundColor {
         write_start_tag(writer, "a:fgClr", vec![], false);
 
         // a:schemeClr
-        let _ = &self.scheme_color.write_to(writer);
+        self.scheme_color.write_to(writer);
 
         write_end_tag(writer, "a:fgClr");
     }

--- a/src/structs/drawing/format_scheme.rs
+++ b/src/structs/drawing/format_scheme.rs
@@ -132,16 +132,16 @@ impl FormatScheme {
         write_start_tag(writer, "a:fmtScheme", attributes, false);
 
         // a:fillStyleLst
-        let _ = &self.fill_style_list.write_to(writer);
+        self.fill_style_list.write_to(writer);
 
         // a:lnStyleLst
-        let _ = &self.line_style_list.write_to(writer);
+        self.line_style_list.write_to(writer);
 
         // a:effectStyleLst
-        let _ = &self.effect_style_list.write_to(writer);
+        self.effect_style_list.write_to(writer);
 
         // a:bgFillStyleLst
-        let _ = &self.background_fill_style_list.write_to(writer);
+        self.background_fill_style_list.write_to(writer);
 
         write_end_tag(writer, "a:fmtScheme");
     }

--- a/src/structs/drawing/gradient_fill.rs
+++ b/src/structs/drawing/gradient_fill.rs
@@ -130,7 +130,7 @@ impl GradientFill {
         write_start_tag(writer, "a:gradFill", attributes, false);
 
         // a:gsLst
-        let _ = &self.gradient_stop_list.write_to(writer);
+        self.gradient_stop_list.write_to(writer);
 
         // a:lin
         if let Some(v) = &self.linear_gradient_fill {

--- a/src/structs/drawing/graphic.rs
+++ b/src/structs/drawing/graphic.rs
@@ -60,7 +60,7 @@ impl Graphic {
         write_start_tag(writer, "a:graphic", vec![], false);
 
         // a:graphicData
-        let _ = &self.graphic_data.write_to(writer, rel_list);
+        self.graphic_data.write_to(writer, rel_list);
 
         write_end_tag(writer, "a:graphic");
     }

--- a/src/structs/drawing/outer_shadow.rs
+++ b/src/structs/drawing/outer_shadow.rs
@@ -2,6 +2,7 @@
 use super::PresetColor;
 use super::RgbColorModelHex;
 use super::SchemeColor;
+use crate::StringValue;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -11,79 +12,79 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct OuterShadow {
-    blur_radius: Option<String>,
-    alignment: Option<String>,
-    horizontal_ratio: Option<String>,
-    vertical_ratio: Option<String>,
-    direction: Option<String>,
-    distance: Option<String>,
-    rotate_with_shape: Option<String>,
+    blur_radius: StringValue,
+    alignment: StringValue,
+    horizontal_ratio: StringValue,
+    vertical_ratio: StringValue,
+    direction: StringValue,
+    distance: StringValue,
+    rotate_with_shape: StringValue,
     preset_color: Option<PresetColor>,
     scheme_color: Option<SchemeColor>,
     rgb_color_model_hex: Option<RgbColorModelHex>,
 }
 
 impl OuterShadow {
-    pub fn get_blur_radius(&self) -> Option<&String> {
-        self.blur_radius.as_ref()
+    pub fn get_blur_radius(&self) -> Option<&str> {
+        self.blur_radius.get_value()
     }
 
     pub fn set_blur_radius<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.blur_radius = Some(value.into());
+        self.blur_radius.set_value(value);
         self
     }
 
-    pub fn get_horizontal_ratio(&self) -> Option<&String> {
-        self.horizontal_ratio.as_ref()
+    pub fn get_horizontal_ratio(&self) -> Option<&str> {
+        self.horizontal_ratio.get_value()
     }
 
     pub fn set_horizontal_ratio<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.horizontal_ratio = Some(value.into());
+        self.horizontal_ratio.set_value(value);
         self
     }
 
-    pub fn get_vertical_ratio(&self) -> Option<&String> {
-        self.vertical_ratio.as_ref()
+    pub fn get_vertical_ratio(&self) -> Option<&str> {
+        self.vertical_ratio.get_value()
     }
 
     pub fn set_vertical_ratio<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.vertical_ratio = Some(value.into());
+        self.vertical_ratio.set_value(value);
         self
     }
 
-    pub fn get_alignment(&self) -> Option<&String> {
-        self.alignment.as_ref()
+    pub fn get_alignment(&self) -> Option<&str> {
+        self.alignment.get_value()
     }
 
     pub fn set_alignment<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.alignment = Some(value.into());
+        self.alignment.set_value(value);
         self
     }
 
-    pub fn get_direction(&self) -> Option<&String> {
-        self.direction.as_ref()
+    pub fn get_direction(&self) -> Option<&str> {
+        self.direction.get_value()
     }
 
     pub fn set_direction<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.direction = Some(value.into());
+        self.direction.set_value(value);
         self
     }
 
-    pub fn get_distance(&self) -> Option<&String> {
-        self.distance.as_ref()
+    pub fn get_distance(&self) -> Option<&str> {
+        self.distance.get_value()
     }
 
     pub fn set_distance<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.distance = Some(value.into());
+        self.distance.set_value(value);
         self
     }
 
-    pub fn get_rotate_with_shape(&self) -> Option<&String> {
-        self.rotate_with_shape.as_ref()
+    pub fn get_rotate_with_shape(&self) -> Option<&str> {
+        self.rotate_with_shape.get_value()
     }
 
     pub fn set_rotate_with_shape<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.rotate_with_shape = Some(value.into());
+        self.rotate_with_shape.set_value(value);
         self
     }
 
@@ -202,25 +203,25 @@ impl OuterShadow {
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:outerShdw
         let mut attributes: Vec<(&str, &str)> = Vec::new();
-        if let Some(v) = &self.blur_radius {
+        if let Some(v) = self.blur_radius.get_value() {
             attributes.push(("blurRad", v));
         }
-        if let Some(v) = &self.distance {
+        if let Some(v) = self.distance.get_value() {
             attributes.push(("dist", v));
         }
-        if let Some(v) = &self.direction {
+        if let Some(v) = self.direction.get_value() {
             attributes.push(("dir", v));
         }
-        if let Some(v) = &self.horizontal_ratio {
+        if let Some(v) = self.horizontal_ratio.get_value() {
             attributes.push(("sx", v));
         }
-        if let Some(v) = &self.vertical_ratio {
+        if let Some(v) = self.vertical_ratio.get_value() {
             attributes.push(("sy", v));
         }
-        if let Some(v) = &self.alignment {
+        if let Some(v) = self.alignment.get_value() {
             attributes.push(("algn", v));
         }
-        if let Some(v) = &self.rotate_with_shape {
+        if let Some(v) = self.rotate_with_shape.get_value() {
             attributes.push(("rotWithShape", v));
         }
         write_start_tag(writer, "a:outerShdw", attributes, false);

--- a/src/structs/drawing/outline.rs
+++ b/src/structs/drawing/outline.rs
@@ -8,6 +8,7 @@ use super::PresetDash;
 use super::Round;
 use super::SolidFill;
 use super::TailEnd;
+use crate::StringValue;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -20,8 +21,8 @@ use writer::driver::*;
 #[derive(Clone, Default, Debug)]
 pub struct Outline {
     width: UInt32Value,
-    cap_type: Option<String>,
-    compound_line_type: Option<String>,
+    cap_type: StringValue,
+    compound_line_type: StringValue,
     solid_fill: Option<SolidFill>,
     gradient_fill: Option<GradientFill>,
     tail_end: Option<TailEnd>,
@@ -43,21 +44,21 @@ impl Outline {
         self
     }
 
-    pub fn get_cap_type(&self) -> Option<&String> {
-        self.cap_type.as_ref()
+    pub fn get_cap_type(&self) -> Option<&str> {
+        self.cap_type.get_value()
     }
 
     pub fn set_cap_type<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.cap_type = Some(value.into());
+        self.cap_type.set_value(value);
         self
     }
 
-    pub fn get_compound_line_type(&self) -> Option<&String> {
-        self.compound_line_type.as_ref()
+    pub fn get_compound_line_type(&self) -> Option<&str> {
+        self.compound_line_type.get_value()
     }
 
     pub fn set_compound_line_type<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.compound_line_type = Some(value.into());
+        self.compound_line_type.set_value(value);
         self
     }
 
@@ -260,10 +261,10 @@ impl Outline {
         if self.width.has_value() {
             attributes.push(("w", &width));
         }
-        if let Some(v) = &self.cap_type {
+        if let Some(v) = self.cap_type.get_value() {
             attributes.push(("cap", v));
         }
-        if let Some(v) = &self.compound_line_type {
+        if let Some(v) = self.compound_line_type.get_value() {
             attributes.push(("cmpd", v));
         }
         if self.alignment.has_value() {

--- a/src/structs/drawing/paragraph.rs
+++ b/src/structs/drawing/paragraph.rs
@@ -107,7 +107,7 @@ impl Paragraph {
         write_start_tag(writer, "a:p", vec![], false);
 
         // a:pPr
-        let _ = &self.paragraph_properties.write_to(writer);
+        self.paragraph_properties.write_to(writer);
 
         // a:r
         for run in &self.run {

--- a/src/structs/drawing/paragraph_properties.rs
+++ b/src/structs/drawing/paragraph_properties.rs
@@ -3,6 +3,7 @@ use super::super::EnumValue;
 use super::LineSpacing;
 use super::RunProperties;
 use super::TextAlignmentTypeValues;
+use crate::StringValue;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -12,19 +13,19 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct ParagraphProperties {
-    right_to_left: Option<String>,
+    right_to_left: StringValue,
     alignment: EnumValue<TextAlignmentTypeValues>,
     default_run_properties: Option<RunProperties>,
     line_spacing: Option<LineSpacing>,
 }
 
 impl ParagraphProperties {
-    pub fn get_right_to_left(&self) -> Option<&String> {
-        self.right_to_left.as_ref()
+    pub fn get_right_to_left(&self) -> Option<&str> {
+        self.right_to_left.get_value()
     }
 
     pub fn set_right_to_left<S: Into<String>>(&mut self, value: S) -> &mut ParagraphProperties {
-        self.right_to_left = Some(value.into());
+        self.right_to_left.set_value(value);
         self
     }
 
@@ -114,7 +115,7 @@ impl ParagraphProperties {
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:pPr
         let mut attributes: Vec<(&str, &str)> = Vec::new();
-        if let Some(v) = &self.right_to_left {
+        if let Some(v) = self.right_to_left.get_value() {
             attributes.push(("rtl", v));
         }
         if self.alignment.has_value() {

--- a/src/structs/drawing/pattern_fill.rs
+++ b/src/structs/drawing/pattern_fill.rs
@@ -97,10 +97,10 @@ impl PatternFill {
         write_start_tag(writer, "a:pattFill", vec![("prst", &self.preset)], false);
 
         // a:fgClr
-        let _ = &self.foreground_color.write_to(writer);
+        self.foreground_color.write_to(writer);
 
         // a:bgClr
-        let _ = &self.background_color.write_to(writer);
+        self.background_color.write_to(writer);
 
         write_end_tag(writer, "a:pattFill");
     }

--- a/src/structs/drawing/preset_geometry.rs
+++ b/src/structs/drawing/preset_geometry.rs
@@ -251,7 +251,7 @@ impl PresetGeometry {
         write_start_tag(writer, "a:prstGeom", vec![("prst", &self.geometry)], false);
 
         // a:avLst
-        let _ = &self.adjust_value_list.write_to(writer);
+        self.adjust_value_list.write_to(writer);
 
         write_end_tag(writer, "a:prstGeom");
     }

--- a/src/structs/drawing/source_rectangle.rs
+++ b/src/structs/drawing/source_rectangle.rs
@@ -1,4 +1,5 @@
 // a:srcRect
+use crate::StringValue;
 use quick_xml::events::BytesStart;
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -8,42 +9,42 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct SourceRectangle {
-    t: Option<String>,
-    l: Option<String>,
-    r: Option<String>,
-    b: Option<String>,
+    t: StringValue,
+    l: StringValue,
+    r: StringValue,
+    b: StringValue,
 }
 impl SourceRectangle {
     pub fn set_t<S: Into<String>>(&mut self, value: S) {
-        self.t = Some(value.into());
+        self.t.set_value(value);
     }
 
-    pub fn get_t(&self) -> Option<&String> {
-        self.t.as_ref()
+    pub fn get_t(&self) -> Option<&str> {
+        self.t.get_value()
     }
 
     pub fn set_l<S: Into<String>>(&mut self, value: S) {
-        self.l = Some(value.into());
+        self.l.set_value(value);
     }
 
-    pub fn get_l(&self) -> Option<&String> {
-        self.l.as_ref()
+    pub fn get_l(&self) -> Option<&str> {
+        self.l.get_value()
     }
 
     pub fn set_r<S: Into<String>>(&mut self, value: S) {
-        self.r = Some(value.into());
+        self.r.set_value(value);
     }
 
-    pub fn get_r(&self) -> Option<&String> {
-        self.r.as_ref()
+    pub fn get_r(&self) -> Option<&str> {
+        self.r.get_value()
     }
 
     pub fn set_b<S: Into<String>>(&mut self, value: S) {
-        self.b = Some(value.into());
+        self.b.set_value(value);
     }
 
-    pub fn get_b(&self) -> Option<&String> {
-        self.b.as_ref()
+    pub fn get_b(&self) -> Option<&str> {
+        self.b.get_value()
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(
@@ -68,16 +69,16 @@ impl SourceRectangle {
         // a:srcRect
         let mut attributes: Vec<(&str, &str)> = Vec::new();
 
-        if let Some(v) = &self.t {
+        if let Some(v) = self.t.get_value() {
             attributes.push(("t", v))
         }
-        if let Some(v) = &self.l {
+        if let Some(v) = self.l.get_value() {
             attributes.push(("l", v))
         }
-        if let Some(v) = &self.r {
+        if let Some(v) = self.r.get_value() {
             attributes.push(("r", v))
         }
-        if let Some(v) = &self.b {
+        if let Some(v) = self.b.get_value() {
             attributes.push(("b", v))
         }
         write_start_tag(writer, "a:srcRect", attributes, true);

--- a/src/structs/drawing/spreadsheet/blip_fill.rs
+++ b/src/structs/drawing/spreadsheet/blip_fill.rs
@@ -126,7 +126,7 @@ impl BlipFill {
         write_start_tag(writer, "xdr:blipFill", attributes, false);
 
         // a:blip
-        let _ = &self.blip.write_to(writer, rel_list);
+        self.blip.write_to(writer, rel_list);
 
         // a:srcRect
         if let Some(v) = &self.source_rectangle {
@@ -134,7 +134,7 @@ impl BlipFill {
         }
 
         // a:stretch
-        let _ = &self.stretch.write_to(writer);
+        self.stretch.write_to(writer);
 
         write_end_tag(writer, "xdr:blipFill");
     }

--- a/src/structs/drawing/spreadsheet/connection_shape.rs
+++ b/src/structs/drawing/spreadsheet/connection_shape.rs
@@ -116,13 +116,13 @@ impl ConnectionShape {
         write_start_tag(writer, "xdr:cxnSp", vec![("macro", "")], false);
 
         // xdr:nvCxnSpPr
-        let _ = &self.non_visual_connection_shape_properties.write_to(writer);
+        self.non_visual_connection_shape_properties.write_to(writer);
 
         // xdr:spPr
-        let _ = &self.shape_properties.write_to(writer, rel_list);
+        self.shape_properties.write_to(writer, rel_list);
 
         // xdr:style
-        let _ = &self.shape_style.write_to(writer);
+        self.shape_style.write_to(writer);
 
         write_end_tag(writer, "xdr:cxnSp");
     }

--- a/src/structs/drawing/spreadsheet/graphic_frame.rs
+++ b/src/structs/drawing/spreadsheet/graphic_frame.rs
@@ -123,13 +123,13 @@ impl GraphicFrame {
         );
 
         // xdr:nvGraphicFramePr
-        let _ = &self.non_visual_graphic_frame_properties.write_to(writer);
+        self.non_visual_graphic_frame_properties.write_to(writer);
 
         // xdr:xfrm
-        let _ = &self.transform.write_to(writer);
+        self.transform.write_to(writer);
 
         // a:graphic
-        let _ = &self.graphic.write_to(writer, rel_list);
+        self.graphic.write_to(writer, rel_list);
 
         write_end_tag(writer, "xdr:graphicFrame");
     }

--- a/src/structs/drawing/spreadsheet/marker_type.rs
+++ b/src/structs/drawing/spreadsheet/marker_type.rs
@@ -106,11 +106,11 @@ impl MarkerType {
         }
     }
     pub(crate) fn write_to_from(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
-        let _ = &self.write_to(writer, "xdr:from");
+        self.write_to(writer, "xdr:from");
     }
 
     pub(crate) fn write_to_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
-        let _ = &self.write_to(writer, "xdr:to");
+        self.write_to(writer, "xdr:to");
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, tag_name: &str) {

--- a/src/structs/drawing/spreadsheet/non_visual_connection_shape_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_connection_shape_properties.rs
@@ -84,11 +84,10 @@ impl NonVisualConnectionShapeProperties {
         write_start_tag(writer, "xdr:nvCxnSpPr", vec![], false);
 
         // xdr:cNvPr
-        let _ = &self.non_visual_drawing_properties.write_to(writer, &0);
+        self.non_visual_drawing_properties.write_to(writer, &0);
 
         // xdr:cNvCxnSpPr
-        let _ = &self
-            .non_visual_connector_shape_drawing_properties
+        self.non_visual_connector_shape_drawing_properties
             .write_to(writer);
 
         write_end_tag(writer, "xdr:nvCxnSpPr");

--- a/src/structs/drawing/spreadsheet/non_visual_graphic_frame_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_graphic_frame_properties.rs
@@ -91,11 +91,10 @@ impl NonVisualGraphicFrameProperties {
         write_start_tag(writer, "xdr:nvGraphicFramePr", vec![], false);
 
         // xdr:cNvPr
-        let _ = &self.non_visual_drawing_properties.write_to(writer, &0);
+        self.non_visual_drawing_properties.write_to(writer, &0);
 
         // xdr:cNvGraphicFramePr
-        let _ = &self
-            .non_visual_graphic_frame_drawing_properties
+        self.non_visual_graphic_frame_drawing_properties
             .write_to(writer);
 
         write_end_tag(writer, "xdr:nvGraphicFramePr");

--- a/src/structs/drawing/spreadsheet/non_visual_picture_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_picture_properties.rs
@@ -91,10 +91,10 @@ impl NonVisualPictureProperties {
         write_start_tag(writer, "xdr:nvPicPr", vec![], false);
 
         // xdr:cNvPr
-        let _ = &self.non_visual_drawing_properties.write_to(writer, &0);
+        self.non_visual_drawing_properties.write_to(writer, &0);
 
         // xdr:cNvPicPr
-        let _ = &self.non_visual_picture_drawing_properties.write_to(writer);
+        self.non_visual_picture_drawing_properties.write_to(writer);
 
         write_end_tag(writer, "xdr:nvPicPr");
     }

--- a/src/structs/drawing/spreadsheet/non_visual_shape_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_shape_properties.rs
@@ -58,7 +58,7 @@ impl NonVisualShapeProperties {
         write_start_tag(writer, "xdr:nvSpPr", vec![], false);
 
         // xdr:cNvPr
-        let _ = &self.non_visual_drawing_properties.write_to(writer, ole_id);
+        self.non_visual_drawing_properties.write_to(writer, ole_id);
 
         // xdr:cNvSpPr
         write_start_tag(writer, "xdr:cNvSpPr", vec![], true);

--- a/src/structs/drawing/spreadsheet/one_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/one_cell_anchor.rs
@@ -146,10 +146,10 @@ impl OneCellAnchor {
         write_start_tag(writer, "xdr:oneCellAnchor", vec![], false);
 
         // xdr:from
-        let _ = &self.from_marker.write_to_from(writer);
+        self.from_marker.write_to_from(writer);
 
         // xdr:ext
-        let _ = &self.extent.write_to(writer);
+        self.extent.write_to(writer);
 
         // xdr:grpSp
         if let Some(v) = &self.group_shape {

--- a/src/structs/drawing/spreadsheet/picture.rs
+++ b/src/structs/drawing/spreadsheet/picture.rs
@@ -95,13 +95,13 @@ impl Picture {
         write_start_tag(writer, "xdr:pic", vec![], false);
 
         // xdr:nvPicPr
-        let _ = &self.non_visual_picture_properties.write_to(writer);
+        self.non_visual_picture_properties.write_to(writer);
 
         // xdr:blipFill
-        let _ = &self.blip_fill.write_to(writer, rel_list);
+        self.blip_fill.write_to(writer, rel_list);
 
         // xdr:spPr
-        let _ = &self.shape_properties.write_to(writer, rel_list);
+        self.shape_properties.write_to(writer, rel_list);
 
         write_end_tag(writer, "xdr:pic");
     }

--- a/src/structs/drawing/spreadsheet/shape.rs
+++ b/src/structs/drawing/spreadsheet/shape.rs
@@ -135,10 +135,10 @@ impl Shape {
         );
 
         // xdr:nvSpPr
-        let _ = &self.non_visual_shape_properties.write_to(writer, ole_id);
+        self.non_visual_shape_properties.write_to(writer, ole_id);
 
         // xdr:spPr
-        let _ = &self.shape_properties.write_to(writer, rel_list);
+        self.shape_properties.write_to(writer, rel_list);
 
         // xdr:style
         if let Some(v) = &self.shape_style {

--- a/src/structs/drawing/spreadsheet/shape_properties.rs
+++ b/src/structs/drawing/spreadsheet/shape_properties.rs
@@ -207,7 +207,7 @@ impl ShapeProperties {
         }
 
         // a:prstGeom
-        let _ = &self.preset_geometry.write_to(writer);
+        self.preset_geometry.write_to(writer);
 
         // a:blipFill
         if let Some(v) = &self.blip_fill {

--- a/src/structs/drawing/spreadsheet/text_body.rs
+++ b/src/structs/drawing/spreadsheet/text_body.rs
@@ -100,10 +100,10 @@ impl TextBody {
         write_start_tag(writer, "xdr:txBody", vec![], false);
 
         // a:bodyPr
-        let _ = &self.body_properties.write_to(writer);
+        self.body_properties.write_to(writer);
 
         // a:lstStyle
-        let _ = &self.list_style.write_to(writer);
+        self.list_style.write_to(writer);
 
         for content in &self.paragraph {
             content.write_to(writer);

--- a/src/structs/drawing/spreadsheet/transform.rs
+++ b/src/structs/drawing/spreadsheet/transform.rs
@@ -115,10 +115,10 @@ impl Transform {
         write_start_tag(writer, "xdr:xfrm", attributes, false);
 
         // a:off
-        let _ = &self.offset.write_to(writer);
+        self.offset.write_to(writer);
 
         // a:ext
-        let _ = &self.extents.write_to(writer);
+        self.extents.write_to(writer);
 
         write_end_tag(writer, "xdr:xfrm");
     }

--- a/src/structs/drawing/spreadsheet/two_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/two_cell_anchor.rs
@@ -249,10 +249,10 @@ impl TwoCellAnchor {
         write_start_tag(writer, "xdr:twoCellAnchor", attributes, false);
 
         // xdr:from
-        let _ = &self.from_marker.write_to_from(writer);
+        self.from_marker.write_to_from(writer);
 
         // xdr:to
-        let _ = &self.to_marker.write_to_to(writer);
+        self.to_marker.write_to_to(writer);
 
         // xdr:grpSp
         if let Some(v) = &self.group_shape {

--- a/src/structs/drawing/theme.rs
+++ b/src/structs/drawing/theme.rs
@@ -558,7 +558,7 @@ impl Theme {
         write_start_tag(writer, "a:theme", attributes, false);
 
         // a:themeElements
-        let _ = &self.theme_elements.write_to(writer);
+        self.theme_elements.write_to(writer);
 
         // a:objectDefaults
         write_start_tag(writer, "a:objectDefaults", vec![], true);

--- a/src/structs/drawing/theme_elements.rs
+++ b/src/structs/drawing/theme_elements.rs
@@ -88,13 +88,13 @@ impl ThemeElements {
         write_start_tag(writer, "a:themeElements", vec![], false);
 
         // a:clrScheme
-        let _ = &self.color_scheme.write_to(writer);
+        self.color_scheme.write_to(writer);
 
         // a:fontScheme
-        let _ = &self.font_scheme.write_to(writer);
+        self.font_scheme.write_to(writer);
 
         // a:fmtScheme
-        let _ = &self.format_scheme.write_to(writer);
+        self.format_scheme.write_to(writer);
 
         write_end_tag(writer, "a:themeElements");
     }

--- a/src/structs/drawing/transform2d.rs
+++ b/src/structs/drawing/transform2d.rs
@@ -1,4 +1,5 @@
 // a:xfrm
+use crate::StringValue;
 use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
@@ -14,9 +15,9 @@ pub struct Transform2D {
     extents: PositiveSize2DType,
     child_offset: Option<Point2DType>,
     child_extents: Option<PositiveSize2DType>,
-    rot: Option<String>,
-    flip_v: Option<String>,
-    flip_h: Option<String>,
+    rot: StringValue,
+    flip_v: StringValue,
+    flip_h: StringValue,
 }
 
 impl Transform2D {
@@ -68,28 +69,28 @@ impl Transform2D {
         self.child_extents = Some(value);
     }
 
-    pub fn get_rot(&self) -> Option<&String> {
-        self.rot.as_ref()
+    pub fn get_rot(&self) -> Option<&str> {
+        self.rot.get_value()
     }
 
     pub fn set_rot<S: Into<String>>(&mut self, value: S) {
-        self.rot = Some(value.into());
+        self.rot.set_value(value);
     }
 
-    pub fn get_flip_v(&self) -> Option<&String> {
-        self.flip_v.as_ref()
+    pub fn get_flip_v(&self) -> Option<&str> {
+        self.flip_v.get_value()
     }
 
     pub fn set_flip_v<S: Into<String>>(&mut self, value: S) {
-        self.flip_v = Some(value.into());
+        self.flip_v.set_value(value);
     }
 
-    pub fn get_flip_h(&self) -> Option<&String> {
-        self.flip_h.as_ref()
+    pub fn get_flip_h(&self) -> Option<&str> {
+        self.flip_h.get_value()
     }
 
     pub fn set_flip_h<S: Into<String>>(&mut self, value: S) {
-        self.flip_h = Some(value.into());
+        self.flip_h.set_value(value);
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(
@@ -144,13 +145,13 @@ impl Transform2D {
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // a:xfrm
         let mut attributes: Vec<(&str, &str)> = Vec::new();
-        if let Some(v) = &self.rot {
+        if let Some(v) = self.rot.get_value() {
             attributes.push(("rot", v))
         }
-        if let Some(v) = &self.flip_h {
+        if let Some(v) = self.flip_h.get_value() {
             attributes.push(("flipH", v))
         }
-        if let Some(v) = &self.flip_v {
+        if let Some(v) = self.flip_v.get_value() {
             attributes.push(("flipV", v))
         }
         write_start_tag(writer, "a:xfrm", attributes, false);

--- a/src/structs/gradient_stop.rs
+++ b/src/structs/gradient_stop.rs
@@ -84,7 +84,7 @@ impl GradientStop {
         );
 
         // color
-        let _ = &self.color.write_to_color(writer);
+        self.color.write_to_color(writer);
 
         write_end_tag(writer, "stop");
     }

--- a/src/structs/header_footer.rs
+++ b/src/structs/header_footer.rs
@@ -78,10 +78,10 @@ impl HeaderFooter {
             write_start_tag(writer, "headerFooter", vec![], false);
 
             // oddHeader
-            let _ = &self.get_odd_header().write_to(writer);
+            self.get_odd_header().write_to(writer);
 
             // oddFooter
-            let _ = &self.get_odd_footer().write_to(writer);
+            self.get_odd_footer().write_to(writer);
 
             write_end_tag(writer, "headerFooter");
         }

--- a/src/structs/object_anchor.rs
+++ b/src/structs/object_anchor.rs
@@ -115,10 +115,10 @@ impl ObjectAnchor {
         write_start_tag(writer, "anchor", attributes, false);
 
         // xdr:from
-        let _ = &self.from_marker.write_to(writer);
+        self.from_marker.write_to(writer);
 
         // xdr:to
-        let _ = &self.to_marker.write_to(writer);
+        self.to_marker.write_to(writer);
 
         write_end_tag(writer, "anchor");
     }

--- a/src/structs/ole_object.rs
+++ b/src/structs/ole_object.rs
@@ -191,8 +191,7 @@ impl OleObject {
         write_start_tag(writer, "oleObject", attributes, false);
 
         // objectPr
-        let _ = &self
-            .embedded_object_properties
+        self.embedded_object_properties
             .write_to(writer, &(r_id + 1));
 
         write_end_tag(writer, "oleObject");

--- a/src/structs/spreadsheet.rs
+++ b/src/structs/spreadsheet.rs
@@ -1,3 +1,4 @@
+use crate::StringValue;
 use helper::address::*;
 use helper::coordinate::*;
 use reader::xlsx::*;
@@ -24,8 +25,8 @@ pub struct Spreadsheet {
     properties: Properties,
     work_sheet_collection: Vec<Worksheet>,
     macros_code: Option<Vec<u8>>,
-    code_name: Option<String>,
-    ribbon_xml_data: Option<String>,
+    code_name: StringValue,
+    ribbon_xml_data: StringValue,
     theme: Theme,
     stylesheet: Stylesheet,
     shared_string_table: Arc<RwLock<SharedStringTable>>,
@@ -237,8 +238,8 @@ impl Spreadsheet {
     /// Default one is `ThisWorkbook`.
     ///
     /// Excel often uses `Workbook________` (8 underscores).
-    pub fn set_code_name<S: ToString>(&mut self, codename: S) -> &mut Self {
-        self.code_name = Some(codename.to_string());
+    pub fn set_code_name<S: Into<String>>(&mut self, codename: S) -> &mut Self {
+        self.code_name.set_value(codename);
         self
     }
 
@@ -247,7 +248,7 @@ impl Spreadsheet {
     /// Must to be the same in workbook with VBA/macros code from this workbook
     /// for that code in Workbook object to work out of the box without adjustments
     pub fn get_code_name(&self) -> Option<&str> {
-        self.code_name.as_deref()
+        self.code_name.get_value()
     }
 
     /// (This method is crate only.)
@@ -536,7 +537,7 @@ impl Spreadsheet {
     /// (This method is crate only.)
     /// Has Ribbon XML Data.
     pub(crate) fn has_ribbon(&self) -> bool {
-        self.ribbon_xml_data.is_some()
+        self.ribbon_xml_data.has_value()
     }
 
     /// Get Workbook View.

--- a/src/structs/stylesheet.rs
+++ b/src/structs/stylesheet.rs
@@ -405,31 +405,31 @@ impl Stylesheet {
         );
 
         // numFmts
-        let _ = &self.numbering_formats.write_to(writer);
+        self.numbering_formats.write_to(writer);
 
         // fonts
-        let _ = &self.fonts.write_to(writer);
+        self.fonts.write_to(writer);
 
         // fills
-        let _ = &self.fills.write_to(writer);
+        self.fills.write_to(writer);
 
         // borders
-        let _ = &self.borders.write_to(writer);
+        self.borders.write_to(writer);
 
         // cellStyleXfs
-        let _ = &self.cell_style_formats.write_to(writer);
+        self.cell_style_formats.write_to(writer);
 
         // cellXfs
-        let _ = &self.cell_formats.write_to(writer);
+        self.cell_formats.write_to(writer);
 
         // cellStyles
-        let _ = &self.cell_styles.write_to(writer);
+        self.cell_styles.write_to(writer);
 
         // dxfs
-        let _ = &self.differential_formats.write_to(writer);
+        self.differential_formats.write_to(writer);
 
         // colors
-        let _ = &self.colors.write_to(writer);
+        self.colors.write_to(writer);
 
         // tableStyles
         write_start_tag(

--- a/src/structs/text_element.rs
+++ b/src/structs/text_element.rs
@@ -117,7 +117,7 @@ impl TextElement {
         }
 
         // t
-        let _ = &self.text.write_to(writer);
+        self.text.write_to(writer);
 
         write_end_tag(writer, "r");
     }

--- a/src/structs/vml/spreadsheet/client_data.rs
+++ b/src/structs/vml/spreadsheet/client_data.rs
@@ -277,7 +277,7 @@ impl ClientData {
         }
 
         // x:Anchor
-        let _ = &self.anchor.write_to(writer);
+        self.anchor.write_to(writer);
 
         // x:AutoFill
         if let Some(v) = &self.auto_fill {

--- a/src/structs/worksheet.rs
+++ b/src/structs/worksheet.rs
@@ -1,3 +1,5 @@
+use crate::traits;
+use crate::StringValue;
 use hashbrown::HashMap;
 use helper::const_str::*;
 use helper::coordinate::*;
@@ -44,8 +46,6 @@ use traits::AdjustmentCoordinateWith2Sheet;
 use traits::AdjustmentCoordinateWithSheet;
 use traits::AdjustmentValue;
 
-use crate::traits;
-
 /// A Worksheet Object.
 #[derive(Clone, Debug, Default)]
 pub struct Worksheet {
@@ -68,7 +68,7 @@ pub struct Worksheet {
     comments: Vec<Comment>,
     active_cell: String,
     tab_color: Option<Color>,
-    code_name: Option<String>,
+    code_name: StringValue,
     ole_objects: OleObjects,
     defined_names: Vec<DefinedName>,
     print_options: PrintOptions,
@@ -910,15 +910,15 @@ impl Worksheet {
     }
 
     /// Get Code Name.
-    pub fn get_code_name(&self) -> Option<&String> {
-        self.code_name.as_ref()
+    pub fn get_code_name(&self) -> Option<&str> {
+        self.code_name.get_value()
     }
 
     /// Set Code Name.
     /// # Arguments
     /// * `value` - Code Name
     pub fn set_code_name<S: Into<String>>(&mut self, value: S) {
-        self.code_name = Some(value.into());
+        self.code_name.set_value(value);
     }
 
     /// Get Header Footer.
@@ -975,7 +975,7 @@ impl Worksheet {
 
     /// Has Code Name.
     pub fn has_code_name(&self) -> bool {
-        self.code_name.is_some()
+        self.code_name.has_value()
     }
 
     /// Get Tab Color.


### PR DESCRIPTION
Changed all struct fields of `Option<String>` to `StringValue` which is internal making the codebase more streamlined, and other minor changes. **Note: Maybe a breaking change due to `pub fn` surface changes for API's to be more flexible** 