### PR TITLE
Changing `CellRawValue` Variant to be more meaningful

### DIFF
--- a/src/helper/formula.rs
+++ b/src/helper/formula.rs
@@ -734,7 +734,7 @@ pub(crate) fn parse_to_tokens<S: Into<String>>(formula: S) -> Vec<FormulaToken> 
     tokens
 }
 
-pub(crate) fn render(formula_token_list: &Vec<FormulaToken>) -> String {
+pub(crate) fn render(formula_token_list: &[FormulaToken]) -> String {
     let mut result = String::from("");
     for token in formula_token_list {
         if token.get_token_type() == &FormulaTokenTypes::Function
@@ -772,7 +772,7 @@ pub(crate) fn render(formula_token_list: &Vec<FormulaToken>) -> String {
 }
 
 pub fn adjustment_insert_formula_coordinate(
-    token_list: &mut Vec<FormulaToken>,
+    token_list: &mut [FormulaToken],
     root_col_num: &u32,
     offset_col_num: &u32,
     root_row_num: &u32,
@@ -823,7 +823,7 @@ pub fn adjustment_insert_formula_coordinate(
 }
 
 pub fn adjustment_remove_formula_coordinate(
-    token_list: &mut Vec<FormulaToken>,
+    token_list: &mut [FormulaToken],
     root_col_num: &u32,
     offset_col_num: &u32,
     root_row_num: &u32,

--- a/src/helper/html.rs
+++ b/src/helper/html.rs
@@ -106,7 +106,7 @@ fn read_node(node_list: &Vec<Node>, parent_element: &Vec<HfdElement>) -> Vec<Htm
     result
 }
 
-fn make_rich_text(html_flat_data_list: &Vec<HtmlFlatData>, method: &AnalysisMethod) -> RichText {
+fn make_rich_text(html_flat_data_list: &[HtmlFlatData], method: &AnalysisMethod) -> RichText {
     let mut result = RichText::default();
 
     for html_flat_data in html_flat_data_list {

--- a/src/helper/range.rs
+++ b/src/helper/range.rs
@@ -70,6 +70,6 @@ pub fn get_split_range(range: &str) -> Vec<&str> {
     range.split(':').collect()
 }
 
-pub fn get_join_range(coordinate_list: &Vec<String>) -> String {
+pub fn get_join_range(coordinate_list: &[String]) -> String {
     coordinate_list.join(":")
 }

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -97,7 +97,7 @@ impl Cell {
     /// Set the cell's value after trying to convert `value` into one of the supported data types.
     /// <br />
     /// Types that `value` may be converted to:
-    /// - `Null` - if the string was `"NULL"`
+    /// - `Empty` - if the string was `"NULL"`
     /// - `Numeric` - if the string can be parsed to an `f64`
     /// - `Bool` - if the string was either `"TRUE"` or `"FALSE"`
     /// - `Error` - if the string was `"#VALUE!"`

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -97,7 +97,7 @@ impl Cell {
     /// Set the cell's value after trying to convert `value` into one of the supported data types.
     /// <br />
     /// Types that `value` may be converted to:
-    /// - `Empty` - if the string was `"NULL"`
+    /// - `Empty` - if the string was `""`
     /// - `Numeric` - if the string can be parsed to an `f64`
     /// - `Bool` - if the string was either `"TRUE"` or `"FALSE"`
     /// - `Error` - if the string was `"#VALUE!"`

--- a/src/structs/cell_raw_value.rs
+++ b/src/structs/cell_raw_value.rs
@@ -2,7 +2,9 @@ use super::RichText;
 use super::Text;
 use std::fmt;
 
-#[derive(Clone, Debug, PartialEq, PartialOrd)]
+/// An enum to represent all different data types that can appear as
+/// a value in a worksheet cell
+#[derive(Clone, Debug, PartialEq, PartialOrd, Default)]
 pub enum CellRawValue {
     String(String),
     Str(String),
@@ -12,7 +14,8 @@ pub enum CellRawValue {
     Bool(bool),
     Inline,
     Error,
-    Null,
+    #[default]
+    Empty,
 }
 impl fmt::Display for CellRawValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -26,11 +29,7 @@ impl fmt::Display for CellRawValue {
         }
     }
 }
-impl Default for CellRawValue {
-    fn default() -> Self {
-        Self::Null
-    }
-}
+
 impl CellRawValue {
     pub fn get_data_type(&self) -> &str {
         match self {

--- a/src/structs/cell_raw_value.rs
+++ b/src/structs/cell_raw_value.rs
@@ -2,8 +2,6 @@ use super::RichText;
 use super::Text;
 use std::fmt;
 
-/// An enum to represent all different data types that can appear as
-/// a value in a worksheet cell
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default)]
 pub enum CellRawValue {
     String(String),

--- a/src/structs/cell_value.rs
+++ b/src/structs/cell_value.rs
@@ -52,7 +52,7 @@ impl CellValue {
     /// Set the raw value after trying to convert `value` into one of the supported data types.
     /// <br />
     /// Types that `value` may be converted to:
-    /// - `Null` - if the string was `"NULL"`
+    /// - `Empty` - if the string was `"NULL"`
     /// - `Numeric` - if the string can be parsed to an `f64`
     /// - `Bool` - if the string was either `"TRUE"` or `"FALSE"`
     /// - `Error` - if the string was `"#VALUE!"`
@@ -158,7 +158,7 @@ impl CellValue {
 
         // Match the value against a few data types
         if uppercase_value == "NULL" {
-            return CellRawValue::Null;
+            return CellRawValue::Empty;
         }
 
         if let Ok(f) = value.parse::<f64>() {

--- a/src/structs/cell_value.rs
+++ b/src/structs/cell_value.rs
@@ -157,7 +157,7 @@ impl CellValue {
         let uppercase_value = value.to_uppercase();
 
         // Match the value against a few data types
-        if uppercase_value == "NULL" {
+        if uppercase_value == "" {
             return CellRawValue::Empty;
         }
 

--- a/src/structs/cell_value.rs
+++ b/src/structs/cell_value.rs
@@ -52,7 +52,7 @@ impl CellValue {
     /// Set the raw value after trying to convert `value` into one of the supported data types.
     /// <br />
     /// Types that `value` may be converted to:
-    /// - `Empty` - if the string was `"NULL"`
+    /// - `Empty` - if the string was `""`
     /// - `Numeric` - if the string can be parsed to an `f64`
     /// - `Bool` - if the string was either `"TRUE"` or `"FALSE"`
     /// - `Error` - if the string was `"#VALUE!"`
@@ -156,28 +156,19 @@ impl CellValue {
     pub(crate) fn guess_typed_data(value: &str) -> CellRawValue {
         let uppercase_value = value.to_uppercase();
 
-        // Match the value against a few data types
-        if uppercase_value == "" {
-            return CellRawValue::Empty;
+        match uppercase_value.as_str() {
+            "" => CellRawValue::Empty,
+            "TRUE" => CellRawValue::Bool(true),
+            "FALSE" => CellRawValue::Bool(false),
+            "#VALUE!" => CellRawValue::Error,
+            _ => {
+                if let Ok(f) = value.parse::<f64>() {
+                    CellRawValue::Numeric(f)
+                } else {
+                    CellRawValue::String(value.into())
+                }
+            }
         }
-
-        if let Ok(f) = value.parse::<f64>() {
-            return CellRawValue::Numeric(f);
-        }
-
-        if uppercase_value == "TRUE" {
-            return CellRawValue::Bool(true);
-        }
-
-        if uppercase_value == "FALSE" {
-            return CellRawValue::Bool(false);
-        }
-
-        if uppercase_value == "#VALUE!" {
-            return CellRawValue::Error;
-        }
-
-        CellRawValue::String(value.into())
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/src/structs/drawing/blip.rs
+++ b/src/structs/drawing/blip.rs
@@ -74,10 +74,10 @@ impl Blip {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
     ) {
         // a:blip
-        let r_id = self.image.get_rid(rel_list);
+        let r_id = self.image.get_rid(rel_list.to_vec());
         let r_id_str = format!("rId{}", r_id);
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         attributes.push(("xmlns:r", REL_OFC_NS));

--- a/src/structs/drawing/blip_fill.rs
+++ b/src/structs/drawing/blip_fill.rs
@@ -116,7 +116,7 @@ impl BlipFill {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
     ) {
         // a:blipFill
         let mut attributes: Vec<(&str, &str)> = Vec::new();

--- a/src/structs/drawing/spreadsheet/blip_fill.rs
+++ b/src/structs/drawing/spreadsheet/blip_fill.rs
@@ -116,7 +116,7 @@ impl BlipFill {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
     ) {
         // xdr:blipFill
         let mut attributes: Vec<(&str, &str)> = Vec::new();

--- a/src/structs/drawing/spreadsheet/connection_shape.rs
+++ b/src/structs/drawing/spreadsheet/connection_shape.rs
@@ -110,7 +110,7 @@ impl ConnectionShape {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
     ) {
         // xdr:cxnSp
         write_start_tag(writer, "xdr:cxnSp", vec![("macro", "")], false);

--- a/src/structs/drawing/spreadsheet/graphic_frame.rs
+++ b/src/structs/drawing/spreadsheet/graphic_frame.rs
@@ -112,7 +112,7 @@ impl GraphicFrame {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
     ) {
         // xdr:graphicFrame
         write_start_tag(
@@ -129,7 +129,7 @@ impl GraphicFrame {
         self.transform.write_to(writer);
 
         // a:graphic
-        self.graphic.write_to(writer, rel_list);
+        self.graphic.write_to(writer, &mut rel_list.to_vec());
 
         write_end_tag(writer, "xdr:graphicFrame");
     }

--- a/src/structs/drawing/spreadsheet/group_shape.rs
+++ b/src/structs/drawing/spreadsheet/group_shape.rs
@@ -111,7 +111,7 @@ impl GroupShape {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
     ) {
         // xdr:grpSp
         write_start_tag(writer, "xdr:grpSp", vec![], false);

--- a/src/structs/drawing/spreadsheet/one_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/one_cell_anchor.rs
@@ -140,7 +140,7 @@ impl OneCellAnchor {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
     ) {
         // xdr:oneCellAnchor
         write_start_tag(writer, "xdr:oneCellAnchor", vec![], false);

--- a/src/structs/drawing/spreadsheet/picture.rs
+++ b/src/structs/drawing/spreadsheet/picture.rs
@@ -89,7 +89,7 @@ impl Picture {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
     ) {
         // xdr:pic
         write_start_tag(writer, "xdr:pic", vec![], false);

--- a/src/structs/drawing/spreadsheet/shape.rs
+++ b/src/structs/drawing/spreadsheet/shape.rs
@@ -123,7 +123,7 @@ impl Shape {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
         ole_id: &usize,
     ) {
         // xdr:sp

--- a/src/structs/drawing/spreadsheet/shape_properties.rs
+++ b/src/structs/drawing/spreadsheet/shape_properties.rs
@@ -196,7 +196,7 @@ impl ShapeProperties {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
     ) {
         // xdr:spPr
         write_start_tag(writer, "xdr:spPr", vec![], false);

--- a/src/structs/drawing/spreadsheet/two_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/two_cell_anchor.rs
@@ -220,7 +220,7 @@ impl TwoCellAnchor {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
         ole_id: &usize,
     ) {
         if *self.get_is_alternate_content() {

--- a/src/structs/drawing/spreadsheet/worksheet_drawing.rs
+++ b/src/structs/drawing/spreadsheet/worksheet_drawing.rs
@@ -350,7 +350,7 @@ impl WorksheetDrawing {
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
         ole_objects: &OleObjects,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
     ) {
         // xdr:wsDr
         write_start_tag(

--- a/src/structs/image.rs
+++ b/src/structs/image.rs
@@ -261,7 +261,7 @@ impl Image {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        rel_list: &mut Vec<(String, String)>,
+        rel_list: &mut [(String, String)],
     ) {
         if let Some(anchor) = self.get_two_cell_anchor() {
             anchor.write_to(writer, rel_list, &0);

--- a/src/structs/media_object.rs
+++ b/src/structs/media_object.rs
@@ -22,7 +22,7 @@ impl MediaObject {
         self
     }
 
-    pub(crate) fn get_rid(&self, rel_list: &mut Vec<(String, String)>) -> i32 {
+    pub(crate) fn get_rid(&self, mut rel_list: Vec<(String, String)>) -> i32 {
         let find = rel_list
             .iter()
             .position(|(k, v)| k == "IMAGE" && v == &self.image_name);

--- a/src/structs/raw/raw_file.rs
+++ b/src/structs/raw/raw_file.rs
@@ -28,11 +28,10 @@ impl RawFile {
     }
 
     pub(crate) fn get_extension(&self) -> String {
-        let file_name = self.get_file_name();
-        let v: Vec<&str> = file_name.split('.').collect();
-        let extension = v.last().unwrap();
-
-        extension.to_lowercase()
+        self.get_file_name()
+            .rsplit_once('.')
+            .map(|(_, ext)| ext.to_lowercase())
+            .unwrap()
     }
 
     pub(crate) fn get_file_target(&self) -> &str {

--- a/src/structs/raw/raw_file.rs
+++ b/src/structs/raw/raw_file.rs
@@ -51,8 +51,8 @@ impl RawFile {
         &mut self.file_data
     }
 
-    pub(crate) fn set_file_data(&mut self, value: Vec<u8>) -> &mut Self {
-        self.file_data = value;
+    pub(crate) fn set_file_data(&mut self, value: &[u8]) -> &mut Self {
+        self.file_data = value.into();
         self
     }
 
@@ -68,7 +68,7 @@ impl RawFile {
         r.read_to_end(&mut buf).unwrap();
 
         self.set_file_target(path_str);
-        self.set_file_data(buf);
+        self.set_file_data(&buf);
     }
 
     pub(crate) fn write_to<W: io::Seek + io::Write>(

--- a/src/writer/xlsx/drawing_rels.rs
+++ b/src/writer/xlsx/drawing_rels.rs
@@ -11,8 +11,8 @@ use structs::WriterManager;
 pub(crate) fn write<W: io::Seek + io::Write>(
     worksheet: &Worksheet,
     drawing_no: &str,
-    chart_no_list: &Vec<String>,
-    rel_list: &Vec<(String, String)>,
+    chart_no_list: &[String],
+    rel_list: &[(String, String)],
     writer_mng: &mut WriterManager<W>,
 ) -> Result<(), XlsxError> {
     let mut is_write = false;

--- a/src/writer/xlsx/worksheet_rels.rs
+++ b/src/writer/xlsx/worksheet_rels.rs
@@ -18,7 +18,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     ole_object_no_list: &[String],
     excel_no_list: &[String],
     printer_settings_no: &str,
-    table_no_list: &Vec<String>,
+    table_no_list: &[String],
     writer_mng: &mut WriterManager<W>,
 ) -> Result<(), XlsxError> {
     let mut is_write = false;


### PR DESCRIPTION
@MathNya, The Variant of Enum `CellRawValue` is given as `Null`. I find it to be confusing to the user. Therefore, I changed the name of the default item of the `CellRawValue` to be `Empty` to be more meaningful. 

In `src/structs/cell_value.rs` & `src/structs/cell.rs` the function `set_value()` if given text "NULL" would store nothing into a cell, which can also be achieved when passed "". Therefore, I feel this should be rationalised. 

**Note: This would be a breaking change** 