### PR TITLE
fixup! Speed up image stuff (#223)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@
 extern crate chrono;
 extern crate fancy_regex;
 extern crate hashbrown;
+#[cfg(feature = "image")]
 extern crate image;
 extern crate md5;
 extern crate quick_xml;

--- a/src/structs/image.rs
+++ b/src/structs/image.rs
@@ -163,6 +163,7 @@ impl Image {
         self.set_one_cell_anchor(one_cell_anchor);
     }
 
+    #[cfg(feature = "image")]
     pub fn change_image(&mut self, path: &str) {
         let marker = self.get_from_marker_type().clone();
         self.remove_two_cell_anchor();


### PR DESCRIPTION
I didn't consider a few places where the functions could be used, so the version `2.1.0` [should be yanked](https://doc.rust-lang.org/cargo/commands/cargo-yank.html).

```toml
umya-spreadsheet = { version = "2.1.0", default-features = false }
```

Will fail.