### PR TITLE
Speed up image stuff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "umya-spreadsheet"
-version = "2.0.2"
+version = "2.0.3"
 authors = ["MathNya <umya.net.info@gmail.com>"]
 repository = "https://github.com/MathNya/umya-spreadsheet"
 keywords = ["excel", "spreadsheet", "xlsx", "reader", "writer"]
@@ -24,7 +24,7 @@ getrandom = { version = "0.2.14" }
 hashbrown = "0.14.3"
 hmac = "0.12.1"
 html_parser = "0.7.0"
-image = "0.25.0"
+image = { version = "0.25.0", optional = true }
 lazy_static = "1.4.0"
 md-5 = "0.10.6"
 regex = "1.10.2"
@@ -38,3 +38,4 @@ doctest = false
 
 [features]
 js = ["getrandom/js"]
+default = ["image"]

--- a/src/structs/image.rs
+++ b/src/structs/image.rs
@@ -1,5 +1,4 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use image::GenericImageView;
 use quick_xml::Writer;
 use std::fs;
 use std::fs::File;
@@ -102,8 +101,7 @@ impl Image {
         let path_obj = std::path::Path::new(path_str);
         let image_name = path_obj.file_name().unwrap().to_str().unwrap();
 
-        let img = image::open(path_obj).unwrap();
-        let (width, height) = img.dimensions();
+        let (width, height) = image::image_dimensions(path_obj).unwrap();
 
         let mut file = File::open(path_str).unwrap();
         let mut buf = Vec::new();


### PR DESCRIPTION
Partially contributes to #199, as it makes three main things:

- replaces reading from a `File` with a reading from a `BufReader` to increase speed
- replaces `image::open()` with `image::image_dimensions()` to increase speed
- makes `image` crate optional to increase compilation speed 
