### PR TITLE
[WIP] Fix for formula being overriden by precomputed value

### DIFF
--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -329,8 +329,8 @@ impl Cell {
                 }
                 Ok(Event::End(ref e)) => match e.name().into_inner() {
                     b"v" => match type_value.as_str() {
-                        _ => if self.cell_value.is_formula() {
-                            self.set_value_lazy(&string_value);
+                        _ if self.is_formula() => {
+                            self.set_formula_result_default(&string_value);
                         }
                         "str" => {
                             self.set_value_string(&string_value);

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -330,7 +330,7 @@ impl Cell {
                 Ok(Event::End(ref e)) => match e.name().into_inner() {
                     b"v" => match type_value.as_str() {
                         _ => if self.cell_value.is_formula() {
-                            self.set_formula_result_default(&string_value);
+                            self.set_value_lazy(&string_value);
                         }
                         "str" => {
                             self.set_value_string(&string_value);

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -329,6 +329,9 @@ impl Cell {
                 }
                 Ok(Event::End(ref e)) => match e.name().into_inner() {
                     b"v" => match type_value.as_str() {
+                        _ => if self.cell_value.is_formula() {
+                            self.set_formula_result_default(&string_value);
+                        }
                         "str" => {
                             self.set_value_string(&string_value);
                         }


### PR DESCRIPTION
Fixes #225 

## Change

Previously, if a cell had both the <f> and <v> tag it would delete the formula.
This pull request adds a check to the handling of the end event of the v tag to handle that scenario

## Question 

I'm not sure if the `Cell::set_formula_result_default` is the proper behaviour for that scenario