### PR TITLE
Reduce memory footprint by reducing size of data types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ lazy_static = "1.4.0"
 md-5 = "0.10.6"
 regex = "1.11.1"
 sha2 = "0.10.8"
+thin-vec = "0.2.13"
 thousands = "0.2.0"
 quick-xml = { version = "0.36.2", features = ["serialize"] }
 zip = { version = "1.1.4", default-features = false, features = ["deflate"] }

--- a/src/helper/html.rs
+++ b/src/helper/html.rs
@@ -7,6 +7,7 @@ use structs::RichText;
 use structs::TextElement;
 use structs::UnderlineValues;
 use structs::VerticalAlignmentRunValues;
+use thin_vec::ThinVec;
 
 /// Generate rich text from html.
 /// # Arguments
@@ -48,8 +49,8 @@ pub fn html_to_richtext_custom(
     Ok(result)
 }
 
-fn read_node(node_list: &Vec<Node>, parent_element: &Vec<HfdElement>) -> Vec<HtmlFlatData> {
-    let mut result: Vec<HtmlFlatData> = Vec::new();
+fn read_node(node_list: &Vec<Node>, parent_element: &[HfdElement]) -> ThinVec<HtmlFlatData> {
+    let mut result: ThinVec<HtmlFlatData> = ThinVec::new();
 
     if node_list.is_empty() {
         return result;
@@ -71,7 +72,7 @@ fn read_node(node_list: &Vec<Node>, parent_element: &Vec<HfdElement>) -> Vec<Htm
                 if &data.text != "" {
                     result.push(data);
                     data = HtmlFlatData::default();
-                    data.element.append(&mut parent_element.clone());
+                    data.element.extend_from_slice(parent_element);
                 }
 
                 let mut elm: HfdElement = HfdElement::default();
@@ -88,7 +89,7 @@ fn read_node(node_list: &Vec<Node>, parent_element: &Vec<HfdElement>) -> Vec<Htm
                     })
                     .collect();
 
-                elm.classes = element.classes.clone();
+                elm.classes = element.classes.clone().into();
                 data.element.push(elm);
 
                 let mut children = read_node(&element.children, &data.element);
@@ -170,14 +171,14 @@ fn make_rich_text(html_flat_data_list: &[HtmlFlatData], method: &AnalysisMethod)
 #[derive(Clone, Default, Debug)]
 pub struct HtmlFlatData {
     text: String,
-    element: Vec<HfdElement>,
+    element: ThinVec<HfdElement>,
 }
 
 #[derive(Clone, Default, Debug)]
 pub struct HfdElement {
     name: String,
     attributes: HashMap<String, String>,
-    classes: Vec<String>,
+    classes: ThinVec<String>,
 }
 impl HfdElement {
     pub fn has_name(&self, name: &str) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ extern crate hashbrown;
 extern crate image;
 extern crate md5;
 extern crate quick_xml;
+extern crate thin_vec;
 extern crate thousands;
 extern crate zip;
 

--- a/src/structs/address.rs
+++ b/src/structs/address.rs
@@ -7,7 +7,7 @@ use traits::AdjustmentCoordinateWithSheet;
 
 #[derive(Clone, Default, Debug)]
 pub struct Address {
-    sheet_name: String,
+    sheet_name: Box<str>,
     range: Range,
 }
 
@@ -17,7 +17,7 @@ impl Address {
     }
 
     pub fn set_sheet_name<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.sheet_name = value.into();
+        self.sheet_name = value.into().into_boxed_str();
         self
     }
 
@@ -39,7 +39,7 @@ impl Address {
         let (sheet_name, range) = split_address(&org_value);
         self.range.set_range(range);
         if sheet_name != "" {
-            self.sheet_name = sheet_name.to_string();
+            self.sheet_name = sheet_name.into();
         }
         self
     }
@@ -68,7 +68,7 @@ impl Address {
             }
             if sheet_name.contains("'") {
                 with_space_char = "'";
-                sheet_name = sheet_name.replace("'", "''");
+                sheet_name = sheet_name.replace("'", "''").into_boxed_str();
             }
             if sheet_name.contains(r#"""#) {
                 with_space_char = "'";
@@ -102,7 +102,7 @@ impl AdjustmentCoordinateWithSheet for Address {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        if self.sheet_name == sheet_name {
+        if &*self.sheet_name == sheet_name {
             self.range.adjustment_insert_coordinate(
                 root_col_num,
                 offset_col_num,
@@ -120,7 +120,7 @@ impl AdjustmentCoordinateWithSheet for Address {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        if self.sheet_name == sheet_name {
+        if &*self.sheet_name == sheet_name {
             self.range.adjustment_remove_coordinate(
                 root_col_num,
                 offset_col_num,
@@ -138,7 +138,7 @@ impl AdjustmentCoordinateWithSheet for Address {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) -> bool {
-        self.sheet_name == sheet_name
+        &*self.sheet_name == sheet_name
             && self.range.is_remove_coordinate(
                 root_col_num,
                 offset_col_num,

--- a/src/structs/borders_crate.rs
+++ b/src/structs/borders_crate.rs
@@ -6,19 +6,20 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct BordersCrate {
-    borders: Vec<Borders>,
+    borders: ThinVec<Borders>,
 }
 
 impl BordersCrate {
-    pub(crate) fn get_borders(&self) -> &Vec<Borders> {
+    pub(crate) fn get_borders(&self) -> &[Borders] {
         &self.borders
     }
 
-    pub(crate) fn get_borders_mut(&mut self) -> &mut Vec<Borders> {
+    pub(crate) fn get_borders_mut(&mut self) -> &mut ThinVec<Borders> {
         &mut self.borders
     }
 

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -29,7 +29,7 @@ use writer::driver::*;
 #[derive(Clone, Default, Debug, PartialEq, PartialOrd)]
 pub struct Cell {
     coordinate: Coordinate,
-    pub(crate) cell_value: CellValue,
+    pub(crate) cell_value: Box<CellValue>,
     style: Box<Style>,
     hyperlink: Option<Box<Hyperlink>>,
     cell_meta_index: UInt32Value,
@@ -44,7 +44,7 @@ impl Cell {
     }
 
     pub fn set_cell_value(&mut self, value: CellValue) -> &mut Self {
-        self.cell_value = value;
+        self.cell_value = Box::new(value);
         self
     }
 

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -30,8 +30,8 @@ use writer::driver::*;
 pub struct Cell {
     coordinate: Coordinate,
     pub(crate) cell_value: CellValue,
-    style: Style,
-    hyperlink: Option<Hyperlink>,
+    style: Box<Style>,
+    hyperlink: Option<Box<Hyperlink>>,
     cell_meta_index: UInt32Value,
 }
 impl Cell {
@@ -57,7 +57,7 @@ impl Cell {
     }
 
     pub fn set_style(&mut self, value: Style) -> &mut Self {
-        self.style = value;
+        self.style = Box::new(value);
         self
     }
 
@@ -94,7 +94,7 @@ impl Cell {
     }
 
     pub fn get_hyperlink(&self) -> Option<&Hyperlink> {
-        self.hyperlink.as_ref()
+        self.hyperlink.as_deref()
     }
 
     pub fn get_hyperlink_mut(&mut self) -> &mut Hyperlink {
@@ -106,7 +106,7 @@ impl Cell {
     }
 
     pub fn set_hyperlink(&mut self, value: Hyperlink) -> &mut Self {
-        self.hyperlink = Some(value);
+        self.hyperlink = Some(Box::new(value));
         self
     }
 

--- a/src/structs/cell_formats.rs
+++ b/src/structs/cell_formats.rs
@@ -5,19 +5,20 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct CellFormats {
-    cell_format: Vec<CellFormat>,
+    cell_format: ThinVec<CellFormat>,
 }
 
 impl CellFormats {
-    pub(crate) fn get_cell_format(&self) -> &Vec<CellFormat> {
+    pub(crate) fn get_cell_format(&self) -> &[CellFormat] {
         &self.cell_format
     }
 
-    pub(crate) fn _get_cell_format_mut(&mut self) -> &mut Vec<CellFormat> {
+    pub(crate) fn _get_cell_format_mut(&mut self) -> &mut ThinVec<CellFormat> {
         &mut self.cell_format
     }
 

--- a/src/structs/cell_raw_value.rs
+++ b/src/structs/cell_raw_value.rs
@@ -5,9 +5,9 @@ use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default)]
 pub enum CellRawValue {
-    String(String),
+    String(Box<str>),
     RichText(RichText),
-    Lazy(String),
+    Lazy(Box<str>),
     Numeric(f64),
     Bool(bool),
     Error(CellErrorType),

--- a/src/structs/cell_style_formats.rs
+++ b/src/structs/cell_style_formats.rs
@@ -5,19 +5,20 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct CellStyleFormats {
-    cell_format: Vec<CellFormat>,
+    cell_format: ThinVec<CellFormat>,
 }
 
 impl CellStyleFormats {
-    pub(crate) fn get_cell_format(&self) -> &Vec<CellFormat> {
+    pub(crate) fn get_cell_format(&self) -> &[CellFormat] {
         &self.cell_format
     }
 
-    pub(crate) fn _get_cell_format_mut(&mut self) -> &mut Vec<CellFormat> {
+    pub(crate) fn _get_cell_format_mut(&mut self) -> &mut ThinVec<CellFormat> {
         &mut self.cell_format
     }
 

--- a/src/structs/cell_styles.rs
+++ b/src/structs/cell_styles.rs
@@ -5,19 +5,20 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct CellStyles {
-    cell_style: Vec<CellStyle>,
+    cell_style: ThinVec<CellStyle>,
 }
 
 impl CellStyles {
-    pub fn _get_cell_style(&self) -> &Vec<CellStyle> {
+    pub fn _get_cell_style(&self) -> &[CellStyle] {
         &self.cell_style
     }
 
-    pub fn _get_cell_style_mut(&mut self) -> &mut Vec<CellStyle> {
+    pub fn _get_cell_style_mut(&mut self) -> &mut ThinVec<CellStyle> {
         &mut self.cell_style
     }
 

--- a/src/structs/cell_value.rs
+++ b/src/structs/cell_value.rs
@@ -12,7 +12,7 @@ use traits::AdjustmentCoordinateWith2Sheet;
 #[derive(Clone, Default, Debug, PartialEq, PartialOrd)]
 pub struct CellValue {
     pub(crate) raw_value: CellRawValue,
-    pub(crate) formula: Option<CellFormula>,
+    pub(crate) formula: Option<Box<CellFormula>>,
 }
 impl CellValue {
     pub fn get_data_type(&self) -> &str {
@@ -74,18 +74,18 @@ impl CellValue {
     }
 
     pub fn set_value_lazy<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.raw_value = CellRawValue::Lazy(value.into());
+        self.raw_value = CellRawValue::Lazy(value.into().into_boxed_str());
         self
     }
 
     pub fn set_value_string<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.raw_value = CellRawValue::String(value.into());
+        self.raw_value = CellRawValue::String(value.into().into_boxed_str());
         self.remove_formula();
         self
     }
 
     pub(crate) fn set_value_string_crate<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.raw_value = CellRawValue::String(value.into());
+        self.raw_value = CellRawValue::String(value.into().into_boxed_str());
         self
     }
 
@@ -133,18 +133,18 @@ impl CellValue {
     }
 
     pub fn get_formula_obj(&self) -> Option<&CellFormula> {
-        self.formula.as_ref()
+        self.formula.as_deref()
     }
 
     pub fn set_formula<S: Into<String>>(&mut self, value: S) -> &mut Self {
         let mut obj = CellFormula::default();
         obj.set_text(value.into());
-        self.formula = Some(obj);
+        self.formula = Some(Box::new(obj));
         self
     }
 
     pub fn set_formula_obj(&mut self, value: CellFormula) -> &mut Self {
-        self.formula = Some(value);
+        self.formula = Some(Box::new(value));
         self
     }
 

--- a/src/structs/cells.rs
+++ b/src/structs/cells.rs
@@ -12,13 +12,13 @@ use traits::AdjustmentCoordinateWithSheet;
 
 #[derive(Clone, Default, Debug)]
 pub struct Cells {
-    map: HashMap<(u32, u32), Cell>,
+    map: HashMap<(u32, u32), Box<Cell>>,
     default_cell_value: CellValue,
     default_style: Style,
 }
 impl Cells {
     pub fn get_collection(&self) -> Vec<&Cell> {
-        self.map.values().collect()
+        self.map.values().map(Box::as_ref).collect()
     }
 
     pub fn get_collection_sorted(&self) -> Vec<&Cell> {
@@ -37,10 +37,10 @@ impl Cells {
     }
 
     pub(crate) fn get_collection_mut(&mut self) -> Vec<&mut Cell> {
-        self.map.values_mut().collect()
+        self.map.values_mut().map(Box::as_mut).collect()
     }
 
-    pub fn get_collection_to_hashmap(&self) -> &HashMap<(u32, u32), Cell> {
+    pub fn get_collection_to_hashmap(&self) -> &HashMap<(u32, u32), Box<Cell>> {
         &self.map
     }
 
@@ -48,6 +48,7 @@ impl Cells {
         self.map
             .values()
             .filter(|k| k.get_coordinate().get_col_num() == column_num)
+            .map(Box::as_ref)
             .collect()
     }
 
@@ -55,6 +56,7 @@ impl Cells {
         self.map
             .values()
             .filter(|k| k.get_coordinate().get_row_num() == row_num)
+            .map(Box::as_ref)
             .collect()
     }
 
@@ -62,7 +64,7 @@ impl Cells {
         self.map
             .iter()
             .filter(|(k, _v)| &k.1 == column_num)
-            .map(|(k, v)| (k.0, v))
+            .map(|(k, v)| (k.0, v.as_ref()))
             .collect()
     }
 
@@ -70,11 +72,11 @@ impl Cells {
         self.map
             .iter()
             .filter(|(k, _v)| &k.0 == row_num)
-            .map(|(k, v)| (k.1, v))
+            .map(|(k, v)| (k.1, v.as_ref()))
             .collect()
     }
 
-    pub(crate) fn get_collection_to_hashmap_mut(&mut self) -> &mut HashMap<(u32, u32), Cell> {
+    pub(crate) fn get_collection_to_hashmap_mut(&mut self) -> &mut HashMap<(u32, u32), Box<Cell>> {
         &mut self.map
     }
 
@@ -102,7 +104,9 @@ impl Cells {
         T: Into<CellCoordinates>,
     {
         let CellCoordinates { col, row } = coordinate.into();
-        self.map.get(&(row.to_owned(), col.to_owned()))
+        self.map
+            .get(&(row.to_owned(), col.to_owned()))
+            .map(Box::as_ref)
     }
 
     pub(crate) fn get_mut<T>(
@@ -127,7 +131,7 @@ impl Cells {
                 if row_dimenshon.has_style() {
                     c.set_style(row_dimenshon.get_style().clone());
                 }
-                c
+                Box::new(c)
             })
     }
 
@@ -175,7 +179,7 @@ impl Cells {
         let col_num = cell.get_coordinate().get_col_num();
         let row_num = cell.get_coordinate().get_row_num();
         let k = (row_num.to_owned(), col_num.to_owned());
-        self.map.insert_unique_unchecked(k, cell);
+        self.map.insert_unique_unchecked(k, Box::new(cell));
     }
 
     pub(crate) fn remove(&mut self, col_num: &u32, row_num: &u32) -> bool {

--- a/src/structs/color_scale.rs
+++ b/src/structs/color_scale.rs
@@ -6,20 +6,24 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct ColorScale {
-    cfvo_collection: Vec<ConditionalFormatValueObject>,
-    color_collection: Vec<Color>,
+    cfvo_collection: ThinVec<ConditionalFormatValueObject>,
+    color_collection: ThinVec<Color>,
 }
 
 impl ColorScale {
-    pub fn get_cfvo_collection(&self) -> &Vec<ConditionalFormatValueObject> {
+    pub fn get_cfvo_collection(&self) -> &[ConditionalFormatValueObject] {
         &self.cfvo_collection
     }
 
-    pub fn set_cfvo_collection(&mut self, value: Vec<ConditionalFormatValueObject>) -> &mut Self {
+    pub fn set_cfvo_collection(
+        &mut self,
+        value: ThinVec<ConditionalFormatValueObject>,
+    ) -> &mut Self {
         self.cfvo_collection = value;
         self
     }
@@ -29,12 +33,12 @@ impl ColorScale {
         self
     }
 
-    pub fn get_color_collection(&self) -> &Vec<Color> {
+    pub fn get_color_collection(&self) -> &[Color] {
         &self.color_collection
     }
 
-    pub fn set_color_collection(&mut self, value: Vec<Color>) -> &mut Self {
-        self.color_collection = value;
+    pub fn set_color_collection(&mut self, value: impl Into<ThinVec<Color>>) -> &mut Self {
+        self.color_collection = value.into();
         self
     }
 

--- a/src/structs/column.rs
+++ b/src/structs/column.rs
@@ -31,7 +31,7 @@ pub struct Column {
     pub(crate) width: DoubleValue,
     pub(crate) hidden: BooleanValue,
     pub(crate) best_fit: BooleanValue,
-    style: Style,
+    style: Box<Style>,
     auto_width: BooleanValue,
 }
 
@@ -44,7 +44,7 @@ impl Default for Column {
             width,
             hidden: BooleanValue::default(),
             best_fit: BooleanValue::default(),
-            style: Style::default(),
+            style: Box::new(Style::default()),
             auto_width: BooleanValue::default(),
         }
     }
@@ -96,7 +96,7 @@ impl Column {
     }
 
     pub fn set_style(&mut self, value: Style) -> &mut Self {
-        self.style = value;
+        self.style = Box::new(value);
         self
     }
 
@@ -146,7 +146,7 @@ impl Column {
     }
 
     pub(crate) fn has_style(&self) -> bool {
-        &self.style != &Style::default()
+        &*self.style != &Style::default()
     }
 
     pub(crate) fn get_hash_code(&self) -> String {

--- a/src/structs/column_breaks.rs
+++ b/src/structs/column_breaks.rs
@@ -5,19 +5,20 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::Break;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct ColumnBreaks {
-    break_list: Vec<Break>,
+    break_list: ThinVec<Break>,
 }
 
 impl ColumnBreaks {
-    pub fn get_break_list(&self) -> &Vec<Break> {
+    pub fn get_break_list(&self) -> &[Break] {
         &self.break_list
     }
 
-    pub fn get_break_list_mut(&mut self) -> &mut Vec<Break> {
+    pub fn get_break_list_mut(&mut self) -> &mut ThinVec<Break> {
         &mut self.break_list
     }
 

--- a/src/structs/columns.rs
+++ b/src/structs/columns.rs
@@ -8,20 +8,21 @@ use structs::Cells;
 use structs::Column;
 use structs::MergeCells;
 use structs::Stylesheet;
+use thin_vec::ThinVec;
 use traits::AdjustmentValue;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct Columns {
-    column: Vec<Column>,
+    column: ThinVec<Column>,
 }
 
 impl Columns {
-    pub(crate) fn get_column_collection(&self) -> &Vec<Column> {
+    pub(crate) fn get_column_collection(&self) -> &[Column] {
         &self.column
     }
 
-    pub(crate) fn get_column_collection_mut(&mut self) -> &mut Vec<Column> {
+    pub(crate) fn get_column_collection_mut(&mut self) -> &mut ThinVec<Column> {
         &mut self.column
     }
 

--- a/src/structs/comment.rs
+++ b/src/structs/comment.rs
@@ -12,7 +12,7 @@ use traits::AdjustmentCoordinate;
 #[derive(Clone, Default, Debug)]
 pub struct Comment {
     coordinate: Coordinate,
-    author: String,
+    author: Box<str>,
     text: RichText,
     shape: Shape,
 }
@@ -31,7 +31,7 @@ impl Comment {
     }
 
     pub fn set_author<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.author = value.into();
+        self.author = value.into().into_boxed_str();
         self
     }
 

--- a/src/structs/conditional_formatting.rs
+++ b/src/structs/conditional_formatting.rs
@@ -7,13 +7,14 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use traits::AdjustmentCoordinate;
 use writer::driver::*;
 
 #[derive(Default, Debug, Clone)]
 pub struct ConditionalFormatting {
     sequence_of_references: SequenceOfReferences,
-    conditional_collection: Vec<ConditionalFormattingRule>,
+    conditional_collection: ThinVec<ConditionalFormattingRule>,
 }
 
 impl ConditionalFormatting {
@@ -30,19 +31,19 @@ impl ConditionalFormatting {
         self
     }
 
-    pub fn get_conditional_collection(&self) -> &Vec<ConditionalFormattingRule> {
+    pub fn get_conditional_collection(&self) -> &[ConditionalFormattingRule] {
         &self.conditional_collection
     }
 
-    pub fn get_conditional_collection_mut(&mut self) -> &mut Vec<ConditionalFormattingRule> {
+    pub fn get_conditional_collection_mut(&mut self) -> &mut ThinVec<ConditionalFormattingRule> {
         &mut self.conditional_collection
     }
 
     pub fn set_conditional_collection(
         &mut self,
-        value: Vec<ConditionalFormattingRule>,
+        value: impl Into<ThinVec<ConditionalFormattingRule>>,
     ) -> &mut Self {
-        self.conditional_collection = value;
+        self.conditional_collection = value.into();
         self
     }
 

--- a/src/structs/conditional_formatting_rule.rs
+++ b/src/structs/conditional_formatting_rule.rs
@@ -34,11 +34,11 @@ pub struct ConditionalFormattingRule {
     above_average: BooleanValue,
     equal_average: BooleanValue,
     time_period: EnumValue<TimePeriodValues>,
-    style: Option<Style>,
+    style: Option<Box<Style>>,
     color_scale: Option<ColorScale>,
     data_bar: Option<DataBar>,
     icon_set: Option<IconSet>,
-    formula: Option<Formula>,
+    formula: Option<Box<Formula>>,
 }
 
 impl ConditionalFormattingRule {
@@ -151,11 +151,11 @@ impl ConditionalFormattingRule {
     }
 
     pub fn get_style(&self) -> Option<&Style> {
-        self.style.as_ref()
+        self.style.as_deref()
     }
 
     pub fn set_style(&mut self, value: Style) -> &mut Self {
-        self.style = Some(value);
+        self.style = Some(Box::new(value));
         self
     }
 
@@ -207,11 +207,11 @@ impl ConditionalFormattingRule {
     }
 
     pub fn get_formula(&self) -> Option<&Formula> {
-        self.formula.as_ref()
+        self.formula.as_deref()
     }
 
     pub fn set_formula(&mut self, value: Formula) -> &mut Self {
-        self.formula = Some(value);
+        self.formula = Some(Box::new(value));
         self
     }
 
@@ -272,7 +272,7 @@ impl ConditionalFormattingRule {
                     b"formula" => {
                         let mut obj = Formula::default();
                         obj.set_attributes(reader, e);
-                        self.formula = Some(obj);
+                        self.formula = Some(Box::new(obj));
                     }
                     _ => (),
                 }

--- a/src/structs/csv_writer_option.rs
+++ b/src/structs/csv_writer_option.rs
@@ -4,7 +4,7 @@ use structs::CsvEncodeValues;
 #[derive(Clone, Default, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct CsvWriterOption {
     pub(crate) csv_encode_values: EnumValue<CsvEncodeValues>,
-    pub(crate) wrap_with_char: String,
+    pub(crate) wrap_with_char: Box<str>,
     pub(crate) do_trim: bool,
 }
 impl CsvWriterOption {
@@ -22,7 +22,7 @@ impl CsvWriterOption {
     }
 
     pub fn set_wrap_with_char<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.wrap_with_char = value.into();
+        self.wrap_with_char = value.into().into_boxed_str();
         self
     }
 

--- a/src/structs/custom_properties/custom_document_property.rs
+++ b/src/structs/custom_properties/custom_document_property.rs
@@ -48,7 +48,8 @@ impl CustomDocumentProperty {
     }
 
     pub fn set_value_string<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.custom_document_property_value = CustomDocumentPropertyValue::String(value.into());
+        self.custom_document_property_value =
+            CustomDocumentPropertyValue::String(value.into().into_boxed_str());
         self
     }
 
@@ -62,12 +63,14 @@ impl CustomDocumentProperty {
 
     pub fn set_value_date(&mut self, year: i32, month: i32, day: i32) -> &mut Self {
         let value = format!("{:>04}-{:>02}-{:>02}T10:00:00Z", year, month, day);
-        self.custom_document_property_value = CustomDocumentPropertyValue::Date(value);
+        self.custom_document_property_value =
+            CustomDocumentPropertyValue::Date(value.into_boxed_str());
         self
     }
 
     pub fn set_value_date_manual<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.custom_document_property_value = CustomDocumentPropertyValue::Date(value.into());
+        self.custom_document_property_value =
+            CustomDocumentPropertyValue::Date(value.into().into_boxed_str());
         self
     }
 

--- a/src/structs/custom_properties/custom_document_property_value.rs
+++ b/src/structs/custom_properties/custom_document_property_value.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub enum CustomDocumentPropertyValue {
-    String(String),
-    Date(String),
+    String(Box<str>),
+    Date(Box<str>),
     Numeric(i32),
     Bool(bool),
     Null,

--- a/src/structs/custom_properties/properties.rs
+++ b/src/structs/custom_properties/properties.rs
@@ -7,27 +7,30 @@ use reader::driver::*;
 use std::borrow::Cow;
 use std::io::Cursor;
 use structs::custom_properties::CustomDocumentProperty;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Default, Debug, Clone)]
 pub struct Properties {
-    custom_document_property_list: Vec<CustomDocumentProperty>,
+    custom_document_property_list: ThinVec<CustomDocumentProperty>,
 }
 
 impl Properties {
-    pub fn get_custom_document_property_list(&self) -> &Vec<CustomDocumentProperty> {
+    pub fn get_custom_document_property_list(&self) -> &[CustomDocumentProperty] {
         &self.custom_document_property_list
     }
 
-    pub fn get_custom_document_property_list_mut(&mut self) -> &mut Vec<CustomDocumentProperty> {
+    pub fn get_custom_document_property_list_mut(
+        &mut self,
+    ) -> &mut ThinVec<CustomDocumentProperty> {
         &mut self.custom_document_property_list
     }
 
     pub fn set_custom_document_property_list(
         &mut self,
-        value: Vec<CustomDocumentProperty>,
+        value: impl Into<ThinVec<CustomDocumentProperty>>,
     ) -> &mut Self {
-        self.custom_document_property_list = value;
+        self.custom_document_property_list = value.into();
         self
     }
 

--- a/src/structs/data_bar.rs
+++ b/src/structs/data_bar.rs
@@ -6,20 +6,24 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct DataBar {
-    cfvo_collection: Vec<ConditionalFormatValueObject>,
-    color_collection: Vec<Color>,
+    cfvo_collection: ThinVec<ConditionalFormatValueObject>,
+    color_collection: ThinVec<Color>,
 }
 
 impl DataBar {
-    pub fn get_cfvo_collection(&self) -> &Vec<ConditionalFormatValueObject> {
+    pub fn get_cfvo_collection(&self) -> &[ConditionalFormatValueObject] {
         &self.cfvo_collection
     }
 
-    pub fn set_cfvo_collection(&mut self, value: Vec<ConditionalFormatValueObject>) -> &mut Self {
+    pub fn set_cfvo_collection(
+        &mut self,
+        value: ThinVec<ConditionalFormatValueObject>,
+    ) -> &mut Self {
         self.cfvo_collection = value;
         self
     }
@@ -29,12 +33,12 @@ impl DataBar {
         self
     }
 
-    pub fn get_color_collection(&self) -> &Vec<Color> {
+    pub fn get_color_collection(&self) -> &[Color] {
         &self.color_collection
     }
 
-    pub fn set_color_collection(&mut self, value: Vec<Color>) -> &mut Self {
-        self.color_collection = value;
+    pub fn set_color_collection(&mut self, value: impl Into<ThinVec<Color>>) -> &mut Self {
+        self.color_collection = value.into();
         self
     }
 

--- a/src/structs/data_validations.rs
+++ b/src/structs/data_validations.rs
@@ -5,24 +5,28 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Default, Debug, Clone)]
 pub struct DataValidations {
-    data_validation_list: Vec<DataValidation>,
+    data_validation_list: ThinVec<DataValidation>,
 }
 
 impl DataValidations {
-    pub fn get_data_validation_list(&self) -> &Vec<DataValidation> {
+    pub fn get_data_validation_list(&self) -> &[DataValidation] {
         &self.data_validation_list
     }
 
-    pub fn get_data_validation_list_mut(&mut self) -> &mut Vec<DataValidation> {
+    pub fn get_data_validation_list_mut(&mut self) -> &mut ThinVec<DataValidation> {
         &mut self.data_validation_list
     }
 
-    pub fn set_data_validation_list(&mut self, value: Vec<DataValidation>) -> &mut Self {
-        self.data_validation_list = value;
+    pub fn set_data_validation_list(
+        &mut self,
+        value: impl Into<ThinVec<DataValidation>>,
+    ) -> &mut Self {
+        self.data_validation_list = value.into();
         self
     }
 

--- a/src/structs/defined_name.rs
+++ b/src/structs/defined_name.rs
@@ -8,13 +8,14 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use traits::AdjustmentCoordinateWithSheet;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct DefinedName {
     name: StringValue,
-    address: Vec<Address>,
+    address: ThinVec<Address>,
     string_value: StringValue,
     local_sheet_id: UInt32Value,
     hidden: BooleanValue,
@@ -72,11 +73,11 @@ impl DefinedName {
             .to_string()
     }
 
-    pub(crate) fn get_address_obj(&self) -> &Vec<Address> {
+    pub(crate) fn get_address_obj(&self) -> &[Address] {
         &self.address
     }
 
-    pub(crate) fn get_address_obj_mut(&mut self) -> &mut Vec<Address> {
+    pub(crate) fn get_address_obj_mut(&mut self) -> &mut ThinVec<Address> {
         &mut self.address
     }
 

--- a/src/structs/differential_format.rs
+++ b/src/structs/differential_format.rs
@@ -14,23 +14,23 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct DifferentialFormat {
-    font: Option<Font>,
+    font: Option<Box<Font>>,
     fill: Option<Fill>,
-    borders: Option<Borders>,
+    borders: Option<Box<Borders>>,
     alignment: Option<Alignment>,
 }
 
 impl DifferentialFormat {
     pub(crate) fn _get_font(&self) -> Option<&Font> {
-        self.font.as_ref()
+        self.font.as_deref()
     }
 
     pub(crate) fn _get_font_mut(&mut self) -> Option<&mut Font> {
-        self.font.as_mut()
+        self.font.as_deref_mut()
     }
 
     pub(crate) fn set_font(&mut self, value: Font) -> &mut Self {
-        self.font = Some(value);
+        self.font = Some(Box::new(value));
         self
     }
 
@@ -48,15 +48,15 @@ impl DifferentialFormat {
     }
 
     pub(crate) fn _get_borders(&self) -> Option<&Borders> {
-        self.borders.as_ref()
+        self.borders.as_deref()
     }
 
     pub(crate) fn _get_borders_mut(&mut self) -> Option<&mut Borders> {
-        self.borders.as_mut()
+        self.borders.as_deref_mut()
     }
 
     pub(crate) fn set_borders(&mut self, value: Borders) -> &mut Self {
-        self.borders = Some(value);
+        self.borders = Some(Box::new(value));
         self
     }
 
@@ -75,17 +75,17 @@ impl DifferentialFormat {
 
     pub(crate) fn get_style(&self) -> Style {
         let mut style = Style::default();
-        style.set_font_crate(self.font.clone());
+        style.set_font_crate(self.font.as_deref().cloned());
         style.set_fill_crate(self.fill.clone());
-        style.set_borders_crate(self.borders.clone());
+        style.set_borders_crate(self.borders.as_deref().cloned());
         style.set_alignment_crate(self.alignment.clone());
         style
     }
 
     pub(crate) fn set_style(&mut self, style: &Style) {
-        self.font = style.get_font().cloned();
+        self.font = style.get_font().cloned().map(Box::new);
         self.fill = style.get_fill().cloned();
-        self.borders = style.get_borders().cloned();
+        self.borders = style.get_borders().cloned().map(Box::new);
         self.alignment = style.get_alignment().cloned();
     }
 

--- a/src/structs/differential_formats.rs
+++ b/src/structs/differential_formats.rs
@@ -6,19 +6,20 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct DifferentialFormats {
-    differential_format: Vec<DifferentialFormat>,
+    differential_format: ThinVec<DifferentialFormat>,
 }
 
 impl DifferentialFormats {
-    pub(crate) fn _get_differential_format(&self) -> &Vec<DifferentialFormat> {
+    pub(crate) fn _get_differential_format(&self) -> &[DifferentialFormat] {
         &self.differential_format
     }
 
-    pub(crate) fn _get_differential_format_mut(&mut self) -> &mut Vec<DifferentialFormat> {
+    pub(crate) fn _get_differential_format_mut(&mut self) -> &mut ThinVec<DifferentialFormat> {
         &mut self.differential_format
     }
 

--- a/src/structs/drawing/adjust_value_list.rs
+++ b/src/structs/drawing/adjust_value_list.rs
@@ -5,24 +5,25 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct AdjustValueList {
-    shape_guide_collection: Vec<ShapeGuide>,
+    shape_guide_collection: ThinVec<ShapeGuide>,
 }
 
 impl AdjustValueList {
-    pub fn get_shape_guide_collection(&self) -> &Vec<ShapeGuide> {
+    pub fn get_shape_guide_collection(&self) -> &[ShapeGuide] {
         &self.shape_guide_collection
     }
 
-    pub fn get_shape_guide_collection_mut(&mut self) -> &mut Vec<ShapeGuide> {
+    pub fn get_shape_guide_collection_mut(&mut self) -> &mut ThinVec<ShapeGuide> {
         &mut self.shape_guide_collection
     }
 
-    pub fn set_shape_guide_collection(&mut self, value: Vec<ShapeGuide>) {
-        self.shape_guide_collection = value;
+    pub fn set_shape_guide_collection(&mut self, value: impl Into<ThinVec<ShapeGuide>>) {
+        self.shape_guide_collection = value.into();
     }
 
     pub fn add_shape_guide_collection(&mut self, value: ShapeGuide) {

--- a/src/structs/drawing/alpha.rs
+++ b/src/structs/drawing/alpha.rs
@@ -8,7 +8,7 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct Alpha {
-    val: String,
+    val: Box<str>,
 }
 impl Alpha {
     pub fn get_val(&self) -> &str {
@@ -16,7 +16,7 @@ impl Alpha {
     }
 
     pub fn set_val<S: Into<String>>(&mut self, value: S) {
-        self.val = value.into();
+        self.val = value.into().into_boxed_str();
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/background_fill_style_list.rs
+++ b/src/structs/drawing/background_fill_style_list.rs
@@ -5,25 +5,26 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct BackgroundFillStyleList {
-    solid_fill: Vec<SolidFill>,
-    gradient_fill_collection: Vec<GradientFill>,
+    solid_fill: ThinVec<SolidFill>,
+    gradient_fill_collection: ThinVec<GradientFill>,
 }
 
 impl BackgroundFillStyleList {
-    pub fn get_solid_fill(&self) -> &Vec<SolidFill> {
+    pub fn get_solid_fill(&self) -> &[SolidFill] {
         &self.solid_fill
     }
 
-    pub fn get_solid_fill_mut(&mut self) -> &mut Vec<SolidFill> {
+    pub fn get_solid_fill_mut(&mut self) -> &mut ThinVec<SolidFill> {
         &mut self.solid_fill
     }
 
-    pub fn set_solid_fill(&mut self, value: Vec<SolidFill>) -> &mut Self {
-        self.solid_fill = value;
+    pub fn set_solid_fill(&mut self, value: impl Into<ThinVec<SolidFill>>) -> &mut Self {
+        self.solid_fill = value.into();
         self
     }
 
@@ -32,16 +33,19 @@ impl BackgroundFillStyleList {
         self
     }
 
-    pub fn get_gradient_fill_collection(&self) -> &Vec<GradientFill> {
+    pub fn get_gradient_fill_collection(&self) -> &[GradientFill] {
         &self.gradient_fill_collection
     }
 
-    pub fn get_gradient_fill_collectionl_mut(&mut self) -> &mut Vec<GradientFill> {
+    pub fn get_gradient_fill_collectionl_mut(&mut self) -> &mut ThinVec<GradientFill> {
         &mut self.gradient_fill_collection
     }
 
-    pub fn set_gradient_fill_collection(&mut self, value: Vec<GradientFill>) -> &mut Self {
-        self.gradient_fill_collection = value;
+    pub fn set_gradient_fill_collection(
+        &mut self,
+        value: impl Into<ThinVec<GradientFill>>,
+    ) -> &mut Self {
+        self.gradient_fill_collection = value.into();
         self
     }
 

--- a/src/structs/drawing/blip.rs
+++ b/src/structs/drawing/blip.rs
@@ -12,7 +12,7 @@ use writer::driver::*;
 #[derive(Clone, Default, Debug)]
 pub struct Blip {
     image: MediaObject,
-    cstate: String,
+    cstate: Box<str>,
 }
 
 impl Blip {
@@ -34,7 +34,7 @@ impl Blip {
     }
 
     pub fn set_cstate<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.cstate = value.into();
+        self.cstate = value.into().into_boxed_str();
         self
     }
 

--- a/src/structs/drawing/blip_fill.rs
+++ b/src/structs/drawing/blip_fill.rs
@@ -15,7 +15,7 @@ use writer::driver::*;
 pub struct BlipFill {
     rotate_with_shape: BooleanValue,
     blip: Blip,
-    source_rectangle: Option<SourceRectangle>,
+    source_rectangle: Option<Box<SourceRectangle>>,
     stretch: Stretch,
 }
 
@@ -30,15 +30,15 @@ impl BlipFill {
     }
 
     pub fn get_source_rectangle(&self) -> Option<&SourceRectangle> {
-        self.source_rectangle.as_ref()
+        self.source_rectangle.as_deref()
     }
 
     pub fn get_source_rectangle_mut(&mut self) -> Option<&mut SourceRectangle> {
-        self.source_rectangle.as_mut()
+        self.source_rectangle.as_deref_mut()
     }
 
     pub fn set_source_rectangle(&mut self, value: SourceRectangle) -> &mut BlipFill {
-        self.source_rectangle = Some(value);
+        self.source_rectangle = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/camera.rs
+++ b/src/structs/drawing/camera.rs
@@ -12,7 +12,7 @@ use writer::driver::*;
 #[derive(Clone, Default, Debug)]
 pub struct Camera {
     preset: EnumValue<PresetCameraValues>,
-    rotation: Option<Rotation>,
+    rotation: Option<Box<Rotation>>,
 }
 
 impl Camera {
@@ -26,15 +26,15 @@ impl Camera {
     }
 
     pub fn get_rotation(&self) -> Option<&Rotation> {
-        self.rotation.as_ref()
+        self.rotation.as_deref()
     }
 
     pub fn get_rotation_mut(&mut self) -> Option<&mut Rotation> {
-        self.rotation.as_mut()
+        self.rotation.as_deref_mut()
     }
 
     pub fn set_rotation(&mut self, value: Rotation) -> &mut Self {
-        self.rotation = Some(value);
+        self.rotation = Some(Box::new(value));
         self
     }
 
@@ -56,7 +56,7 @@ impl Camera {
                 if e.name().into_inner() == b"a:rot" {
                     let mut obj = Rotation::default();
                     obj.set_attributes(reader, e);
-                    self.rotation = Some(obj);
+                    self.rotation = Some(Box::new(obj));
                 }
             },
             Event::End(ref e) => {

--- a/src/structs/drawing/charts/area_3d_chart.rs
+++ b/src/structs/drawing/charts/area_3d_chart.rs
@@ -11,6 +11,7 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -18,8 +19,8 @@ pub struct Area3DChart {
     grouping: Grouping,
     vary_colors: VaryColors,
     area_chart_series_list: AreaChartSeriesList,
-    data_labels: Option<DataLabels>,
-    axis_id: Vec<AxisId>,
+    data_labels: Option<Box<DataLabels>>,
+    axis_id: ThinVec<AxisId>,
 }
 
 impl Area3DChart {
@@ -63,28 +64,28 @@ impl Area3DChart {
     }
 
     pub fn get_data_labels(&self) -> Option<&DataLabels> {
-        self.data_labels.as_ref()
+        self.data_labels.as_deref()
     }
 
     pub fn get_data_labels_mut(&mut self) -> Option<&mut DataLabels> {
-        self.data_labels.as_mut()
+        self.data_labels.as_deref_mut()
     }
 
     pub fn set_data_labels(&mut self, value: DataLabels) -> &mut Self {
-        self.data_labels = Some(value);
+        self.data_labels = Some(Box::new(value));
         self
     }
 
-    pub fn get_axis_id(&self) -> &Vec<AxisId> {
+    pub fn get_axis_id(&self) -> &[AxisId] {
         &self.axis_id
     }
 
-    pub fn get_axis_id_mut(&mut self) -> &mut Vec<AxisId> {
+    pub fn get_axis_id_mut(&mut self) -> &mut ThinVec<AxisId> {
         &mut self.axis_id
     }
 
-    pub fn set_axis_id(&mut self, value: Vec<AxisId>) -> &mut Self {
-        self.axis_id = value;
+    pub fn set_axis_id(&mut self, value: impl Into<ThinVec<AxisId>>) -> &mut Self {
+        self.axis_id = value.into();
         self
     }
 

--- a/src/structs/drawing/charts/area_chart.rs
+++ b/src/structs/drawing/charts/area_chart.rs
@@ -11,6 +11,7 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -19,7 +20,7 @@ pub struct AreaChart {
     vary_colors: VaryColors,
     area_chart_series_list: AreaChartSeriesList,
     data_labels: DataLabels,
-    axis_id: Vec<AxisId>,
+    axis_id: ThinVec<AxisId>,
 }
 
 impl AreaChart {
@@ -75,16 +76,16 @@ impl AreaChart {
         self
     }
 
-    pub fn get_axis_id(&self) -> &Vec<AxisId> {
+    pub fn get_axis_id(&self) -> &[AxisId] {
         &self.axis_id
     }
 
-    pub fn get_axis_id_mut(&mut self) -> &mut Vec<AxisId> {
+    pub fn get_axis_id_mut(&mut self) -> &mut ThinVec<AxisId> {
         &mut self.axis_id
     }
 
-    pub fn set_axis_id(&mut self, value: Vec<AxisId>) -> &mut AreaChart {
-        self.axis_id = value;
+    pub fn set_axis_id(&mut self, value: impl Into<ThinVec<AxisId>>) -> &mut AreaChart {
+        self.axis_id = value.into();
         self
     }
 

--- a/src/structs/drawing/charts/area_chart_series_list.rs
+++ b/src/structs/drawing/charts/area_chart_series_list.rs
@@ -1,20 +1,24 @@
 use super::AreaChartSeries;
+use thin_vec::ThinVec;
 
 #[derive(Clone, Default, Debug)]
 pub struct AreaChartSeriesList {
-    area_chart_series: Vec<AreaChartSeries>,
+    area_chart_series: ThinVec<AreaChartSeries>,
 }
 impl AreaChartSeriesList {
-    pub fn get_area_chart_series(&self) -> &Vec<AreaChartSeries> {
+    pub fn get_area_chart_series(&self) -> &[AreaChartSeries] {
         &self.area_chart_series
     }
 
-    pub fn get_area_chart_series_mut(&mut self) -> &mut Vec<AreaChartSeries> {
+    pub fn get_area_chart_series_mut(&mut self) -> &mut [AreaChartSeries] {
         &mut self.area_chart_series
     }
 
-    pub fn set_area_chart_series(&mut self, value: Vec<AreaChartSeries>) -> &mut Self {
-        self.area_chart_series = value;
+    pub fn set_area_chart_series(
+        &mut self,
+        value: impl Into<ThinVec<AreaChartSeries>>,
+    ) -> &mut Self {
+        self.area_chart_series = value.into();
         self
     }
 

--- a/src/structs/drawing/charts/bar_3d_chart.rs
+++ b/src/structs/drawing/charts/bar_3d_chart.rs
@@ -14,6 +14,7 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -25,7 +26,7 @@ pub struct Bar3DChart {
     data_labels: DataLabels,
     gap_width: GapWidth,
     shape: Shape,
-    axis_id: Vec<AxisId>,
+    axis_id: ThinVec<AxisId>,
 }
 
 impl Bar3DChart {
@@ -120,16 +121,16 @@ impl Bar3DChart {
         self
     }
 
-    pub fn get_axis_id(&self) -> &Vec<AxisId> {
+    pub fn get_axis_id(&self) -> &[AxisId] {
         &self.axis_id
     }
 
-    pub fn get_axis_id_mut(&mut self) -> &mut Vec<AxisId> {
+    pub fn get_axis_id_mut(&mut self) -> &mut ThinVec<AxisId> {
         &mut self.axis_id
     }
 
-    pub fn set_axis_id(&mut self, value: Vec<AxisId>) -> &mut Bar3DChart {
-        self.axis_id = value;
+    pub fn set_axis_id(&mut self, value: impl Into<ThinVec<AxisId>>) -> &mut Bar3DChart {
+        self.axis_id = value.into();
         self
     }
 

--- a/src/structs/drawing/charts/bar_chart.rs
+++ b/src/structs/drawing/charts/bar_chart.rs
@@ -14,6 +14,7 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -25,7 +26,7 @@ pub struct BarChart {
     data_labels: DataLabels,
     gap_width: GapWidth,
     overlap: Overlap,
-    axis_id: Vec<AxisId>,
+    axis_id: ThinVec<AxisId>,
 }
 
 impl BarChart {
@@ -120,16 +121,16 @@ impl BarChart {
         self
     }
 
-    pub fn get_axis_id(&self) -> &Vec<AxisId> {
+    pub fn get_axis_id(&self) -> &[AxisId] {
         &self.axis_id
     }
 
-    pub fn get_axis_id_mut(&mut self) -> &mut Vec<AxisId> {
+    pub fn get_axis_id_mut(&mut self) -> &mut ThinVec<AxisId> {
         &mut self.axis_id
     }
 
-    pub fn set_axis_id(&mut self, value: Vec<AxisId>) -> &mut BarChart {
-        self.axis_id = value;
+    pub fn set_axis_id(&mut self, value: impl Into<ThinVec<AxisId>>) -> &mut BarChart {
+        self.axis_id = value.into();
         self
     }
 

--- a/src/structs/drawing/charts/bubble_chart.rs
+++ b/src/structs/drawing/charts/bubble_chart.rs
@@ -12,6 +12,7 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -21,7 +22,7 @@ pub struct BubbleChart {
     data_labels: DataLabels,
     bubble_scale: BubbleScale,
     show_negative_bubbles: ShowNegativeBubbles,
-    axis_id: Vec<AxisId>,
+    axis_id: ThinVec<AxisId>,
 }
 
 impl BubbleChart {
@@ -90,16 +91,16 @@ impl BubbleChart {
         self
     }
 
-    pub fn get_axis_id(&self) -> &Vec<AxisId> {
+    pub fn get_axis_id(&self) -> &[AxisId] {
         &self.axis_id
     }
 
-    pub fn get_axis_id_mut(&mut self) -> &mut Vec<AxisId> {
+    pub fn get_axis_id_mut(&mut self) -> &mut ThinVec<AxisId> {
         &mut self.axis_id
     }
 
-    pub fn set_axis_id(&mut self, value: Vec<AxisId>) -> &mut BubbleChart {
-        self.axis_id = value;
+    pub fn set_axis_id(&mut self, value: impl Into<ThinVec<AxisId>>) -> &mut BubbleChart {
+        self.axis_id = value.into();
         self
     }
 

--- a/src/structs/drawing/charts/floor.rs
+++ b/src/structs/drawing/charts/floor.rs
@@ -11,7 +11,7 @@ use writer::driver::*;
 #[derive(Clone, Default, Debug)]
 pub struct Floor {
     thickness: Option<Thickness>,
-    shape_properties: Option<ShapeProperties>,
+    shape_properties: Option<Box<ShapeProperties>>,
 }
 
 impl Floor {
@@ -29,15 +29,15 @@ impl Floor {
     }
 
     pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
-        self.shape_properties.as_ref()
+        self.shape_properties.as_deref()
     }
 
     pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
-        self.shape_properties.as_mut()
+        self.shape_properties.as_deref_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {
-        self.shape_properties = Some(value);
+        self.shape_properties = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/charts/format_code.rs
+++ b/src/structs/drawing/charts/format_code.rs
@@ -9,7 +9,7 @@ use crate::xml_read_loop;
 
 #[derive(Clone, Default, Debug)]
 pub struct FormatCode {
-    text: String,
+    text: Box<str>,
 }
 
 impl FormatCode {
@@ -18,7 +18,7 @@ impl FormatCode {
     }
 
     pub fn set_text<S: Into<String>>(&mut self, value: S) -> &mut FormatCode {
-        self.text = value.into();
+        self.text = value.into().into_boxed_str();
         self
     }
 
@@ -44,7 +44,7 @@ impl FormatCode {
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // c:formatCode
         write_start_tag(writer, "c:formatCode", vec![], false);
-        write_text_node(writer, &self.text);
+        write_text_node(writer, &*self.text);
         write_end_tag(writer, "c:formatCode");
     }
 }

--- a/src/structs/drawing/charts/legend.rs
+++ b/src/structs/drawing/charts/legend.rs
@@ -14,10 +14,10 @@ use writer::driver::*;
 #[derive(Clone, Default, Debug)]
 pub struct Legend {
     legend_position: LegendPosition,
-    layout: Option<Layout>,
+    layout: Option<Box<Layout>>,
     overlay: Overlay,
-    shape_properties: Option<ShapeProperties>,
-    text_properties: Option<TextProperties>,
+    shape_properties: Option<Box<ShapeProperties>>,
+    text_properties: Option<Box<TextProperties>>,
 }
 
 impl Legend {
@@ -35,15 +35,15 @@ impl Legend {
     }
 
     pub fn get_layout(&self) -> Option<&Layout> {
-        self.layout.as_ref()
+        self.layout.as_deref()
     }
 
     pub fn get_layout_mut(&mut self) -> Option<&mut Layout> {
-        self.layout.as_mut()
+        self.layout.as_deref_mut()
     }
 
     pub fn set_layout(&mut self, value: Layout) -> &mut Self {
-        self.layout = Some(value);
+        self.layout = Some(Box::new(value));
         self
     }
 
@@ -61,28 +61,28 @@ impl Legend {
     }
 
     pub fn get_shape_properties(&self) -> Option<&ShapeProperties> {
-        self.shape_properties.as_ref()
+        self.shape_properties.as_deref()
     }
 
     pub fn get_shape_properties_mut(&mut self) -> Option<&mut ShapeProperties> {
-        self.shape_properties.as_mut()
+        self.shape_properties.as_deref_mut()
     }
 
     pub fn set_shape_properties(&mut self, value: ShapeProperties) -> &mut Self {
-        self.shape_properties = Some(value);
+        self.shape_properties = Some(Box::new(value));
         self
     }
 
     pub fn get_text_properties(&self) -> Option<&TextProperties> {
-        self.text_properties.as_ref()
+        self.text_properties.as_deref()
     }
 
     pub fn get_text_properties_mut(&mut self) -> Option<&mut TextProperties> {
-        self.text_properties.as_mut()
+        self.text_properties.as_deref_mut()
     }
 
     pub fn set_text_properties(&mut self, value: TextProperties) -> &mut Self {
-        self.text_properties = Some(value);
+        self.text_properties = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/charts/line_3d_chart.rs
+++ b/src/structs/drawing/charts/line_3d_chart.rs
@@ -11,6 +11,7 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -19,7 +20,7 @@ pub struct Line3DChart {
     vary_colors: VaryColors,
     area_chart_series_list: AreaChartSeriesList,
     data_labels: DataLabels,
-    axis_id: Vec<AxisId>,
+    axis_id: ThinVec<AxisId>,
 }
 
 impl Line3DChart {
@@ -75,16 +76,16 @@ impl Line3DChart {
         self
     }
 
-    pub fn get_axis_id(&self) -> &Vec<AxisId> {
+    pub fn get_axis_id(&self) -> &[AxisId] {
         &self.axis_id
     }
 
-    pub fn get_axis_id_mut(&mut self) -> &mut Vec<AxisId> {
+    pub fn get_axis_id_mut(&mut self) -> &mut ThinVec<AxisId> {
         &mut self.axis_id
     }
 
-    pub fn set_axis_id(&mut self, value: Vec<AxisId>) -> &mut Line3DChart {
-        self.axis_id = value;
+    pub fn set_axis_id(&mut self, value: impl Into<ThinVec<AxisId>>) -> &mut Line3DChart {
+        self.axis_id = value.into();
         self
     }
 

--- a/src/structs/drawing/charts/line_chart.rs
+++ b/src/structs/drawing/charts/line_chart.rs
@@ -14,6 +14,7 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use std::io::Cursor;
 use structs::Spreadsheet;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -24,7 +25,7 @@ pub struct LineChart {
     data_labels: DataLabels,
     show_marker: ShowMarker,
     smooth: Smooth,
-    axis_id: Vec<AxisId>,
+    axis_id: ThinVec<AxisId>,
 }
 
 impl LineChart {
@@ -106,16 +107,16 @@ impl LineChart {
         self
     }
 
-    pub fn get_axis_id(&self) -> &Vec<AxisId> {
+    pub fn get_axis_id(&self) -> &[AxisId] {
         &self.axis_id
     }
 
-    pub fn get_axis_id_mut(&mut self) -> &mut Vec<AxisId> {
+    pub fn get_axis_id_mut(&mut self) -> &mut ThinVec<AxisId> {
         &mut self.axis_id
     }
 
-    pub fn set_axis_id(&mut self, value: Vec<AxisId>) -> &mut Self {
-        self.axis_id = value;
+    pub fn set_axis_id(&mut self, value: impl Into<ThinVec<AxisId>>) -> &mut Self {
+        self.axis_id = value.into();
         self
     }
 

--- a/src/structs/drawing/charts/numeric_value.rs
+++ b/src/structs/drawing/charts/numeric_value.rs
@@ -8,7 +8,7 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct NumericValue {
-    text: String,
+    text: Box<str>,
 }
 
 impl NumericValue {
@@ -17,7 +17,7 @@ impl NumericValue {
     }
 
     pub fn set_text<S: Into<String>>(&mut self, value: S) -> &mut NumericValue {
-        self.text = value.into();
+        self.text = value.into().into_boxed_str();
         self
     }
 
@@ -43,7 +43,7 @@ impl NumericValue {
     pub(crate) fn _write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // c:v
         write_start_tag(writer, "c:v", vec![], false);
-        write_text_node(writer, &self.text);
+        write_text_node(writer, &*self.text);
         write_end_tag(writer, "c:v");
     }
 }

--- a/src/structs/drawing/charts/plot_area.rs
+++ b/src/structs/drawing/charts/plot_area.rs
@@ -26,6 +26,7 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use std::io::Cursor;
 use structs::Spreadsheet;
+use thin_vec::ThinVec;
 use traits::AdjustmentCoordinateWithSheet;
 use writer::driver::*;
 
@@ -45,9 +46,9 @@ pub struct PlotArea {
     area_chart: Option<AreaChart>,
     area_3d_chart: Option<Area3DChart>,
     of_pie_chart: Option<OfPieChart>,
-    category_axis: Vec<CategoryAxis>,
-    value_axis: Vec<ValueAxis>,
-    series_axis: Vec<SeriesAxis>,
+    category_axis: ThinVec<CategoryAxis>,
+    value_axis: ThinVec<ValueAxis>,
+    series_axis: ThinVec<SeriesAxis>,
     shape_properties: Option<ShapeProperties>,
 }
 
@@ -234,16 +235,16 @@ impl PlotArea {
         self
     }
 
-    pub fn get_category_axis(&self) -> &Vec<CategoryAxis> {
+    pub fn get_category_axis(&self) -> &[CategoryAxis] {
         &self.category_axis
     }
 
-    pub fn get_category_axis_mut(&mut self) -> &mut Vec<CategoryAxis> {
+    pub fn get_category_axis_mut(&mut self) -> &mut ThinVec<CategoryAxis> {
         &mut self.category_axis
     }
 
-    pub fn set_category_axis(&mut self, value: Vec<CategoryAxis>) -> &mut Self {
-        self.category_axis = value;
+    pub fn set_category_axis(&mut self, value: impl Into<ThinVec<CategoryAxis>>) -> &mut Self {
+        self.category_axis = value.into();
         self
     }
 
@@ -252,16 +253,16 @@ impl PlotArea {
         self
     }
 
-    pub fn get_value_axis(&self) -> &Vec<ValueAxis> {
+    pub fn get_value_axis(&self) -> &[ValueAxis] {
         &self.value_axis
     }
 
-    pub fn get_value_axis_mut(&mut self) -> &mut Vec<ValueAxis> {
+    pub fn get_value_axis_mut(&mut self) -> &mut ThinVec<ValueAxis> {
         &mut self.value_axis
     }
 
-    pub fn set_value_axis(&mut self, value: Vec<ValueAxis>) -> &mut Self {
-        self.value_axis = value;
+    pub fn set_value_axis(&mut self, value: impl Into<ThinVec<ValueAxis>>) -> &mut Self {
+        self.value_axis = value.into();
         self
     }
 
@@ -270,16 +271,16 @@ impl PlotArea {
         self
     }
 
-    pub fn get_series_axis(&self) -> &Vec<SeriesAxis> {
+    pub fn get_series_axis(&self) -> &[SeriesAxis] {
         &self.series_axis
     }
 
-    pub fn get_series_axis_mut(&mut self) -> &mut Vec<SeriesAxis> {
+    pub fn get_series_axis_mut(&mut self) -> &mut ThinVec<SeriesAxis> {
         &mut self.series_axis
     }
 
-    pub fn set_series_axis(&mut self, value: Vec<SeriesAxis>) -> &mut Self {
-        self.series_axis = value;
+    pub fn set_series_axis(&mut self, value: impl Into<ThinVec<SeriesAxis>>) -> &mut Self {
+        self.series_axis = value.into();
         self
     }
 

--- a/src/structs/drawing/charts/radar_chart.rs
+++ b/src/structs/drawing/charts/radar_chart.rs
@@ -11,6 +11,7 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -19,7 +20,7 @@ pub struct RadarChart {
     vary_colors: VaryColors,
     area_chart_series_list: AreaChartSeriesList,
     data_labels: DataLabels,
-    axis_id: Vec<AxisId>,
+    axis_id: ThinVec<AxisId>,
 }
 
 impl RadarChart {
@@ -75,16 +76,16 @@ impl RadarChart {
         self
     }
 
-    pub fn get_axis_id(&self) -> &Vec<AxisId> {
+    pub fn get_axis_id(&self) -> &[AxisId] {
         &self.axis_id
     }
 
-    pub fn get_axis_id_mut(&mut self) -> &mut Vec<AxisId> {
+    pub fn get_axis_id_mut(&mut self) -> &mut ThinVec<AxisId> {
         &mut self.axis_id
     }
 
-    pub fn set_axis_id(&mut self, value: Vec<AxisId>) -> &mut RadarChart {
-        self.axis_id = value;
+    pub fn set_axis_id(&mut self, value: impl Into<ThinVec<AxisId>>) -> &mut RadarChart {
+        self.axis_id = value.into();
         self
     }
 

--- a/src/structs/drawing/charts/rich_text.rs
+++ b/src/structs/drawing/charts/rich_text.rs
@@ -7,13 +7,14 @@ use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct RichText {
     body_properties: BodyProperties,
     list_style: ListStyle,
-    paragraph: Vec<Paragraph>,
+    paragraph: ThinVec<Paragraph>,
 }
 
 impl RichText {
@@ -41,11 +42,11 @@ impl RichText {
         self.list_style = value;
     }
 
-    pub fn get_paragraph(&self) -> &Vec<Paragraph> {
+    pub fn get_paragraph(&self) -> &[Paragraph] {
         &self.paragraph
     }
 
-    pub fn get_paragraph_mut(&mut self) -> &mut Vec<Paragraph> {
+    pub fn get_paragraph_mut(&mut self) -> &mut ThinVec<Paragraph> {
         &mut self.paragraph
     }
 

--- a/src/structs/drawing/charts/scatter_chart.rs
+++ b/src/structs/drawing/charts/scatter_chart.rs
@@ -11,6 +11,7 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::Spreadsheet;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -19,7 +20,7 @@ pub struct ScatterChart {
     vary_colors: VaryColors,
     area_chart_series_list: AreaChartSeriesList,
     data_labels: DataLabels,
-    axis_id: Vec<AxisId>,
+    axis_id: ThinVec<AxisId>,
 }
 
 impl ScatterChart {
@@ -75,16 +76,16 @@ impl ScatterChart {
         self
     }
 
-    pub fn get_axis_id(&self) -> &Vec<AxisId> {
+    pub fn get_axis_id(&self) -> &[AxisId] {
         &self.axis_id
     }
 
-    pub fn get_axis_id_mut(&mut self) -> &mut Vec<AxisId> {
+    pub fn get_axis_id_mut(&mut self) -> &mut ThinVec<AxisId> {
         &mut self.axis_id
     }
 
-    pub fn set_axis_id(&mut self, value: Vec<AxisId>) -> &mut ScatterChart {
-        self.axis_id = value;
+    pub fn set_axis_id(&mut self, value: impl Into<ThinVec<AxisId>>) -> &mut ScatterChart {
+        self.axis_id = value.into();
         self
     }
 

--- a/src/structs/drawing/charts/series_axis.rs
+++ b/src/structs/drawing/charts/series_axis.rs
@@ -23,7 +23,7 @@ pub struct SeriesAxis {
     scaling: Scaling,
     delete: Delete,
     axis_position: AxisPosition,
-    major_gridlines: Option<MajorGridlines>,
+    major_gridlines: Option<Box<MajorGridlines>>,
     title: Option<Title>,
     major_tick_mark: MajorTickMark,
     minor_tick_mark: MinorTickMark,
@@ -86,15 +86,15 @@ impl SeriesAxis {
     }
 
     pub fn get_major_gridlines(&self) -> Option<&MajorGridlines> {
-        self.major_gridlines.as_ref()
+        self.major_gridlines.as_deref()
     }
 
     pub fn get_major_gridlines_mut(&mut self) -> Option<&mut MajorGridlines> {
-        self.major_gridlines.as_mut()
+        self.major_gridlines.as_deref_mut()
     }
 
     pub fn set_major_gridlines(&mut self, value: MajorGridlines) -> &mut SeriesAxis {
-        self.major_gridlines = Some(value);
+        self.major_gridlines = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/charts/string_literal.rs
+++ b/src/structs/drawing/charts/string_literal.rs
@@ -5,19 +5,20 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct StringLiteral {
-    string_point_list: Vec<StringPoint>,
+    string_point_list: ThinVec<StringPoint>,
 }
 
 impl StringLiteral {
-    pub fn get_string_point_list(&self) -> &Vec<StringPoint> {
+    pub fn get_string_point_list(&self) -> &[StringPoint] {
         &self.string_point_list
     }
 
-    pub fn get_string_point_list_mut(&mut self) -> &mut Vec<StringPoint> {
+    pub fn get_string_point_list_mut(&mut self) -> &mut ThinVec<StringPoint> {
         &mut self.string_point_list
     }
 

--- a/src/structs/drawing/charts/text_properties.rs
+++ b/src/structs/drawing/charts/text_properties.rs
@@ -7,13 +7,14 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct TextProperties {
     body_properties: BodyProperties,
     list_style: ListStyle,
-    paragraph: Vec<Paragraph>,
+    paragraph: ThinVec<Paragraph>,
 }
 
 impl TextProperties {
@@ -43,11 +44,11 @@ impl TextProperties {
         self
     }
 
-    pub fn get_paragraph(&self) -> &Vec<Paragraph> {
+    pub fn get_paragraph(&self) -> &[Paragraph] {
         &self.paragraph
     }
 
-    pub fn get_paragraph_mut(&mut self) -> &mut Vec<Paragraph> {
+    pub fn get_paragraph_mut(&mut self) -> &mut ThinVec<Paragraph> {
         &mut self.paragraph
     }
 

--- a/src/structs/drawing/color2_type.rs
+++ b/src/structs/drawing/color2_type.rs
@@ -9,33 +9,33 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct Color2Type {
-    rgb_color_model_hex: Option<RgbColorModelHex>,
-    system_color: Option<SystemColor>,
+    rgb_color_model_hex: Option<Box<RgbColorModelHex>>,
+    system_color: Option<Box<SystemColor>>,
 }
 
 impl Color2Type {
     pub fn set_rgb_color_model_hex(&mut self, value: RgbColorModelHex) {
-        self.rgb_color_model_hex = Some(value);
+        self.rgb_color_model_hex = Some(Box::new(value));
     }
 
     pub fn get_rgb_color_model_hex(&self) -> Option<&RgbColorModelHex> {
-        self.rgb_color_model_hex.as_ref()
+        self.rgb_color_model_hex.as_deref()
     }
 
     pub fn get_rgb_color_model_hex_mut(&mut self) -> Option<&mut RgbColorModelHex> {
-        self.rgb_color_model_hex.as_mut()
+        self.rgb_color_model_hex.as_deref_mut()
     }
 
     pub fn set_system_color(&mut self, value: SystemColor) {
-        self.system_color = Some(value);
+        self.system_color = Some(Box::new(value));
     }
 
     pub fn get_system_color(&self) -> Option<&SystemColor> {
-        self.system_color.as_ref()
+        self.system_color.as_deref()
     }
 
     pub fn get_system_color_mut(&mut self) -> Option<&mut SystemColor> {
-        self.system_color.as_mut()
+        self.system_color.as_deref_mut()
     }
 
     pub fn get_val(&self) -> String {
@@ -60,12 +60,12 @@ impl Color2Type {
                 b"a:srgbClr" => {
                     let mut obj = RgbColorModelHex::default();
                     obj.set_attributes(reader, e, true);
-                    self.rgb_color_model_hex = Some(obj);
+                    self.rgb_color_model_hex = Some(Box::new(obj));
                 }
                 b"a:sysClr" => {
                     let mut obj = SystemColor::default();
                     obj.set_attributes(reader, e);
-                    self.system_color = Some(obj);
+                    self.system_color = Some(Box::new(obj));
                 }
                 _ => (),
                 }
@@ -75,12 +75,12 @@ impl Color2Type {
                 b"a:srgbClr" => {
                     let mut obj = RgbColorModelHex::default();
                     obj.set_attributes(reader, e, false);
-                    self.rgb_color_model_hex = Some(obj);
+                    self.rgb_color_model_hex = Some(Box::new(obj));
                 }
                 b"a:sysClr" => {
                     let mut obj = SystemColor::default();
                     obj.set_attributes(reader, e);
-                    self.system_color = Some(obj);
+                    self.system_color = Some(Box::new(obj));
                 }
                 _ => (),
                 }

--- a/src/structs/drawing/effect_list.rs
+++ b/src/structs/drawing/effect_list.rs
@@ -11,46 +11,46 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct EffectList {
-    glow: Option<Glow>,
-    outer_shadow: Option<OuterShadow>,
-    soft_edge: Option<SoftEdge>,
+    glow: Option<Box<Glow>>,
+    outer_shadow: Option<Box<OuterShadow>>,
+    soft_edge: Option<Box<SoftEdge>>,
 }
 
 impl EffectList {
     pub fn get_glow(&self) -> Option<&Glow> {
-        self.glow.as_ref()
+        self.glow.as_deref()
     }
 
     pub fn get_glow_mut(&mut self) -> Option<&mut Glow> {
-        self.glow.as_mut()
+        self.glow.as_deref_mut()
     }
 
     pub fn set_glow(&mut self, value: Glow) {
-        self.glow = Some(value);
+        self.glow = Some(Box::new(value));
     }
 
     pub fn get_outer_shadow(&self) -> Option<&OuterShadow> {
-        self.outer_shadow.as_ref()
+        self.outer_shadow.as_deref()
     }
 
     pub fn get_outer_shadow_mut(&mut self) -> Option<&mut OuterShadow> {
-        self.outer_shadow.as_mut()
+        self.outer_shadow.as_deref_mut()
     }
 
     pub fn set_outer_shadow(&mut self, value: OuterShadow) {
-        self.outer_shadow = Some(value);
+        self.outer_shadow = Some(Box::new(value));
     }
 
     pub fn get_soft_edge(&self) -> Option<&SoftEdge> {
-        self.soft_edge.as_ref()
+        self.soft_edge.as_deref()
     }
 
     pub fn get_soft_edge_mut(&mut self) -> Option<&mut SoftEdge> {
-        self.soft_edge.as_mut()
+        self.soft_edge.as_deref_mut()
     }
 
     pub fn set_soft_edge(&mut self, value: SoftEdge) {
-        self.soft_edge = Some(value);
+        self.soft_edge = Some(Box::new(value));
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/effect_style.rs
+++ b/src/structs/drawing/effect_style.rs
@@ -11,48 +11,48 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct EffectStyle {
-    effect_list: Option<EffectList>,
-    scene_3d_type: Option<Scene3DType>,
-    shape_3d_type: Option<Shape3DType>,
+    effect_list: Option<Box<EffectList>>,
+    scene_3d_type: Option<Box<Scene3DType>>,
+    shape_3d_type: Option<Box<Shape3DType>>,
 }
 
 impl EffectStyle {
     pub fn get_effect_list(&self) -> Option<&EffectList> {
-        self.effect_list.as_ref()
+        self.effect_list.as_deref()
     }
 
     pub fn get_effect_list_mut(&mut self) -> Option<&mut EffectList> {
-        self.effect_list.as_mut()
+        self.effect_list.as_deref_mut()
     }
 
     pub fn set_effect_list(&mut self, value: EffectList) -> &mut Self {
-        self.effect_list = Some(value);
+        self.effect_list = Some(Box::new(value));
         self
     }
 
     pub fn get_scene_3d_type(&self) -> Option<&Scene3DType> {
-        self.scene_3d_type.as_ref()
+        self.scene_3d_type.as_deref()
     }
 
     pub fn get_scene_3d_type_mut(&mut self) -> Option<&mut Scene3DType> {
-        self.scene_3d_type.as_mut()
+        self.scene_3d_type.as_deref_mut()
     }
 
     pub fn set_scene_3d_type(&mut self, value: Scene3DType) -> &mut Self {
-        self.scene_3d_type = Some(value);
+        self.scene_3d_type = Some(Box::new(value));
         self
     }
 
     pub fn get_shape_3d_type(&self) -> Option<&Shape3DType> {
-        self.shape_3d_type.as_ref()
+        self.shape_3d_type.as_deref()
     }
 
     pub fn get_shape_3d_type_mut(&mut self) -> Option<&mut Shape3DType> {
-        self.shape_3d_type.as_mut()
+        self.shape_3d_type.as_deref_mut()
     }
 
     pub fn set_shape_3d_type(&mut self, value: Shape3DType) -> &mut Self {
-        self.shape_3d_type = Some(value);
+        self.shape_3d_type = Some(Box::new(value));
         self
     }
 
@@ -68,17 +68,17 @@ impl EffectStyle {
                 b"a:effectLst" => {
                     let mut obj = EffectList::default();
                     obj.set_attributes(reader, e, false);
-                    self.effect_list = Some(obj);
+                    self.effect_list = Some(Box::new(obj));
                 }
                 b"a:scene3d" => {
                     let mut obj = Scene3DType::default();
                     obj.set_attributes(reader, e);
-                    self.scene_3d_type = Some(obj);
+                    self.scene_3d_type = Some(Box::new(obj));
                 }
                 b"a:sp3d" => {
                     let mut obj = Shape3DType::default();
                     obj.set_attributes(reader, e);
-                    self.shape_3d_type = Some(obj);
+                    self.shape_3d_type = Some(Box::new(obj));
                 }
                 _ => (),
                 }

--- a/src/structs/drawing/effect_style_list.rs
+++ b/src/structs/drawing/effect_style_list.rs
@@ -4,24 +4,28 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct EffectStyleList {
-    effect_style_collection: Vec<EffectStyle>,
+    effect_style_collection: ThinVec<EffectStyle>,
 }
 
 impl EffectStyleList {
-    pub fn get_effect_style_collection(&self) -> &Vec<EffectStyle> {
+    pub fn get_effect_style_collection(&self) -> &[EffectStyle] {
         &self.effect_style_collection
     }
 
-    pub fn get_effect_style_collection_mut(&mut self) -> &mut Vec<EffectStyle> {
+    pub fn get_effect_style_collection_mut(&mut self) -> &mut ThinVec<EffectStyle> {
         &mut self.effect_style_collection
     }
 
-    pub fn set_effect_style_collection(&mut self, value: Vec<EffectStyle>) -> &mut Self {
-        self.effect_style_collection = value;
+    pub fn set_effect_style_collection(
+        &mut self,
+        value: impl Into<ThinVec<EffectStyle>>,
+    ) -> &mut Self {
+        self.effect_style_collection = value.into();
         self
     }
 

--- a/src/structs/drawing/fill_style_list.rs
+++ b/src/structs/drawing/fill_style_list.rs
@@ -5,25 +5,26 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct FillStyleList {
-    solid_fill: Vec<SolidFill>,
-    gradient_fill_collection: Vec<GradientFill>,
+    solid_fill: ThinVec<SolidFill>,
+    gradient_fill_collection: ThinVec<GradientFill>,
 }
 
 impl FillStyleList {
-    pub fn get_solid_fill(&self) -> &Vec<SolidFill> {
+    pub fn get_solid_fill(&self) -> &[SolidFill] {
         &self.solid_fill
     }
 
-    pub fn get_solid_fill_mut(&mut self) -> &mut Vec<SolidFill> {
+    pub fn get_solid_fill_mut(&mut self) -> &mut ThinVec<SolidFill> {
         &mut self.solid_fill
     }
 
-    pub fn set_solid_fill(&mut self, value: Vec<SolidFill>) -> &mut Self {
-        self.solid_fill = value;
+    pub fn set_solid_fill(&mut self, value: impl Into<ThinVec<SolidFill>>) -> &mut Self {
+        self.solid_fill = value.into();
         self
     }
 
@@ -32,16 +33,19 @@ impl FillStyleList {
         self
     }
 
-    pub fn get_gradient_fill_collection(&self) -> &Vec<GradientFill> {
+    pub fn get_gradient_fill_collection(&self) -> &[GradientFill] {
         &self.gradient_fill_collection
     }
 
-    pub fn get_gradient_fill_collectionl_mut(&mut self) -> &mut Vec<GradientFill> {
+    pub fn get_gradient_fill_collectionl_mut(&mut self) -> &mut ThinVec<GradientFill> {
         &mut self.gradient_fill_collection
     }
 
-    pub fn set_gradient_fill_collection(&mut self, value: Vec<GradientFill>) -> &mut Self {
-        self.gradient_fill_collection = value;
+    pub fn set_gradient_fill_collection(
+        &mut self,
+        value: impl Into<ThinVec<GradientFill>>,
+    ) -> &mut Self {
+        self.gradient_fill_collection = value.into();
         self
     }
 

--- a/src/structs/drawing/font_collection_type.rs
+++ b/src/structs/drawing/font_collection_type.rs
@@ -6,6 +6,7 @@ use quick_xml::events::{BytesStart, Event};
 use quick_xml::Reader;
 use quick_xml::Writer;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -13,7 +14,7 @@ pub struct FontCollectionType {
     latin_font: TextFontType,
     east_asian_font: TextFontType,
     complex_script_font: TextFontType,
-    supplemental_font_list: Vec<SupplementalFont>,
+    supplemental_font_list: ThinVec<SupplementalFont>,
 }
 impl FontCollectionType {
     pub fn get_latin_font(&self) -> &TextFontType {
@@ -55,16 +56,19 @@ impl FontCollectionType {
         self
     }
 
-    pub fn get_supplemental_font_list(&self) -> &Vec<SupplementalFont> {
+    pub fn get_supplemental_font_list(&self) -> &[SupplementalFont] {
         &self.supplemental_font_list
     }
 
-    pub fn get_supplemental_font_list_mut(&mut self) -> &mut Vec<SupplementalFont> {
+    pub fn get_supplemental_font_list_mut(&mut self) -> &mut ThinVec<SupplementalFont> {
         &mut self.supplemental_font_list
     }
 
-    pub fn set_supplemental_font_list(&mut self, value: Vec<SupplementalFont>) -> &mut Self {
-        self.supplemental_font_list = value;
+    pub fn set_supplemental_font_list(
+        &mut self,
+        value: impl Into<ThinVec<SupplementalFont>>,
+    ) -> &mut Self {
+        self.supplemental_font_list = value.into();
         self
     }
 

--- a/src/structs/drawing/glow.rs
+++ b/src/structs/drawing/glow.rs
@@ -11,7 +11,7 @@ use writer::driver::*;
 #[derive(Clone, Default, Debug)]
 pub struct Glow {
     radius: Int64Value,
-    scheme_color: Option<SchemeColor>,
+    scheme_color: Option<Box<SchemeColor>>,
 }
 
 impl Glow {
@@ -25,11 +25,11 @@ impl Glow {
     }
 
     pub fn get_scheme_color(&self) -> Option<&SchemeColor> {
-        self.scheme_color.as_ref()
+        self.scheme_color.as_deref()
     }
 
     pub fn set_scheme_color(&mut self, value: SchemeColor) {
-        self.scheme_color = Some(value);
+        self.scheme_color = Some(Box::new(value));
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/gradient_fill.rs
+++ b/src/structs/drawing/gradient_fill.rs
@@ -17,8 +17,8 @@ pub struct GradientFill {
     flip: EnumValue<TileFlipValues>,
     rotate_with_shape: BooleanValue,
     gradient_stop_list: GradientStopList,
-    linear_gradient_fill: Option<LinearGradientFill>,
-    tile_rectangle: Option<TileRectangle>,
+    linear_gradient_fill: Option<Box<LinearGradientFill>>,
+    tile_rectangle: Option<Box<TileRectangle>>,
 }
 
 impl GradientFill {
@@ -54,28 +54,28 @@ impl GradientFill {
     }
 
     pub fn get_linear_gradient_fill(&self) -> Option<&LinearGradientFill> {
-        self.linear_gradient_fill.as_ref()
+        self.linear_gradient_fill.as_deref()
     }
 
     pub fn get_linear_gradient_fill_mut(&mut self) -> Option<&mut LinearGradientFill> {
-        self.linear_gradient_fill.as_mut()
+        self.linear_gradient_fill.as_deref_mut()
     }
 
     pub fn set_linear_gradient_fill(&mut self, value: LinearGradientFill) -> &mut GradientFill {
-        self.linear_gradient_fill = Some(value);
+        self.linear_gradient_fill = Some(Box::new(value));
         self
     }
 
     pub fn get_tile_rectangle(&self) -> Option<&TileRectangle> {
-        self.tile_rectangle.as_ref()
+        self.tile_rectangle.as_deref()
     }
 
     pub fn get_tile_rectangle_mut(&mut self) -> Option<&mut TileRectangle> {
-        self.tile_rectangle.as_mut()
+        self.tile_rectangle.as_deref_mut()
     }
 
     pub fn set_tile_rectangle(&mut self, value: TileRectangle) -> &mut GradientFill {
-        self.tile_rectangle = Some(value);
+        self.tile_rectangle = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/gradient_stop.rs
+++ b/src/structs/drawing/gradient_stop.rs
@@ -11,8 +11,8 @@ use writer::driver::*;
 #[derive(Clone, Default, Debug)]
 pub struct GradientStop {
     position: i32,
-    scheme_color: Option<SchemeColor>,
-    rgb_color_model_hex: Option<RgbColorModelHex>,
+    scheme_color: Option<Box<SchemeColor>>,
+    rgb_color_model_hex: Option<Box<RgbColorModelHex>>,
 }
 
 impl GradientStop {
@@ -26,28 +26,28 @@ impl GradientStop {
     }
 
     pub fn get_scheme_color(&self) -> Option<&SchemeColor> {
-        self.scheme_color.as_ref()
+        self.scheme_color.as_deref()
     }
 
     pub fn get_scheme_color_mut(&mut self) -> Option<&mut SchemeColor> {
-        self.scheme_color.as_mut()
+        self.scheme_color.as_deref_mut()
     }
 
     pub fn set_scheme_color(&mut self, value: SchemeColor) -> &mut GradientStop {
-        self.scheme_color = Some(value);
+        self.scheme_color = Some(Box::new(value));
         self
     }
 
     pub fn get_rgb_color_model_hex(&self) -> Option<&RgbColorModelHex> {
-        self.rgb_color_model_hex.as_ref()
+        self.rgb_color_model_hex.as_deref()
     }
 
     pub fn get_rgb_color_model_hex_mut(&mut self) -> Option<&mut RgbColorModelHex> {
-        self.rgb_color_model_hex.as_mut()
+        self.rgb_color_model_hex.as_deref_mut()
     }
 
     pub fn set_rgb_color_model_hex(&mut self, value: RgbColorModelHex) -> &mut GradientStop {
-        self.rgb_color_model_hex = Some(value);
+        self.rgb_color_model_hex = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/gradient_stop_list.rs
+++ b/src/structs/drawing/gradient_stop_list.rs
@@ -5,24 +5,28 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct GradientStopList {
-    gradient_stop: Vec<GradientStop>,
+    gradient_stop: ThinVec<GradientStop>,
 }
 
 impl GradientStopList {
-    pub fn get_gradient_stop(&self) -> &Vec<GradientStop> {
+    pub fn get_gradient_stop(&self) -> &[GradientStop] {
         &self.gradient_stop
     }
 
-    pub fn get_gradient_stop_mut(&mut self) -> &mut Vec<GradientStop> {
+    pub fn get_gradient_stop_mut(&mut self) -> &mut ThinVec<GradientStop> {
         &mut self.gradient_stop
     }
 
-    pub fn set_gradient_stop(&mut self, value: Vec<GradientStop>) -> &mut GradientStopList {
-        self.gradient_stop = value;
+    pub fn set_gradient_stop(
+        &mut self,
+        value: impl Into<ThinVec<GradientStop>>,
+    ) -> &mut GradientStopList {
+        self.gradient_stop = value.into();
         self
     }
 

--- a/src/structs/drawing/light_rig.rs
+++ b/src/structs/drawing/light_rig.rs
@@ -14,7 +14,7 @@ use writer::driver::*;
 pub struct LightRig {
     rig: EnumValue<LightRigValues>,
     definition: EnumValue<LightRigDirectionValues>,
-    rotation: Option<Rotation>,
+    rotation: Option<Box<Rotation>>,
 }
 
 impl LightRig {
@@ -37,15 +37,15 @@ impl LightRig {
     }
 
     pub fn get_rotation(&self) -> Option<&Rotation> {
-        self.rotation.as_ref()
+        self.rotation.as_deref()
     }
 
     pub fn get_rotation_mut(&mut self) -> Option<&mut Rotation> {
-        self.rotation.as_mut()
+        self.rotation.as_deref_mut()
     }
 
     pub fn set_rotation(&mut self, value: Rotation) -> &mut Self {
-        self.rotation = Some(value);
+        self.rotation = Some(Box::new(value));
         self
     }
 
@@ -68,7 +68,7 @@ impl LightRig {
                 if e.name().into_inner() == b"a:rot" {
                     let mut obj = Rotation::default();
                     obj.set_attributes(reader, e);
-                    self.rotation = Some(obj);
+                    self.rotation = Some(Box::new(obj));
                 }
             },
             Event::End(ref e) => {

--- a/src/structs/drawing/line_style_list.rs
+++ b/src/structs/drawing/line_style_list.rs
@@ -4,24 +4,25 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct LineStyleList {
-    outline_collection: Vec<Outline>,
+    outline_collection: ThinVec<Outline>,
 }
 
 impl LineStyleList {
-    pub fn get_outline_collection(&self) -> &Vec<Outline> {
+    pub fn get_outline_collection(&self) -> &[Outline] {
         &self.outline_collection
     }
 
-    pub fn get_outline_collection_mut(&mut self) -> &mut Vec<Outline> {
+    pub fn get_outline_collection_mut(&mut self) -> &mut ThinVec<Outline> {
         &mut self.outline_collection
     }
 
-    pub fn set_outline_collection(&mut self, value: Vec<Outline>) -> &mut Self {
-        self.outline_collection = value;
+    pub fn set_outline_collection(&mut self, value: impl Into<ThinVec<Outline>>) -> &mut Self {
+        self.outline_collection = value.into();
         self
     }
 

--- a/src/structs/drawing/list_style.rs
+++ b/src/structs/drawing/list_style.rs
@@ -11,32 +11,36 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct ListStyle {
-    effect_list: Option<EffectList>,
-    text_paragraph_properties_type: HashMap<String, TextParagraphPropertiesType>,
+    effect_list: Option<Box<EffectList>>,
+    text_paragraph_properties_type: HashMap<Box<str>, Box<TextParagraphPropertiesType>>,
 }
 
 impl ListStyle {
     pub fn get_effect_list(&self) -> Option<&EffectList> {
-        self.effect_list.as_ref()
+        self.effect_list.as_deref()
     }
 
     pub fn get_effect_list_mut(&mut self) -> Option<&mut EffectList> {
-        self.effect_list.as_mut()
+        self.effect_list.as_deref_mut()
     }
 
     pub fn set_effect_list(&mut self, value: EffectList) -> &mut Self {
-        self.effect_list = Some(value);
+        self.effect_list = Some(Box::new(value));
         self
     }
 
     pub fn get_default_paragraph_properties(&self) -> Option<&TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get("def")
+        self.text_paragraph_properties_type
+            .get("def")
+            .map(Box::as_ref)
     }
 
     pub fn get_default_paragraph_properties_mut(
         &mut self,
     ) -> Option<&mut TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get_mut("def")
+        self.text_paragraph_properties_type
+            .get_mut("def")
+            .map(Box::as_mut)
     }
 
     pub fn set_default_paragraph_properties(
@@ -44,18 +48,22 @@ impl ListStyle {
         value: TextParagraphPropertiesType,
     ) -> &mut Self {
         self.text_paragraph_properties_type
-            .insert(String::from("def"), value);
+            .insert(String::from("def").into_boxed_str(), Box::new(value));
         self
     }
 
     pub fn get_level1_paragraph_properties(&self) -> Option<&TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get("lv1")
+        self.text_paragraph_properties_type
+            .get("lv1")
+            .map(Box::as_ref)
     }
 
     pub fn get_level1_paragraph_properties_mut(
         &mut self,
     ) -> Option<&mut TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get_mut("lv1")
+        self.text_paragraph_properties_type
+            .get_mut("lv1")
+            .map(Box::as_mut)
     }
 
     pub fn set_level1_paragraph_properties(
@@ -63,18 +71,22 @@ impl ListStyle {
         value: TextParagraphPropertiesType,
     ) -> &mut Self {
         self.text_paragraph_properties_type
-            .insert(String::from("lv1"), value);
+            .insert(String::from("lv1").into_boxed_str(), Box::new(value));
         self
     }
 
     pub fn get_level2_paragraph_properties(&self) -> Option<&TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get("lv2")
+        self.text_paragraph_properties_type
+            .get("lv2")
+            .map(Box::as_ref)
     }
 
     pub fn get_level2_paragraph_properties_mut(
         &mut self,
     ) -> Option<&mut TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get_mut("lv2")
+        self.text_paragraph_properties_type
+            .get_mut("lv2")
+            .map(Box::as_mut)
     }
 
     pub fn set_level2_paragraph_properties(
@@ -82,18 +94,22 @@ impl ListStyle {
         value: TextParagraphPropertiesType,
     ) -> &mut Self {
         self.text_paragraph_properties_type
-            .insert(String::from("lv2"), value);
+            .insert(String::from("lv2").into_boxed_str(), Box::new(value));
         self
     }
 
     pub fn get_level3_paragraph_properties(&self) -> Option<&TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get("lv3")
+        self.text_paragraph_properties_type
+            .get("lv3")
+            .map(Box::as_ref)
     }
 
     pub fn get_level3_paragraph_properties_mut(
         &mut self,
     ) -> Option<&mut TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get_mut("lv3")
+        self.text_paragraph_properties_type
+            .get_mut("lv3")
+            .map(Box::as_mut)
     }
 
     pub fn set_level3_paragraph_properties(
@@ -101,18 +117,22 @@ impl ListStyle {
         value: TextParagraphPropertiesType,
     ) -> &mut Self {
         self.text_paragraph_properties_type
-            .insert(String::from("lv3"), value);
+            .insert(String::from("lv3").into_boxed_str(), Box::new(value));
         self
     }
 
     pub fn get_level4_paragraph_properties(&self) -> Option<&TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get("lv4")
+        self.text_paragraph_properties_type
+            .get("lv4")
+            .map(Box::as_ref)
     }
 
     pub fn get_level4_paragraph_properties_mut(
         &mut self,
     ) -> Option<&mut TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get_mut("lv4")
+        self.text_paragraph_properties_type
+            .get_mut("lv4")
+            .map(Box::as_mut)
     }
 
     pub fn set_level4_paragraph_properties(
@@ -120,18 +140,22 @@ impl ListStyle {
         value: TextParagraphPropertiesType,
     ) -> &mut Self {
         self.text_paragraph_properties_type
-            .insert(String::from("lv4"), value);
+            .insert(String::from("lv4").into_boxed_str(), Box::new(value));
         self
     }
 
     pub fn get_level5_paragraph_properties(&self) -> Option<&TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get("lv5")
+        self.text_paragraph_properties_type
+            .get("lv5")
+            .map(Box::as_ref)
     }
 
     pub fn get_level5_paragraph_properties_mut(
         &mut self,
     ) -> Option<&mut TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get_mut("lv5")
+        self.text_paragraph_properties_type
+            .get_mut("lv5")
+            .map(Box::as_mut)
     }
 
     pub fn set_level5_paragraph_properties(
@@ -139,18 +163,22 @@ impl ListStyle {
         value: TextParagraphPropertiesType,
     ) -> &mut Self {
         self.text_paragraph_properties_type
-            .insert(String::from("lv5"), value);
+            .insert(String::from("lv5").into_boxed_str(), Box::new(value));
         self
     }
 
     pub fn get_level6_paragraph_properties(&self) -> Option<&TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get("lv6")
+        self.text_paragraph_properties_type
+            .get("lv6")
+            .map(Box::as_ref)
     }
 
     pub fn get_level6_paragraph_properties_mut(
         &mut self,
     ) -> Option<&mut TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get_mut("lv6")
+        self.text_paragraph_properties_type
+            .get_mut("lv6")
+            .map(Box::as_mut)
     }
 
     pub fn set_level6_paragraph_properties(
@@ -158,18 +186,22 @@ impl ListStyle {
         value: TextParagraphPropertiesType,
     ) -> &mut Self {
         self.text_paragraph_properties_type
-            .insert(String::from("lv6"), value);
+            .insert(String::from("lv6").into_boxed_str(), Box::new(value));
         self
     }
 
     pub fn get_level7_paragraph_properties(&self) -> Option<&TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get("lv7")
+        self.text_paragraph_properties_type
+            .get("lv7")
+            .map(Box::as_ref)
     }
 
     pub fn get_level7_paragraph_properties_mut(
         &mut self,
     ) -> Option<&mut TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get_mut("lv7")
+        self.text_paragraph_properties_type
+            .get_mut("lv7")
+            .map(Box::as_mut)
     }
 
     pub fn set_level7_paragraph_properties(
@@ -177,18 +209,22 @@ impl ListStyle {
         value: TextParagraphPropertiesType,
     ) -> &mut Self {
         self.text_paragraph_properties_type
-            .insert(String::from("lv7"), value);
+            .insert(String::from("lv7").into_boxed_str(), Box::new(value));
         self
     }
 
     pub fn get_level8_paragraph_properties(&self) -> Option<&TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get("lv8")
+        self.text_paragraph_properties_type
+            .get("lv8")
+            .map(Box::as_ref)
     }
 
     pub fn get_level8_paragraph_properties_mut(
         &mut self,
     ) -> Option<&mut TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get_mut("lv8")
+        self.text_paragraph_properties_type
+            .get_mut("lv8")
+            .map(Box::as_mut)
     }
 
     pub fn set_level8_paragraph_properties(
@@ -196,18 +232,22 @@ impl ListStyle {
         value: TextParagraphPropertiesType,
     ) -> &mut Self {
         self.text_paragraph_properties_type
-            .insert(String::from("lv8"), value);
+            .insert(String::from("lv8").into_boxed_str(), Box::new(value));
         self
     }
 
     pub fn get_level9_paragraph_properties(&self) -> Option<&TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get("lv9")
+        self.text_paragraph_properties_type
+            .get("lv9")
+            .map(Box::as_ref)
     }
 
     pub fn get_level9_paragraph_properties_mut(
         &mut self,
     ) -> Option<&mut TextParagraphPropertiesType> {
-        self.text_paragraph_properties_type.get_mut("lv9")
+        self.text_paragraph_properties_type
+            .get_mut("lv9")
+            .map(Box::as_mut)
     }
 
     pub fn set_level9_paragraph_properties(
@@ -215,7 +255,7 @@ impl ListStyle {
         value: TextParagraphPropertiesType,
     ) -> &mut Self {
         self.text_paragraph_properties_type
-            .insert(String::from("lv9"), value);
+            .insert(String::from("lv9").into_boxed_str(), Box::new(value));
         self
     }
 

--- a/src/structs/drawing/outer_shadow.rs
+++ b/src/structs/drawing/outer_shadow.rs
@@ -19,9 +19,9 @@ pub struct OuterShadow {
     direction: StringValue,
     distance: StringValue,
     rotate_with_shape: StringValue,
-    preset_color: Option<PresetColor>,
-    scheme_color: Option<SchemeColor>,
-    rgb_color_model_hex: Option<RgbColorModelHex>,
+    preset_color: Option<Box<PresetColor>>,
+    scheme_color: Option<Box<SchemeColor>>,
+    rgb_color_model_hex: Option<Box<RgbColorModelHex>>,
 }
 
 impl OuterShadow {
@@ -89,41 +89,41 @@ impl OuterShadow {
     }
 
     pub fn get_preset_color(&self) -> Option<&PresetColor> {
-        self.preset_color.as_ref()
+        self.preset_color.as_deref()
     }
 
     pub fn get_preset_color_mut(&mut self) -> Option<&mut PresetColor> {
-        self.preset_color.as_mut()
+        self.preset_color.as_deref_mut()
     }
 
     pub fn set_preset_color(&mut self, value: PresetColor) -> &mut Self {
-        self.preset_color = Some(value);
+        self.preset_color = Some(Box::new(value));
         self
     }
 
     pub fn get_scheme_color(&self) -> Option<&SchemeColor> {
-        self.scheme_color.as_ref()
+        self.scheme_color.as_deref()
     }
 
     pub fn get_scheme_color_mut(&mut self) -> Option<&mut SchemeColor> {
-        self.scheme_color.as_mut()
+        self.scheme_color.as_deref_mut()
     }
 
     pub fn set_scheme_color(&mut self, value: SchemeColor) -> &mut Self {
-        self.scheme_color = Some(value);
+        self.scheme_color = Some(Box::new(value));
         self
     }
 
     pub fn get_rgb_color_model_hex(&self) -> Option<&RgbColorModelHex> {
-        self.rgb_color_model_hex.as_ref()
+        self.rgb_color_model_hex.as_deref()
     }
 
     pub fn get_rgb_color_model_hex_mut(&mut self) -> Option<&mut RgbColorModelHex> {
-        self.rgb_color_model_hex.as_mut()
+        self.rgb_color_model_hex.as_deref_mut()
     }
 
     pub fn set_rgb_color_model_hex(&mut self, value: RgbColorModelHex) -> &mut Self {
-        self.rgb_color_model_hex = Some(value);
+        self.rgb_color_model_hex = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/outline.rs
+++ b/src/structs/drawing/outline.rs
@@ -23,11 +23,11 @@ pub struct Outline {
     width: UInt32Value,
     cap_type: StringValue,
     compound_line_type: StringValue,
-    solid_fill: Option<SolidFill>,
-    gradient_fill: Option<GradientFill>,
-    tail_end: Option<TailEnd>,
+    solid_fill: Option<Box<SolidFill>>,
+    gradient_fill: Option<Box<GradientFill>>,
+    tail_end: Option<Box<TailEnd>>,
     no_fill: Option<NoFill>,
-    bevel: Option<Bevel>,
+    bevel: Option<Box<Bevel>>,
     preset_dash: Option<PresetDash>,
     miter: Option<Miter>,
     round: Option<Round>,
@@ -63,41 +63,41 @@ impl Outline {
     }
 
     pub fn get_solid_fill(&self) -> Option<&SolidFill> {
-        self.solid_fill.as_ref()
+        self.solid_fill.as_deref()
     }
 
     pub fn get_solid_fill_mut(&mut self) -> Option<&mut SolidFill> {
-        self.solid_fill.as_mut()
+        self.solid_fill.as_deref_mut()
     }
 
     pub fn set_solid_fill(&mut self, value: SolidFill) -> &mut Self {
-        self.solid_fill = Some(value);
+        self.solid_fill = Some(Box::new(value));
         self
     }
 
     pub fn get_gradient_fill(&self) -> Option<&GradientFill> {
-        self.gradient_fill.as_ref()
+        self.gradient_fill.as_deref()
     }
 
     pub fn get_gradient_fill_mut(&mut self) -> Option<&mut GradientFill> {
-        self.gradient_fill.as_mut()
+        self.gradient_fill.as_deref_mut()
     }
 
     pub fn set_gradient_fill(&mut self, value: GradientFill) -> &mut Self {
-        self.gradient_fill = Some(value);
+        self.gradient_fill = Some(Box::new(value));
         self
     }
 
     pub fn get_tail_end(&self) -> Option<&TailEnd> {
-        self.tail_end.as_ref()
+        self.tail_end.as_deref()
     }
 
     pub fn get_tail_end_mut(&mut self) -> Option<&mut TailEnd> {
-        self.tail_end.as_mut()
+        self.tail_end.as_deref_mut()
     }
 
     pub fn set_tail_end(&mut self, value: TailEnd) -> &mut Self {
-        self.tail_end = Some(value);
+        self.tail_end = Some(Box::new(value));
         self
     }
 
@@ -115,15 +115,15 @@ impl Outline {
     }
 
     pub fn get_bevel(&self) -> Option<&Bevel> {
-        self.bevel.as_ref()
+        self.bevel.as_deref()
     }
 
     pub fn get_bevel_mut(&mut self) -> Option<&mut Bevel> {
-        self.bevel.as_mut()
+        self.bevel.as_deref_mut()
     }
 
     pub fn set_bevel(&mut self, value: Bevel) -> &mut Self {
-        self.bevel = Some(value);
+        self.bevel = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/paragraph.rs
+++ b/src/structs/drawing/paragraph.rs
@@ -7,13 +7,14 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct Paragraph {
     paragraph_properties: ParagraphProperties,
-    run: Vec<Run>,
-    end_para_run_properties: Option<RunProperties>,
+    run: ThinVec<Run>,
+    end_para_run_properties: Option<Box<RunProperties>>,
 }
 
 impl Paragraph {
@@ -30,7 +31,7 @@ impl Paragraph {
         self
     }
 
-    pub fn get_run(&self) -> &Vec<Run> {
+    pub fn get_run(&self) -> &[Run] {
         &self.run
     }
 
@@ -39,15 +40,15 @@ impl Paragraph {
     }
 
     pub fn get_end_para_run_properties(&self) -> Option<&RunProperties> {
-        self.end_para_run_properties.as_ref()
+        self.end_para_run_properties.as_deref()
     }
 
     pub fn get_end_para_run_properties_mut(&mut self) -> Option<&mut RunProperties> {
-        self.end_para_run_properties.as_mut()
+        self.end_para_run_properties.as_deref_mut()
     }
 
     pub fn set_end_para_run_properties(&mut self, value: RunProperties) -> &mut Paragraph {
-        self.end_para_run_properties = Some(value);
+        self.end_para_run_properties = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/paragraph_properties.rs
+++ b/src/structs/drawing/paragraph_properties.rs
@@ -15,7 +15,7 @@ use writer::driver::*;
 pub struct ParagraphProperties {
     right_to_left: StringValue,
     alignment: EnumValue<TextAlignmentTypeValues>,
-    default_run_properties: Option<RunProperties>,
+    default_run_properties: Option<Box<RunProperties>>,
     line_spacing: Option<LineSpacing>,
 }
 
@@ -39,15 +39,15 @@ impl ParagraphProperties {
     }
 
     pub fn get_default_run_properties(&self) -> Option<&RunProperties> {
-        self.default_run_properties.as_ref()
+        self.default_run_properties.as_deref()
     }
 
     pub fn get_default_run_properties_mut(&mut self) -> Option<&mut RunProperties> {
-        self.default_run_properties.as_mut()
+        self.default_run_properties.as_deref_mut()
     }
 
     pub fn set_default_run_properties(&mut self, value: RunProperties) -> &mut ParagraphProperties {
-        self.default_run_properties = Some(value);
+        self.default_run_properties = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/pattern_fill.rs
+++ b/src/structs/drawing/pattern_fill.rs
@@ -10,7 +10,7 @@ use writer::driver::*;
 
 #[derive(Clone, Debug)]
 pub struct PatternFill {
-    preset: String,
+    preset: Box<str>,
     foreground_color: ForegroundColor,
     background_color: BackgroundColor,
 }
@@ -27,11 +27,11 @@ impl Default for PatternFill {
 
 impl PatternFill {
     pub fn get_preset(&self) -> &str {
-        self.preset.as_str()
+        &self.preset
     }
 
     pub fn set_preset(&mut self, value: String) -> &mut PatternFill {
-        self.preset = value;
+        self.preset = value.into_boxed_str();
         self
     }
 

--- a/src/structs/drawing/preset_color.rs
+++ b/src/structs/drawing/preset_color.rs
@@ -9,7 +9,7 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct PresetColor {
-    val: String,
+    val: Box<str>,
     alpha: Option<Alpha>,
 }
 
@@ -19,7 +19,7 @@ impl PresetColor {
     }
 
     pub fn set_val<S: Into<String>>(&mut self, value: S) {
-        self.val = value.into();
+        self.val = value.into().into_boxed_str();
     }
 
     pub fn get_alpha(&self) -> Option<&Alpha> {

--- a/src/structs/drawing/preset_geometry.rs
+++ b/src/structs/drawing/preset_geometry.rs
@@ -9,7 +9,7 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct PresetGeometry {
-    geometry: String,
+    geometry: Box<str>,
     adjust_value_list: AdjustValueList,
 }
 
@@ -208,7 +208,7 @@ impl PresetGeometry {
     }
 
     pub fn set_geometry<S: Into<String>>(&mut self, value: S) {
-        self.geometry = value.into();
+        self.geometry = value.into().into_boxed_str();
     }
 
     pub fn get_adjust_value_list(&self) -> &AdjustValueList {

--- a/src/structs/drawing/run.rs
+++ b/src/structs/drawing/run.rs
@@ -8,7 +8,7 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct Run {
-    text: String,
+    text: Box<str>,
     run_properties: RunProperties,
 }
 
@@ -18,7 +18,7 @@ impl Run {
     }
 
     pub fn set_text<S: Into<String>>(&mut self, value: S) {
-        self.text = value.into();
+        self.text = value.into().into_boxed_str();
     }
 
     pub fn get_run_properties(&self) -> &RunProperties {
@@ -71,7 +71,7 @@ impl Run {
 
         // a:t
         write_start_tag(writer, "a:t", vec![], false);
-        write_text_node(writer, &self.text);
+        write_text_node(writer, &*self.text);
         write_end_tag(writer, "a:t");
 
         write_end_tag(writer, "a:r");

--- a/src/structs/drawing/run_properties.rs
+++ b/src/structs/drawing/run_properties.rs
@@ -17,7 +17,7 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct RunProperties {
-    text: String,
+    text: Box<str>,
     kumimoji: StringValue,
     language: StringValue,
     alternative_language: StringValue,
@@ -27,13 +27,13 @@ pub struct RunProperties {
     capital: EnumValue<TextCapsValues>,
     spacing: Int32Value,
     strike: StringValue,
-    outline: Option<Outline>,
-    solid_fill: Option<SolidFill>,
-    latin_font: Option<TextFontType>,
-    east_asian_font: Option<TextFontType>,
-    gradient_fill: Option<GradientFill>,
+    outline: Option<Box<Outline>>,
+    solid_fill: Option<Box<SolidFill>>,
+    latin_font: Option<Box<TextFontType>>,
+    east_asian_font: Option<Box<TextFontType>>,
+    gradient_fill: Option<Box<GradientFill>>,
     no_fill: Option<NoFill>,
-    effect_list: Option<EffectList>,
+    effect_list: Option<Box<EffectList>>,
 }
 
 impl RunProperties {
@@ -42,7 +42,7 @@ impl RunProperties {
     }
 
     pub fn set_text<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.text = value.into();
+        self.text = value.into().into_boxed_str();
         self
     }
 
@@ -128,67 +128,67 @@ impl RunProperties {
     }
 
     pub fn get_solid_fill(&self) -> Option<&SolidFill> {
-        self.solid_fill.as_ref()
+        self.solid_fill.as_deref()
     }
 
     pub fn get_solid_fill_mut(&mut self) -> Option<&mut SolidFill> {
-        self.solid_fill.as_mut()
+        self.solid_fill.as_deref_mut()
     }
 
     pub fn set_solid_fill(&mut self, value: SolidFill) -> &mut Self {
-        self.solid_fill = Some(value);
+        self.solid_fill = Some(Box::new(value));
         self
     }
 
     pub fn get_outline(&self) -> Option<&Outline> {
-        self.outline.as_ref()
+        self.outline.as_deref()
     }
 
     pub fn get_outline_mut(&mut self) -> Option<&mut Outline> {
-        self.outline.as_mut()
+        self.outline.as_deref_mut()
     }
 
     pub fn set_outline(&mut self, value: Outline) -> &mut Self {
-        self.outline = Some(value);
+        self.outline = Some(Box::new(value));
         self
     }
 
     pub fn get_latin_font(&self) -> Option<&TextFontType> {
-        self.latin_font.as_ref()
+        self.latin_font.as_deref()
     }
 
     pub fn get_latin_font_mut(&mut self) -> Option<&mut TextFontType> {
-        self.latin_font.as_mut()
+        self.latin_font.as_deref_mut()
     }
 
     pub fn set_latin_font(&mut self, value: TextFontType) -> &mut Self {
-        self.latin_font = Some(value);
+        self.latin_font = Some(Box::new(value));
         self
     }
 
     pub fn get_east_asian_font(&self) -> Option<&TextFontType> {
-        self.east_asian_font.as_ref()
+        self.east_asian_font.as_deref()
     }
 
     pub fn get_east_asian_font_mut(&mut self) -> Option<&mut TextFontType> {
-        self.east_asian_font.as_mut()
+        self.east_asian_font.as_deref_mut()
     }
 
     pub fn set_east_asian_font(&mut self, value: TextFontType) -> &mut Self {
-        self.east_asian_font = Some(value);
+        self.east_asian_font = Some(Box::new(value));
         self
     }
 
     pub fn get_gradient_fill(&self) -> Option<&GradientFill> {
-        self.gradient_fill.as_ref()
+        self.gradient_fill.as_deref()
     }
 
     pub fn get_gradient_fill_mut(&mut self) -> Option<&mut GradientFill> {
-        self.gradient_fill.as_mut()
+        self.gradient_fill.as_deref_mut()
     }
 
     pub fn set_gradient_fill(&mut self, value: GradientFill) -> &mut Self {
-        self.gradient_fill = Some(value);
+        self.gradient_fill = Some(Box::new(value));
         self
     }
 
@@ -206,15 +206,15 @@ impl RunProperties {
     }
 
     pub fn get_effect_list(&self) -> Option<&EffectList> {
-        self.effect_list.as_ref()
+        self.effect_list.as_deref()
     }
 
     pub fn get_effect_list_mut(&mut self) -> Option<&mut EffectList> {
-        self.effect_list.as_mut()
+        self.effect_list.as_deref_mut()
     }
 
     pub fn set_effect_list(&mut self, value: EffectList) -> &mut Self {
-        self.effect_list = Some(value);
+        self.effect_list = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/shape_3d_type.rs
+++ b/src/structs/drawing/shape_3d_type.rs
@@ -13,8 +13,8 @@ use writer::driver::*;
 #[derive(Clone, Default, Debug)]
 pub struct Shape3DType {
     preset_material: EnumValue<PresetMaterialTypeValues>,
-    bevel_top: Option<BevelTop>,
-    bevel_bottom: Option<BevelBottom>,
+    bevel_top: Option<Box<BevelTop>>,
+    bevel_bottom: Option<Box<BevelBottom>>,
 }
 
 impl Shape3DType {
@@ -28,27 +28,27 @@ impl Shape3DType {
     }
 
     pub fn get_bevel_top(&self) -> Option<&BevelTop> {
-        self.bevel_top.as_ref()
+        self.bevel_top.as_deref()
     }
 
     pub fn get_bevel_top_mut(&mut self) -> Option<&mut BevelTop> {
-        self.bevel_top.as_mut()
+        self.bevel_top.as_deref_mut()
     }
 
     pub fn set_bevel_top(&mut self, value: BevelTop) {
-        self.bevel_top = Some(value);
+        self.bevel_top = Some(Box::new(value));
     }
 
     pub fn get_bevel_bottom(&self) -> Option<&BevelBottom> {
-        self.bevel_bottom.as_ref()
+        self.bevel_bottom.as_deref()
     }
 
     pub fn get_bevel_bottom_mut(&mut self) -> Option<&mut BevelBottom> {
-        self.bevel_bottom.as_mut()
+        self.bevel_bottom.as_deref_mut()
     }
 
     pub fn set_bevel_bottom(&mut self, value: BevelBottom) {
-        self.bevel_bottom = Some(value);
+        self.bevel_bottom = Some(Box::new(value));
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/shape_guide.rs
+++ b/src/structs/drawing/shape_guide.rs
@@ -5,8 +5,8 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct ShapeGuide {
-    name: String,
-    fmla: String,
+    name: Box<str>,
+    fmla: Box<str>,
 }
 impl ShapeGuide {
     pub fn get_name(&self) -> &str {
@@ -14,7 +14,7 @@ impl ShapeGuide {
     }
 
     pub fn set_name<S: Into<String>>(&mut self, value: S) {
-        self.name = value.into();
+        self.name = value.into().into_boxed_str();
     }
 
     pub fn get_fmla(&self) -> &str {
@@ -22,7 +22,7 @@ impl ShapeGuide {
     }
 
     pub fn set_fmla<S: Into<String>>(&mut self, value: S) {
-        self.fmla = value.into();
+        self.fmla = value.into().into_boxed_str();
     }
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {

--- a/src/structs/drawing/solid_fill.rs
+++ b/src/structs/drawing/solid_fill.rs
@@ -10,33 +10,33 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct SolidFill {
-    scheme_color: Option<SchemeColor>,
-    rgb_color_model_hex: Option<RgbColorModelHex>,
+    scheme_color: Option<Box<SchemeColor>>,
+    rgb_color_model_hex: Option<Box<RgbColorModelHex>>,
 }
 
 impl SolidFill {
     pub fn get_scheme_color(&self) -> Option<&SchemeColor> {
-        self.scheme_color.as_ref()
+        self.scheme_color.as_deref()
     }
 
     pub fn get_scheme_color_mut(&mut self) -> Option<&mut SchemeColor> {
-        self.scheme_color.as_mut()
+        self.scheme_color.as_deref_mut()
     }
 
     pub fn set_scheme_color(&mut self, value: SchemeColor) {
-        self.scheme_color = Some(value);
+        self.scheme_color = Some(Box::new(value));
     }
 
     pub fn get_rgb_color_model_hex(&self) -> Option<&RgbColorModelHex> {
-        self.rgb_color_model_hex.as_ref()
+        self.rgb_color_model_hex.as_deref()
     }
 
     pub fn get_rgb_color_model_hex_mut(&mut self) -> Option<&mut RgbColorModelHex> {
-        self.rgb_color_model_hex.as_mut()
+        self.rgb_color_model_hex.as_deref_mut()
     }
 
     pub fn set_rgb_color_model_hex(&mut self, value: RgbColorModelHex) {
-        self.rgb_color_model_hex = Some(value);
+        self.rgb_color_model_hex = Some(Box::new(value));
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/spreadsheet/blip_fill.rs
+++ b/src/structs/drawing/spreadsheet/blip_fill.rs
@@ -15,7 +15,7 @@ use writer::driver::*;
 pub struct BlipFill {
     rotate_with_shape: BooleanValue,
     blip: Blip,
-    source_rectangle: Option<SourceRectangle>,
+    source_rectangle: Option<Box<SourceRectangle>>,
     stretch: Stretch,
 }
 
@@ -30,15 +30,15 @@ impl BlipFill {
     }
 
     pub fn get_source_rectangle(&self) -> Option<&SourceRectangle> {
-        self.source_rectangle.as_ref()
+        self.source_rectangle.as_deref()
     }
 
     pub fn get_source_rectangle_mut(&mut self) -> Option<&mut SourceRectangle> {
-        self.source_rectangle.as_mut()
+        self.source_rectangle.as_deref_mut()
     }
 
     pub fn set_source_rectangle(&mut self, value: SourceRectangle) -> &mut BlipFill {
-        self.source_rectangle = Some(value);
+        self.source_rectangle = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/spreadsheet/group_shape.rs
+++ b/src/structs/drawing/spreadsheet/group_shape.rs
@@ -9,14 +9,15 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::raw::RawRelationships;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct GroupShape {
     non_visual_group_shape_properties: NonVisualGroupShapeProperties,
     group_shape_properties: GroupShapeProperties,
-    picture_collection: Vec<Picture>,
-    shape_collection: Vec<Shape>,
+    picture_collection: ThinVec<Picture>,
+    shape_collection: ThinVec<Shape>,
 }
 
 impl GroupShape {
@@ -46,11 +47,11 @@ impl GroupShape {
         self.group_shape_properties = value;
     }
 
-    pub fn get_picture_collection(&self) -> &Vec<Picture> {
+    pub fn get_picture_collection(&self) -> &[Picture] {
         &self.picture_collection
     }
 
-    pub fn get_picture_collection_mut(&mut self) -> &mut Vec<Picture> {
+    pub fn get_picture_collection_mut(&mut self) -> &mut ThinVec<Picture> {
         &mut self.picture_collection
     }
 
@@ -58,11 +59,11 @@ impl GroupShape {
         self.picture_collection.push(value);
     }
 
-    pub fn get_shape_collection(&self) -> &Vec<Shape> {
+    pub fn get_shape_collection(&self) -> &[Shape] {
         &self.shape_collection
     }
 
-    pub fn get_shape_collection_mut(&mut self) -> &mut Vec<Shape> {
+    pub fn get_shape_collection_mut(&mut self) -> &mut ThinVec<Shape> {
         &mut self.shape_collection
     }
 

--- a/src/structs/drawing/spreadsheet/non_visual_connector_shape_drawing_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_connector_shape_drawing_properties.rs
@@ -10,17 +10,17 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct NonVisualConnectorShapeDrawingProperties {
-    start_connection: Option<StartConnection>,
-    end_connection: Option<EndConnection>,
+    start_connection: Option<Box<StartConnection>>,
+    end_connection: Option<Box<EndConnection>>,
 }
 
 impl NonVisualConnectorShapeDrawingProperties {
     pub fn get_start_connection(&self) -> Option<&StartConnection> {
-        self.start_connection.as_ref()
+        self.start_connection.as_deref()
     }
 
     pub fn set_start_connection(&mut self, value: StartConnection) {
-        self.start_connection = Some(value);
+        self.start_connection = Some(Box::new(value));
     }
 
     pub fn remove_start_connection(&mut self) {
@@ -28,11 +28,11 @@ impl NonVisualConnectorShapeDrawingProperties {
     }
 
     pub fn get_end_connection(&self) -> Option<&EndConnection> {
-        self.end_connection.as_ref()
+        self.end_connection.as_deref()
     }
 
     pub fn set_end_connection(&mut self, value: EndConnection) {
-        self.end_connection = Some(value);
+        self.end_connection = Some(Box::new(value));
     }
 
     pub fn remove_end_connection(&mut self) {

--- a/src/structs/drawing/spreadsheet/one_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/one_cell_anchor.rs
@@ -17,9 +17,9 @@ use writer::driver::*;
 pub struct OneCellAnchor {
     from_marker: MarkerType,
     extent: Extent,
-    group_shape: Option<GroupShape>,
-    shape: Option<Shape>,
-    picture: Option<Picture>,
+    group_shape: Option<Box<GroupShape>>,
+    shape: Option<Box<Shape>>,
+    picture: Option<Box<Picture>>,
 }
 
 impl OneCellAnchor {
@@ -50,41 +50,41 @@ impl OneCellAnchor {
     }
 
     pub fn get_group_shape(&self) -> Option<&GroupShape> {
-        self.group_shape.as_ref()
+        self.group_shape.as_deref()
     }
 
     pub fn get_group_shape_mut(&mut self) -> Option<&mut GroupShape> {
-        self.group_shape.as_mut()
+        self.group_shape.as_deref_mut()
     }
 
     pub fn set_group_shape(&mut self, value: GroupShape) -> &mut Self {
-        self.group_shape = Some(value);
+        self.group_shape = Some(Box::new(value));
         self
     }
 
     pub fn get_shape(&self) -> Option<&Shape> {
-        self.shape.as_ref()
+        self.shape.as_deref()
     }
 
     pub fn get_shape_mut(&mut self) -> Option<&mut Shape> {
-        self.shape.as_mut()
+        self.shape.as_deref_mut()
     }
 
     pub fn set_shape(&mut self, value: Shape) -> &mut OneCellAnchor {
-        self.shape = Some(value);
+        self.shape = Some(Box::new(value));
         self
     }
 
     pub fn get_picture(&self) -> Option<&Picture> {
-        self.picture.as_ref()
+        self.picture.as_deref()
     }
 
     pub fn get_picture_mut(&mut self) -> Option<&mut Picture> {
-        self.picture.as_mut()
+        self.picture.as_deref_mut()
     }
 
     pub fn set_picture(&mut self, value: Picture) -> &mut Self {
-        self.picture = Some(value);
+        self.picture = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/spreadsheet/shape.rs
+++ b/src/structs/drawing/spreadsheet/shape.rs
@@ -17,8 +17,8 @@ pub struct Shape {
     anchor: Anchor,
     non_visual_shape_properties: NonVisualShapeProperties,
     shape_properties: ShapeProperties,
-    shape_style: Option<ShapeStyle>,
-    text_body: Option<TextBody>,
+    shape_style: Option<Box<ShapeStyle>>,
+    text_body: Option<Box<TextBody>>,
 }
 
 impl Shape {
@@ -59,27 +59,27 @@ impl Shape {
     }
 
     pub fn get_shape_style(&self) -> Option<&ShapeStyle> {
-        self.shape_style.as_ref()
+        self.shape_style.as_deref()
     }
 
     pub fn get_shape_style_mut(&mut self) -> Option<&mut ShapeStyle> {
-        self.shape_style.as_mut()
+        self.shape_style.as_deref_mut()
     }
 
     pub fn set_shape_style(&mut self, value: ShapeStyle) {
-        self.shape_style = Some(value);
+        self.shape_style = Some(Box::new(value));
     }
 
     pub fn get_text_body(&self) -> Option<&TextBody> {
-        self.text_body.as_ref()
+        self.text_body.as_deref()
     }
 
     pub fn get_text_body_mut(&mut self) -> Option<&mut TextBody> {
-        self.text_body.as_mut()
+        self.text_body.as_deref_mut()
     }
 
     pub fn set_text_body(&mut self, value: TextBody) {
-        self.text_body = Some(value);
+        self.text_body = Some(Box::new(value));
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/spreadsheet/shape_properties.rs
+++ b/src/structs/drawing/spreadsheet/shape_properties.rs
@@ -17,26 +17,26 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct ShapeProperties {
-    transform2d: Option<Transform2D>,
+    transform2d: Option<Box<Transform2D>>,
     preset_geometry: PresetGeometry,
-    blip_fill: Option<BlipFill>,
-    solid_fill: Option<SolidFill>,
-    outline: Option<Outline>,
-    effect_list: Option<EffectList>,
+    blip_fill: Option<Box<BlipFill>>,
+    solid_fill: Option<Box<SolidFill>>,
+    outline: Option<Box<Outline>>,
+    effect_list: Option<Box<EffectList>>,
     no_fill: Option<NoFill>,
     extension_list: Option<ExtensionList>,
 }
 impl ShapeProperties {
     pub fn get_transform2d(&self) -> Option<&Transform2D> {
-        self.transform2d.as_ref()
+        self.transform2d.as_deref()
     }
 
     pub fn get_transform2d_mut(&mut self) -> Option<&mut Transform2D> {
-        self.transform2d.as_mut()
+        self.transform2d.as_deref_mut()
     }
 
     pub fn set_transform2d(&mut self, value: Transform2D) -> &mut Self {
-        self.transform2d = Some(value);
+        self.transform2d = Some(Box::new(value));
         self
     }
 
@@ -54,54 +54,54 @@ impl ShapeProperties {
     }
 
     pub fn get_blip_fill(&self) -> Option<&BlipFill> {
-        self.blip_fill.as_ref()
+        self.blip_fill.as_deref()
     }
 
     pub fn get_blip_fill_mut(&mut self) -> Option<&mut BlipFill> {
-        self.blip_fill.as_mut()
+        self.blip_fill.as_deref_mut()
     }
 
     pub fn set_blip_fill(&mut self, value: BlipFill) -> &mut Self {
-        self.blip_fill = Some(value);
+        self.blip_fill = Some(Box::new(value));
         self
     }
 
     pub fn get_solid_fill(&self) -> Option<&SolidFill> {
-        self.solid_fill.as_ref()
+        self.solid_fill.as_deref()
     }
 
     pub fn get_solid_fill_mut(&mut self) -> Option<&mut SolidFill> {
-        self.solid_fill.as_mut()
+        self.solid_fill.as_deref_mut()
     }
 
     pub fn set_solid_fill(&mut self, value: SolidFill) -> &mut Self {
-        self.solid_fill = Some(value);
+        self.solid_fill = Some(Box::new(value));
         self
     }
 
     pub fn get_outline(&self) -> Option<&Outline> {
-        self.outline.as_ref()
+        self.outline.as_deref()
     }
 
     pub fn get_outline_mut(&mut self) -> Option<&mut Outline> {
-        self.outline.as_mut()
+        self.outline.as_deref_mut()
     }
 
     pub fn set_outline(&mut self, value: Outline) -> &mut Self {
-        self.outline = Some(value);
+        self.outline = Some(Box::new(value));
         self
     }
 
     pub fn get_effect_list(&self) -> Option<&EffectList> {
-        self.effect_list.as_ref()
+        self.effect_list.as_deref()
     }
 
     pub fn get_effect_list_mut(&mut self) -> Option<&mut EffectList> {
-        self.effect_list.as_mut()
+        self.effect_list.as_deref_mut()
     }
 
     pub fn set_effect_list(&mut self, value: EffectList) -> &mut Self {
-        self.effect_list = Some(value);
+        self.effect_list = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/spreadsheet/shape_style.rs
+++ b/src/structs/drawing/spreadsheet/shape_style.rs
@@ -9,43 +9,43 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct ShapeStyle {
-    line_reference: Option<StyleMatrixReferenceType>,
-    fill_reference: Option<StyleMatrixReferenceType>,
-    effect_reference: Option<StyleMatrixReferenceType>,
-    font_reference: Option<StyleMatrixReferenceType>,
+    line_reference: Option<Box<StyleMatrixReferenceType>>,
+    fill_reference: Option<Box<StyleMatrixReferenceType>>,
+    effect_reference: Option<Box<StyleMatrixReferenceType>>,
+    font_reference: Option<Box<StyleMatrixReferenceType>>,
 }
 
 impl ShapeStyle {
     pub fn get_line_reference(&self) -> Option<&StyleMatrixReferenceType> {
-        self.line_reference.as_ref()
+        self.line_reference.as_deref()
     }
 
     pub fn set_line_reference(&mut self, value: StyleMatrixReferenceType) {
-        self.line_reference = Some(value);
+        self.line_reference = Some(Box::new(value));
     }
 
     pub fn get_fill_reference(&self) -> Option<&StyleMatrixReferenceType> {
-        self.fill_reference.as_ref()
+        self.fill_reference.as_deref()
     }
 
     pub fn set_fill_reference(&mut self, value: StyleMatrixReferenceType) {
-        self.fill_reference = Some(value);
+        self.fill_reference = Some(Box::new(value));
     }
 
     pub fn get_effect_reference(&self) -> Option<&StyleMatrixReferenceType> {
-        self.effect_reference.as_ref()
+        self.effect_reference.as_deref()
     }
 
     pub fn set_effect_reference(&mut self, value: StyleMatrixReferenceType) {
-        self.effect_reference = Some(value);
+        self.effect_reference = Some(Box::new(value));
     }
 
     pub fn get_font_reference(&self) -> Option<&StyleMatrixReferenceType> {
-        self.font_reference.as_ref()
+        self.font_reference.as_deref()
     }
 
     pub fn set_font_reference(&mut self, value: StyleMatrixReferenceType) {
-        self.font_reference = Some(value);
+        self.font_reference = Some(Box::new(value));
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/spreadsheet/text_body.rs
+++ b/src/structs/drawing/spreadsheet/text_body.rs
@@ -6,13 +6,14 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct TextBody {
     body_properties: BodyProperties,
     list_style: ListStyle,
-    paragraph: Vec<Paragraph>,
+    paragraph: ThinVec<Paragraph>,
 }
 
 impl TextBody {
@@ -40,11 +41,11 @@ impl TextBody {
         self.list_style = value;
     }
 
-    pub fn get_paragraph(&self) -> &Vec<Paragraph> {
+    pub fn get_paragraph(&self) -> &[Paragraph] {
         &self.paragraph
     }
 
-    pub fn get_paragraph_mut(&mut self) -> &mut Vec<Paragraph> {
+    pub fn get_paragraph_mut(&mut self) -> &mut ThinVec<Paragraph> {
         &mut self.paragraph
     }
 

--- a/src/structs/drawing/spreadsheet/two_cell_anchor.rs
+++ b/src/structs/drawing/spreadsheet/two_cell_anchor.rs
@@ -25,11 +25,11 @@ pub struct TwoCellAnchor {
     edit_as: EnumValue<EditAsValues>,
     from_marker: MarkerType,
     to_marker: MarkerType,
-    group_shape: Option<GroupShape>,
-    graphic_frame: Option<GraphicFrame>,
-    shape: Option<Shape>,
-    connection_shape: Option<ConnectionShape>,
-    picture: Option<Picture>,
+    group_shape: Option<Box<GroupShape>>,
+    graphic_frame: Option<Box<GraphicFrame>>,
+    shape: Option<Box<Shape>>,
+    connection_shape: Option<Box<ConnectionShape>>,
+    picture: Option<Box<Picture>>,
     is_alternate_content: BooleanValue,
 }
 
@@ -70,67 +70,67 @@ impl TwoCellAnchor {
     }
 
     pub fn get_group_shape(&self) -> Option<&GroupShape> {
-        self.group_shape.as_ref()
+        self.group_shape.as_deref()
     }
 
     pub fn get_group_shape_mut(&mut self) -> Option<&mut GroupShape> {
-        self.group_shape.as_mut()
+        self.group_shape.as_deref_mut()
     }
 
     pub fn set_group_shape(&mut self, value: GroupShape) -> &mut Self {
-        self.group_shape = Some(value);
+        self.group_shape = Some(Box::new(value));
         self
     }
 
     pub fn get_graphic_frame(&self) -> Option<&GraphicFrame> {
-        self.graphic_frame.as_ref()
+        self.graphic_frame.as_deref()
     }
 
     pub fn get_graphic_frame_mut(&mut self) -> Option<&mut GraphicFrame> {
-        self.graphic_frame.as_mut()
+        self.graphic_frame.as_deref_mut()
     }
 
     pub fn set_graphic_frame(&mut self, value: GraphicFrame) -> &mut Self {
-        self.graphic_frame = Some(value);
+        self.graphic_frame = Some(Box::new(value));
         self
     }
 
     pub fn get_shape(&self) -> Option<&Shape> {
-        self.shape.as_ref()
+        self.shape.as_deref()
     }
 
     pub fn get_shape_mut(&mut self) -> Option<&mut Shape> {
-        self.shape.as_mut()
+        self.shape.as_deref_mut()
     }
 
     pub fn set_shape(&mut self, value: Shape) -> &mut Self {
-        self.shape = Some(value);
+        self.shape = Some(Box::new(value));
         self
     }
 
     pub fn get_connection_shape(&self) -> Option<&ConnectionShape> {
-        self.connection_shape.as_ref()
+        self.connection_shape.as_deref()
     }
 
     pub fn get_connection_shape_mut(&mut self) -> Option<&mut ConnectionShape> {
-        self.connection_shape.as_mut()
+        self.connection_shape.as_deref_mut()
     }
 
     pub fn set_connection_shape(&mut self, value: ConnectionShape) -> &mut Self {
-        self.connection_shape = Some(value);
+        self.connection_shape = Some(Box::new(value));
         self
     }
 
     pub fn get_picture(&self) -> Option<&Picture> {
-        self.picture.as_ref()
+        self.picture.as_deref()
     }
 
     pub fn get_picture_mut(&mut self) -> Option<&mut Picture> {
-        self.picture.as_mut()
+        self.picture.as_deref_mut()
     }
 
     pub fn set_picture(&mut self, value: Picture) -> &mut Self {
-        self.picture = Some(value);
+        self.picture = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/spreadsheet/worksheet_drawing.rs
+++ b/src/structs/drawing/spreadsheet/worksheet_drawing.rs
@@ -15,24 +15,25 @@ use structs::raw::RawRelationships;
 use structs::Chart;
 use structs::Image;
 use structs::OleObjects;
+use thin_vec::ThinVec;
 use traits::AdjustmentCoordinate;
 use traits::AdjustmentCoordinateWithSheet;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct WorksheetDrawing {
-    image_collection: Vec<Image>,
-    chart_collection: Vec<Chart>,
-    one_cell_anchor_collection: Vec<OneCellAnchor>,
-    two_cell_anchor_collection: Vec<TwoCellAnchor>,
+    image_collection: ThinVec<Image>,
+    chart_collection: ThinVec<Chart>,
+    one_cell_anchor_collection: ThinVec<OneCellAnchor>,
+    two_cell_anchor_collection: ThinVec<TwoCellAnchor>,
 }
 
 impl WorksheetDrawing {
-    pub fn get_image_collection(&self) -> &Vec<Image> {
+    pub fn get_image_collection(&self) -> &[Image] {
         &self.image_collection
     }
 
-    pub fn get_image_collection_mut(&mut self) -> &mut Vec<Image> {
+    pub fn get_image_collection_mut(&mut self) -> &mut ThinVec<Image> {
         &mut self.image_collection
     }
 
@@ -73,11 +74,11 @@ impl WorksheetDrawing {
         result
     }
 
-    pub fn get_chart_collection(&self) -> &Vec<Chart> {
+    pub fn get_chart_collection(&self) -> &[Chart] {
         &self.chart_collection
     }
 
-    pub fn get_chart_collection_mut(&mut self) -> &mut Vec<Chart> {
+    pub fn get_chart_collection_mut(&mut self) -> &mut ThinVec<Chart> {
         &mut self.chart_collection
     }
 
@@ -118,11 +119,11 @@ impl WorksheetDrawing {
         result
     }
 
-    pub fn get_one_cell_anchor_collection(&self) -> &Vec<OneCellAnchor> {
+    pub fn get_one_cell_anchor_collection(&self) -> &[OneCellAnchor] {
         &self.one_cell_anchor_collection
     }
 
-    pub fn get_one_cell_anchor_collection_mut(&mut self) -> &mut Vec<OneCellAnchor> {
+    pub fn get_one_cell_anchor_collection_mut(&mut self) -> &mut ThinVec<OneCellAnchor> {
         &mut self.one_cell_anchor_collection
     }
 
@@ -131,11 +132,11 @@ impl WorksheetDrawing {
         self
     }
 
-    pub fn get_two_cell_anchor_collection(&self) -> &Vec<TwoCellAnchor> {
+    pub fn get_two_cell_anchor_collection(&self) -> &[TwoCellAnchor] {
         &self.two_cell_anchor_collection
     }
 
-    pub fn get_two_cell_anchor_collection_mut(&mut self) -> &mut Vec<TwoCellAnchor> {
+    pub fn get_two_cell_anchor_collection_mut(&mut self) -> &mut ThinVec<TwoCellAnchor> {
         &mut self.two_cell_anchor_collection
     }
 

--- a/src/structs/drawing/stretch.rs
+++ b/src/structs/drawing/stretch.rs
@@ -9,20 +9,20 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct Stretch {
-    fill_rectangle: Option<FillRectangle>,
+    fill_rectangle: Option<Box<FillRectangle>>,
 }
 
 impl Stretch {
     pub fn get_fill_rectangle(&self) -> Option<&FillRectangle> {
-        self.fill_rectangle.as_ref()
+        self.fill_rectangle.as_deref()
     }
 
     pub fn get_fill_rectangle_mut(&mut self) -> Option<&mut FillRectangle> {
-        self.fill_rectangle.as_mut()
+        self.fill_rectangle.as_deref_mut()
     }
 
     pub fn set_fill_rectangle(&mut self, value: FillRectangle) {
-        self.fill_rectangle = Some(value);
+        self.fill_rectangle = Some(Box::new(value));
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/style_matrix_reference_type.rs
+++ b/src/structs/drawing/style_matrix_reference_type.rs
@@ -9,8 +9,8 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct StyleMatrixReferenceType {
-    index: String,
-    scheme_color: Option<SchemeColor>,
+    index: Box<str>,
+    scheme_color: Option<Box<SchemeColor>>,
 }
 
 impl StyleMatrixReferenceType {
@@ -19,15 +19,15 @@ impl StyleMatrixReferenceType {
     }
 
     pub fn set_index<S: Into<String>>(&mut self, value: S) {
-        self.index = value.into();
+        self.index = value.into().into_boxed_str();
     }
 
     pub fn get_scheme_color(&self) -> Option<&SchemeColor> {
-        self.scheme_color.as_ref()
+        self.scheme_color.as_deref()
     }
 
     pub fn set_scheme_color(&mut self, value: SchemeColor) {
-        self.scheme_color = Some(value);
+        self.scheme_color = Some(Box::new(value));
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/drawing/text_paragraph_properties_type.rs
+++ b/src/structs/drawing/text_paragraph_properties_type.rs
@@ -20,7 +20,7 @@ pub struct TextParagraphPropertiesType {
     font_alignment: EnumValue<TextFontAlignmentValues>,
     space_before: Option<SpaceBefore>,
     space_after: Option<SpaceAfter>,
-    default_run_properties: Option<RunProperties>,
+    default_run_properties: Option<Box<RunProperties>>,
 }
 impl TextParagraphPropertiesType {
     pub fn get_right_to_left(&self) -> &bool {
@@ -77,15 +77,15 @@ impl TextParagraphPropertiesType {
     }
 
     pub fn get_default_run_properties(&self) -> Option<&RunProperties> {
-        self.default_run_properties.as_ref()
+        self.default_run_properties.as_deref()
     }
 
     pub fn get_default_run_properties_mut(&mut self) -> Option<&mut RunProperties> {
-        self.default_run_properties.as_mut()
+        self.default_run_properties.as_deref_mut()
     }
 
     pub fn set_default_run_properties(&mut self, value: RunProperties) -> &mut Self {
-        self.default_run_properties = Some(value);
+        self.default_run_properties = Some(Box::new(value));
         self
     }
 

--- a/src/structs/drawing/transform2d.rs
+++ b/src/structs/drawing/transform2d.rs
@@ -13,8 +13,8 @@ use writer::driver::*;
 pub struct Transform2D {
     offset: Point2DType,
     extents: PositiveSize2DType,
-    child_offset: Option<Point2DType>,
-    child_extents: Option<PositiveSize2DType>,
+    child_offset: Option<Box<Point2DType>>,
+    child_extents: Option<Box<PositiveSize2DType>>,
     rot: StringValue,
     flip_v: StringValue,
     flip_h: StringValue,
@@ -46,27 +46,27 @@ impl Transform2D {
     }
 
     pub fn get_child_offset(&self) -> Option<&Point2DType> {
-        self.child_offset.as_ref()
+        self.child_offset.as_deref()
     }
 
     pub fn get_child_offset_mut(&mut self) -> Option<&mut Point2DType> {
-        self.child_offset.as_mut()
+        self.child_offset.as_deref_mut()
     }
 
     pub fn set_child_offset(&mut self, value: Point2DType) {
-        self.child_offset = Some(value);
+        self.child_offset = Some(Box::new(value));
     }
 
     pub fn get_child_extents(&self) -> Option<&PositiveSize2DType> {
-        self.child_extents.as_ref()
+        self.child_extents.as_deref()
     }
 
     pub fn get_child_extents_mut(&mut self) -> Option<&mut PositiveSize2DType> {
-        self.child_extents.as_mut()
+        self.child_extents.as_deref_mut()
     }
 
     pub fn set_child_extents(&mut self, value: PositiveSize2DType) {
-        self.child_extents = Some(value);
+        self.child_extents = Some(Box::new(value));
     }
 
     pub fn get_rot(&self) -> Option<&str> {

--- a/src/structs/fill.rs
+++ b/src/structs/fill.rs
@@ -11,13 +11,13 @@ use writer::driver::*;
 
 #[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 pub struct Fill {
-    pattern_fill: Option<PatternFill>,
-    gradient_fill: Option<GradientFill>,
+    pattern_fill: Option<Box<PatternFill>>,
+    gradient_fill: Option<Box<GradientFill>>,
 }
 
 impl Fill {
     pub fn get_pattern_fill(&self) -> Option<&PatternFill> {
-        self.pattern_fill.as_ref()
+        self.pattern_fill.as_deref()
     }
 
     pub fn get_pattern_fill_mut(&mut self) -> &mut PatternFill {
@@ -29,13 +29,13 @@ impl Fill {
     }
 
     pub fn set_pattern_fill(&mut self, value: PatternFill) -> &mut Self {
-        self.pattern_fill = Some(value);
+        self.pattern_fill = Some(Box::new(value));
         self.gradient_fill = None;
         self
     }
 
     pub fn get_gradient_fill(&self) -> Option<&GradientFill> {
-        self.gradient_fill.as_ref()
+        self.gradient_fill.as_deref()
     }
 
     pub fn get_gradient_fill_mut(&mut self) -> &mut GradientFill {
@@ -48,7 +48,7 @@ impl Fill {
 
     pub fn set_gradient_fill(&mut self, value: GradientFill) -> &mut Self {
         self.pattern_fill = None;
-        self.gradient_fill = Some(value);
+        self.gradient_fill = Some(Box::new(value));
         self
     }
 

--- a/src/structs/fills.rs
+++ b/src/structs/fills.rs
@@ -6,19 +6,20 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct Fills {
-    fill: Vec<Fill>,
+    fill: ThinVec<Fill>,
 }
 
 impl Fills {
-    pub(crate) fn get_fill(&self) -> &Vec<Fill> {
+    pub(crate) fn get_fill(&self) -> &[Fill] {
         &self.fill
     }
 
-    pub(crate) fn get_fill_mut(&mut self) -> &mut Vec<Fill> {
+    pub(crate) fn get_fill_mut(&mut self) -> &mut ThinVec<Fill> {
         &mut self.fill
     }
 

--- a/src/structs/fonts.rs
+++ b/src/structs/fonts.rs
@@ -6,19 +6,20 @@ use reader::driver::*;
 use std::io::Cursor;
 use structs::Font;
 use structs::Style;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct Fonts {
-    font: Vec<Font>,
+    font: ThinVec<Font>,
 }
 
 impl Fonts {
-    pub(crate) fn get_font(&self) -> &Vec<Font> {
+    pub(crate) fn get_font(&self) -> &[Font] {
         &self.font
     }
 
-    pub(crate) fn get_font_mut(&mut self) -> &mut Vec<Font> {
+    pub(crate) fn get_font_mut(&mut self) -> &mut ThinVec<Font> {
         &mut self.font
     }
 

--- a/src/structs/gradient_fill.rs
+++ b/src/structs/gradient_fill.rs
@@ -8,12 +8,13 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::fmt::Write;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 pub struct GradientFill {
     degree: DoubleValue,
-    gradient_stop: Vec<GradientStop>,
+    gradient_stop: ThinVec<GradientStop>,
 }
 
 impl GradientFill {
@@ -26,11 +27,11 @@ impl GradientFill {
         self
     }
 
-    pub fn get_gradient_stop(&self) -> &Vec<GradientStop> {
+    pub fn get_gradient_stop(&self) -> &[GradientStop] {
         &self.gradient_stop
     }
 
-    pub fn get_gradient_stop_mut(&mut self) -> &mut Vec<GradientStop> {
+    pub fn get_gradient_stop_mut(&mut self) -> &mut ThinVec<GradientStop> {
         &mut self.gradient_stop
     }
 

--- a/src/structs/hyperlink.rs
+++ b/src/structs/hyperlink.rs
@@ -1,25 +1,25 @@
 #[derive(Clone, Default, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Hyperlink {
-    url: String,
-    tooltip: String,
+    url: Box<str>,
+    tooltip: Box<str>,
     location: bool,
 }
 impl Hyperlink {
     pub fn get_url(&self) -> &str {
-        self.url.as_str()
+        &self.url
     }
 
     pub fn set_url<S: Into<String>>(&mut self, value: S) -> &mut Hyperlink {
-        self.url = value.into();
+        self.url = value.into().into_boxed_str();
         self
     }
 
     pub fn get_tooltip(&self) -> &str {
-        self.tooltip.as_str()
+        &self.tooltip
     }
 
     pub fn set_tooltip<S: Into<String>>(&mut self, value: S) -> &mut Hyperlink {
-        self.tooltip = value.into();
+        self.tooltip = value.into().into_boxed_str();
         self
     }
 

--- a/src/structs/icon_set.rs
+++ b/src/structs/icon_set.rs
@@ -6,21 +6,25 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct IconSet {
-    cfvo_collection: Vec<ConditionalFormatValueObject>,
-    color_collection: Vec<Color>,
+    cfvo_collection: ThinVec<ConditionalFormatValueObject>,
+    color_collection: ThinVec<Color>,
 }
 
 impl IconSet {
-    pub fn get_cfvo_collection(&self) -> &Vec<ConditionalFormatValueObject> {
+    pub fn get_cfvo_collection(&self) -> &[ConditionalFormatValueObject] {
         &self.cfvo_collection
     }
 
-    pub fn set_cfvo_collection(&mut self, value: Vec<ConditionalFormatValueObject>) -> &mut Self {
-        self.cfvo_collection = value;
+    pub fn set_cfvo_collection(
+        &mut self,
+        value: impl Into<ThinVec<ConditionalFormatValueObject>>,
+    ) -> &mut Self {
+        self.cfvo_collection = value.into();
         self
     }
 
@@ -29,12 +33,12 @@ impl IconSet {
         self
     }
 
-    pub fn get_color_collection(&self) -> &Vec<Color> {
+    pub fn get_color_collection(&self) -> &[Color] {
         &self.color_collection
     }
 
-    pub fn set_color_collection(&mut self, value: Vec<Color>) -> &mut Self {
-        self.color_collection = value;
+    pub fn set_color_collection(&mut self, value: impl Into<ThinVec<Color>>) -> &mut Self {
+        self.color_collection = value.into();
         self
     }
 

--- a/src/structs/image.rs
+++ b/src/structs/image.rs
@@ -21,8 +21,8 @@ lazy_static! {
 
 #[derive(Clone, Default, Debug)]
 pub struct Image {
-    two_cell_anchor: Box<Option<TwoCellAnchor>>,
-    one_cell_anchor: Box<Option<OneCellAnchor>>,
+    two_cell_anchor: Option<Box<TwoCellAnchor>>,
+    one_cell_anchor: Option<Box<OneCellAnchor>>,
 }
 /// ## Example
 /// ```rust
@@ -66,38 +66,38 @@ pub struct Image {
 /// ```
 impl Image {
     pub fn get_two_cell_anchor(&self) -> Option<&TwoCellAnchor> {
-        self.two_cell_anchor.as_ref().as_ref()
+        self.two_cell_anchor.as_deref()
     }
 
     pub fn get_two_cell_anchor_mut(&mut self) -> Option<&mut TwoCellAnchor> {
-        self.two_cell_anchor.as_mut().as_mut()
+        self.two_cell_anchor.as_deref_mut()
     }
 
     pub fn set_two_cell_anchor(&mut self, value: TwoCellAnchor) -> &mut Self {
-        self.two_cell_anchor = Box::new(Some(value));
+        self.two_cell_anchor = Some(Box::new(value));
         self
     }
 
     pub fn remove_two_cell_anchor(&mut self) -> &mut Self {
-        self.two_cell_anchor = Box::new(None);
+        self.two_cell_anchor = None;
         self
     }
 
     pub fn get_one_cell_anchor(&self) -> Option<&OneCellAnchor> {
-        self.one_cell_anchor.as_ref().as_ref()
+        self.one_cell_anchor.as_deref()
     }
 
     pub fn get_one_cell_anchor_mut(&mut self) -> Option<&mut OneCellAnchor> {
-        self.one_cell_anchor.as_mut().as_mut()
+        self.one_cell_anchor.as_deref_mut()
     }
 
     pub fn set_one_cell_anchor(&mut self, value: OneCellAnchor) -> &mut Self {
-        self.one_cell_anchor = Box::new(Some(value));
+        self.one_cell_anchor = Some(Box::new(value));
         self
     }
 
     pub fn remove_one_cell_anchor(&mut self) -> &mut Self {
-        self.one_cell_anchor = Box::new(None);
+        self.one_cell_anchor = None;
         self
     }
 
@@ -190,7 +190,7 @@ impl Image {
         }
     }
 
-    pub fn get_image_data(&self) -> &Vec<u8> {
+    pub fn get_image_data(&self) -> &[u8] {
         match self.get_media_object().first() {
             Some(v) => v.get_image_data(),
             None => &EMPTY_VEC,

--- a/src/structs/media_object.rs
+++ b/src/structs/media_object.rs
@@ -1,7 +1,9 @@
+use thin_vec::ThinVec;
+
 #[derive(Clone, Default, Debug)]
 pub struct MediaObject {
-    image_name: String,
-    image_data: Vec<u8>,
+    image_name: Box<str>,
+    image_data: ThinVec<u8>,
 }
 impl MediaObject {
     pub fn get_image_name(&self) -> &str {
@@ -9,27 +11,27 @@ impl MediaObject {
     }
 
     pub fn set_image_name<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.image_name = value.into();
+        self.image_name = value.into().into_boxed_str();
         self
     }
 
-    pub fn get_image_data(&self) -> &Vec<u8> {
+    pub fn get_image_data(&self) -> &[u8] {
         &self.image_data
     }
 
-    pub fn set_image_data(&mut self, value: Vec<u8>) -> &mut Self {
-        self.image_data = value;
+    pub fn set_image_data(&mut self, value: impl Into<ThinVec<u8>>) -> &mut Self {
+        self.image_data = value.into();
         self
     }
 
     pub(crate) fn get_rid(&self, rel_list: &mut Vec<(String, String)>) -> i32 {
         let find = rel_list
             .iter()
-            .position(|(k, v)| k == "IMAGE" && v == &self.image_name);
+            .position(|(k, v)| k == "IMAGE" && v == &*self.image_name);
         match find {
             Some(v) => return (v + 1) as i32,
             None => {
-                rel_list.push((String::from("IMAGE"), self.image_name.clone()));
+                rel_list.push((String::from("IMAGE"), self.image_name.to_string()));
                 return rel_list.len() as i32;
             }
         }

--- a/src/structs/merge_cells.rs
+++ b/src/structs/merge_cells.rs
@@ -6,19 +6,20 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct MergeCells {
-    range: Vec<Range>,
+    range: ThinVec<Range>,
 }
 
 impl MergeCells {
-    pub(crate) fn get_range_collection(&self) -> &Vec<Range> {
+    pub(crate) fn get_range_collection(&self) -> &[Range] {
         &self.range
     }
 
-    pub(crate) fn get_range_collection_mut(&mut self) -> &mut Vec<Range> {
+    pub(crate) fn get_range_collection_mut(&mut self) -> &mut ThinVec<Range> {
         &mut self.range
     }
 

--- a/src/structs/mru_colors.rs
+++ b/src/structs/mru_colors.rs
@@ -5,19 +5,20 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct MruColors {
-    color: Vec<Color>,
+    color: ThinVec<Color>,
 }
 
 impl MruColors {
-    pub(crate) fn get_color(&self) -> &Vec<Color> {
+    pub(crate) fn get_color(&self) -> &[Color] {
         &self.color
     }
 
-    pub(crate) fn _get_color_mut(&mut self) -> &mut Vec<Color> {
+    pub(crate) fn _get_color_mut(&mut self) -> &mut ThinVec<Color> {
         &mut self.color
     }
 

--- a/src/structs/office/excel/reference_sequence.rs
+++ b/src/structs/office/excel/reference_sequence.rs
@@ -7,23 +7,24 @@ use std::io::Cursor;
 use std::vec;
 use structs::Coordinate;
 use structs::Range;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Default, Debug, Clone)]
 pub struct ReferenceSequence {
-    value: Vec<Range>,
+    value: ThinVec<Range>,
 }
 impl ReferenceSequence {
-    pub fn get_value(&self) -> &Vec<Range> {
+    pub fn get_value(&self) -> &[Range] {
         &self.value
     }
 
-    pub fn get_value_mut(&mut self) -> &mut Vec<Range> {
+    pub fn get_value_mut(&mut self) -> &mut ThinVec<Range> {
         &mut self.value
     }
 
-    pub fn set_value(&mut self, value: Vec<Range>) -> &mut Self {
-        self.value = value;
+    pub fn set_value(&mut self, value: impl Into<ThinVec<Range>>) -> &mut Self {
+        self.value = value.into();
         self
     }
 

--- a/src/structs/office2010/excel/data_validation.rs
+++ b/src/structs/office2010/excel/data_validation.rs
@@ -25,8 +25,8 @@ pub struct DataValidation {
     prompt_title: StringValue,
     prompt: StringValue,
     reference_sequence: ReferenceSequence,
-    formula1: Option<DataValidationForumla1>,
-    formula2: Option<DataValidationForumla2>,
+    formula1: Option<Box<DataValidationForumla1>>,
+    formula2: Option<Box<DataValidationForumla2>>,
 }
 impl DataValidation {
     pub fn get_type(&self) -> &DataValidationValues {
@@ -106,15 +106,15 @@ impl DataValidation {
     }
 
     pub fn get_formula1(&self) -> Option<&DataValidationForumla1> {
-        self.formula1.as_ref()
+        self.formula1.as_deref()
     }
 
     pub fn get_formula1_mut(&mut self) -> Option<&mut DataValidationForumla1> {
-        self.formula1.as_mut()
+        self.formula1.as_deref_mut()
     }
 
     pub fn set_formula1(&mut self, value: DataValidationForumla1) -> &mut Self {
-        self.formula1 = Some(value);
+        self.formula1 = Some(Box::new(value));
         self
     }
 
@@ -124,15 +124,15 @@ impl DataValidation {
     }
 
     pub fn get_formula2(&self) -> Option<&DataValidationForumla2> {
-        self.formula2.as_ref()
+        self.formula2.as_deref()
     }
 
     pub fn get_formula2_mut(&mut self) -> Option<&mut DataValidationForumla2> {
-        self.formula2.as_mut()
+        self.formula2.as_deref_mut()
     }
 
     pub fn set_formula2(&mut self, value: DataValidationForumla2) -> &mut Self {
-        self.formula2 = Some(value);
+        self.formula2 = Some(Box::new(value));
         self
     }
 
@@ -186,12 +186,12 @@ impl DataValidation {
                     b"x14:formula1" => {
                         let mut obj = DataValidationForumla1::default();
                         obj.set_attributes(reader, e);
-                        self.formula1 = Some(obj);
+                        self.formula1 = Some(Box::new(obj));
                     }
                     b"x14:formula2" => {
                         let mut obj = DataValidationForumla2::default();
                         obj.set_attributes(reader, e);
-                        self.formula2 = Some(obj);
+                        self.formula2 = Some(Box::new(obj));
                     }
                     b"xm:sqref" => {
                         let mut obj = ReferenceSequence::default();

--- a/src/structs/office2010/excel/data_validations.rs
+++ b/src/structs/office2010/excel/data_validations.rs
@@ -6,24 +6,28 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::office2010::excel::DataValidation;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Default, Debug, Clone)]
 pub struct DataValidations {
-    data_validation_list: Vec<DataValidation>,
+    data_validation_list: ThinVec<DataValidation>,
 }
 
 impl DataValidations {
-    pub fn get_data_validation_list(&self) -> &Vec<DataValidation> {
+    pub fn get_data_validation_list(&self) -> &[DataValidation] {
         &self.data_validation_list
     }
 
-    pub fn get_data_validation_list_mut(&mut self) -> &mut Vec<DataValidation> {
+    pub fn get_data_validation_list_mut(&mut self) -> &mut ThinVec<DataValidation> {
         &mut self.data_validation_list
     }
 
-    pub fn set_data_validation_list(&mut self, value: Vec<DataValidation>) -> &mut Self {
-        self.data_validation_list = value;
+    pub fn set_data_validation_list(
+        &mut self,
+        value: impl Into<ThinVec<DataValidation>>,
+    ) -> &mut Self {
+        self.data_validation_list = value.into();
         self
     }
 

--- a/src/structs/ole_objects.rs
+++ b/src/structs/ole_objects.rs
@@ -6,19 +6,20 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::raw::RawRelationships;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct OleObjects {
-    ole_object: Vec<OleObject>,
+    ole_object: ThinVec<OleObject>,
 }
 
 impl OleObjects {
-    pub fn get_ole_object(&self) -> &Vec<OleObject> {
+    pub fn get_ole_object(&self) -> &[OleObject] {
         &self.ole_object
     }
 
-    pub fn get_ole_object_mut(&mut self) -> &mut Vec<OleObject> {
+    pub fn get_ole_object_mut(&mut self) -> &mut ThinVec<OleObject> {
         &mut self.ole_object
     }
 

--- a/src/structs/page_setup.rs
+++ b/src/structs/page_setup.rs
@@ -7,6 +7,7 @@ use structs::raw::RawRelationships;
 use structs::EnumValue;
 use structs::OrientationValues;
 use structs::UInt32Value;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -18,7 +19,7 @@ pub struct PageSetup {
     fit_to_width: UInt32Value,
     horizontal_dpi: UInt32Value,
     vertical_dpi: UInt32Value,
-    object_data: Option<Vec<u8>>,
+    object_data: Option<ThinVec<u8>>,
 }
 
 impl PageSetup {
@@ -85,16 +86,16 @@ impl PageSetup {
         self
     }
 
-    pub fn get_object_data(&self) -> Option<&Vec<u8>> {
-        self.object_data.as_ref()
+    pub fn get_object_data(&self) -> Option<&[u8]> {
+        self.object_data.as_deref()
     }
 
-    pub fn get_object_data_mut(&mut self) -> Option<&mut Vec<u8>> {
+    pub fn get_object_data_mut(&mut self) -> Option<&mut ThinVec<u8>> {
         self.object_data.as_mut()
     }
 
-    pub fn set_object_data(&mut self, value: Vec<u8>) -> &mut Self {
-        self.object_data = Some(value);
+    pub fn set_object_data(&mut self, value: impl Into<ThinVec<u8>>) -> &mut Self {
+        self.object_data = Some(value.into());
         self
     }
 

--- a/src/structs/pattern_fill.rs
+++ b/src/structs/pattern_fill.rs
@@ -13,8 +13,8 @@ use writer::driver::*;
 #[derive(Default, Debug, Clone, PartialEq, PartialOrd)]
 pub struct PatternFill {
     pub(crate) pattern_type: EnumValue<PatternValues>,
-    foreground_color: Option<Color>,
-    background_color: Option<Color>,
+    foreground_color: Option<Box<Color>>,
+    background_color: Option<Box<Color>>,
 }
 
 impl PatternFill {
@@ -39,15 +39,16 @@ impl PatternFill {
     }
 
     pub fn get_foreground_color(&self) -> Option<&Color> {
-        self.foreground_color.as_ref()
+        self.foreground_color.as_deref()
     }
 
     pub fn get_foreground_color_mut(&mut self) -> &mut Color {
-        self.foreground_color.get_or_insert(Color::default())
+        self.foreground_color
+            .get_or_insert(Box::new(Color::default()))
     }
 
     pub fn set_foreground_color(&mut self, value: Color) -> &mut Self {
-        self.foreground_color = Some(value);
+        self.foreground_color = Some(Box::new(value));
         self.auto_set_pattern_type();
         self
     }
@@ -58,15 +59,16 @@ impl PatternFill {
     }
 
     pub fn get_background_color(&self) -> Option<&Color> {
-        self.background_color.as_ref()
+        self.background_color.as_deref()
     }
 
     pub fn get_background_color_mut(&mut self) -> &mut Color {
-        self.background_color.get_or_insert(Color::default())
+        self.background_color
+            .get_or_insert(Box::new(Color::default()))
     }
 
     pub fn set_background_color(&mut self, value: Color) -> &mut Self {
-        self.background_color = Some(value);
+        self.background_color = Some(Box::new(value));
         self
     }
 

--- a/src/structs/properties.rs
+++ b/src/structs/properties.rs
@@ -359,7 +359,7 @@ impl Properties {
     pub(crate) fn write_to_app(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        work_sheet_collection: &Vec<Worksheet>,
+        work_sheet_collection: &[Worksheet],
     ) {
         let sheet_count_str = work_sheet_collection.len().to_string();
 

--- a/src/structs/raw/raw_file.rs
+++ b/src/structs/raw/raw_file.rs
@@ -3,12 +3,13 @@ use std::io;
 use std::io::Read;
 use structs::StringValue;
 use structs::WriterManager;
+use thin_vec::ThinVec;
 use XlsxError;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct RawFile {
     file_target: StringValue,
-    file_data: Vec<u8>,
+    file_data: ThinVec<u8>,
 }
 impl RawFile {
     pub(crate) fn get_file_name(&self) -> String {
@@ -43,11 +44,11 @@ impl RawFile {
         self
     }
 
-    pub(crate) fn get_file_data(&self) -> &Vec<u8> {
+    pub(crate) fn get_file_data(&self) -> &[u8] {
         &self.file_data
     }
 
-    pub(crate) fn _get_file_data_mut(&mut self) -> &mut Vec<u8> {
+    pub(crate) fn _get_file_data_mut(&mut self) -> &mut ThinVec<u8> {
         &mut self.file_data
     }
 

--- a/src/structs/raw/raw_relationships.rs
+++ b/src/structs/raw/raw_relationships.rs
@@ -9,12 +9,13 @@ use structs::raw::RawRelationship;
 use structs::StringValue;
 use structs::WriterManager;
 use structs::XlsxError;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct RawRelationships {
     file_target: StringValue,
-    relationship_list: Vec<RawRelationship>,
+    relationship_list: ThinVec<RawRelationship>,
 }
 
 impl RawRelationships {
@@ -33,11 +34,11 @@ impl RawRelationships {
         self
     }
 
-    pub(crate) fn get_relationship_list(&self) -> &Vec<RawRelationship> {
+    pub(crate) fn get_relationship_list(&self) -> &[RawRelationship] {
         &self.relationship_list
     }
 
-    pub(crate) fn _get_relationship_list_mut(&mut self) -> &mut Vec<RawRelationship> {
+    pub(crate) fn _get_relationship_list_mut(&mut self) -> &mut ThinVec<RawRelationship> {
         &mut self.relationship_list
     }
 

--- a/src/structs/raw/raw_worksheet.rs
+++ b/src/structs/raw/raw_worksheet.rs
@@ -4,11 +4,12 @@ use structs::raw::RawFile;
 use structs::raw::RawRelationships;
 use structs::WriterManager;
 use structs::XlsxError;
+use thin_vec::ThinVec;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct RawWorksheet {
     worksheet_file: RawFile,
-    relationships_list: Vec<RawRelationships>,
+    relationships_list: ThinVec<RawRelationships>,
 }
 impl RawWorksheet {
     pub(crate) fn get_worksheet_file(&self) -> &RawFile {
@@ -19,11 +20,11 @@ impl RawWorksheet {
         &mut self.worksheet_file
     }
 
-    pub(crate) fn get_relationships_list(&self) -> &Vec<RawRelationships> {
+    pub(crate) fn get_relationships_list(&self) -> &[RawRelationships] {
         &self.relationships_list
     }
 
-    pub(crate) fn _get_relationships_list_mut(&mut self) -> &mut Vec<RawRelationships> {
+    pub(crate) fn _get_relationships_list_mut(&mut self) -> &mut ThinVec<RawRelationships> {
         &mut self.relationships_list
     }
 

--- a/src/structs/rich_text.rs
+++ b/src/structs/rich_text.rs
@@ -7,11 +7,12 @@ use reader::driver::*;
 use std::borrow::Cow;
 use std::fmt::Write;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug, PartialEq, PartialOrd)]
 pub struct RichText {
-    rich_text_elements: Vec<TextElement>,
+    rich_text_elements: ThinVec<TextElement>,
 }
 
 impl RichText {
@@ -31,16 +32,16 @@ impl RichText {
         self
     }
 
-    pub fn get_rich_text_elements(&self) -> &Vec<TextElement> {
+    pub fn get_rich_text_elements(&self) -> &[TextElement] {
         &self.rich_text_elements
     }
 
-    pub fn get_rich_text_elements_mut(&mut self) -> &mut Vec<TextElement> {
+    pub fn get_rich_text_elements_mut(&mut self) -> &mut ThinVec<TextElement> {
         &mut self.rich_text_elements
     }
 
-    pub fn set_rich_text_elements(&mut self, value: Vec<TextElement>) -> &mut Self {
-        self.rich_text_elements = value;
+    pub fn set_rich_text_elements(&mut self, value: impl Into<ThinVec<TextElement>>) -> &mut Self {
+        self.rich_text_elements = value.into();
         self
     }
 

--- a/src/structs/row.rs
+++ b/src/structs/row.rs
@@ -24,7 +24,7 @@ pub struct Row {
     thick_bot: BooleanValue,
     custom_height: BooleanValue,
     hidden: BooleanValue,
-    style: Style,
+    style: Box<Style>,
 }
 impl Default for Row {
     fn default() -> Self {
@@ -35,7 +35,7 @@ impl Default for Row {
             thick_bot: BooleanValue::default(),
             custom_height: BooleanValue::default(),
             hidden: BooleanValue::default(),
-            style: Style::default(),
+            style: Box::new(Style::default()),
         }
     }
 }
@@ -104,12 +104,12 @@ impl Row {
     }
 
     pub fn set_style(&mut self, value: Style) -> &mut Self {
-        self.style = value;
+        self.style = Box::new(value);
         self
     }
 
     pub(crate) fn has_style(&self) -> bool {
-        &self.style != &Style::default()
+        &*self.style != &Style::default()
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/row_breaks.rs
+++ b/src/structs/row_breaks.rs
@@ -5,19 +5,20 @@ use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
 use structs::Break;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct RowBreaks {
-    break_list: Vec<Break>,
+    break_list: ThinVec<Break>,
 }
 
 impl RowBreaks {
-    pub fn get_break_list(&self) -> &Vec<Break> {
+    pub fn get_break_list(&self) -> &[Break] {
         &self.break_list
     }
 
-    pub fn get_break_list_mut(&mut self) -> &mut Vec<Break> {
+    pub fn get_break_list_mut(&mut self) -> &mut ThinVec<Break> {
         &mut self.break_list
     }
 

--- a/src/structs/rows.rs
+++ b/src/structs/rows.rs
@@ -4,7 +4,7 @@ use traits::AdjustmentValue;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct Rows {
-    rows: HashMap<u32, Row>,
+    rows: HashMap<u32, Box<Row>>,
 }
 impl Rows {
     pub(crate) fn has_sheet_data(&self) -> bool {
@@ -13,26 +13,26 @@ impl Rows {
 
     /// Get Row Dimension List.
     pub(crate) fn get_row_dimensions(&self) -> Vec<&Row> {
-        self.rows.values().collect()
+        self.rows.values().map(Box::as_ref).collect()
     }
 
     /// Get Row Dimension List in mutable.
     pub(crate) fn get_row_dimensions_mut(&mut self) -> Vec<&mut Row> {
-        self.rows.values_mut().collect()
+        self.rows.values_mut().map(Box::as_mut).collect()
     }
 
     /// Get Row Dimension convert Hashmap.
-    pub(crate) fn get_row_dimensions_to_hashmap(&self) -> &HashMap<u32, Row> {
+    pub(crate) fn get_row_dimensions_to_hashmap(&self) -> &HashMap<u32, Box<Row>> {
         &self.rows
     }
 
-    pub(crate) fn get_row_dimensions_to_hashmap_mut(&mut self) -> &mut HashMap<u32, Row> {
+    pub(crate) fn get_row_dimensions_to_hashmap_mut(&mut self) -> &mut HashMap<u32, Box<Row>> {
         &mut self.rows
     }
 
     /// Get Row Dimension.
     pub(crate) fn get_row_dimension(&self, row: &u32) -> Option<&Row> {
-        self.rows.get(row)
+        self.rows.get(row).map(Box::as_ref)
     }
 
     /// Get Row Dimension in mutable.
@@ -40,7 +40,7 @@ impl Rows {
         self.rows.entry(row.to_owned()).or_insert_with(|| {
             let mut obj = Row::default();
             obj.set_row_num(*row);
-            obj
+            Box::new(obj)
         })
     }
 
@@ -48,7 +48,7 @@ impl Rows {
     /// Set Row Dimension.
     pub(crate) fn set_row_dimension(&mut self, value: Row) -> &mut Self {
         let row = value.get_row_num();
-        self.rows.insert(row.to_owned(), value);
+        self.rows.insert(row.to_owned(), Box::new(value));
         self
     }
 

--- a/src/structs/sequence_of_references.rs
+++ b/src/structs/sequence_of_references.rs
@@ -1,22 +1,23 @@
 use super::Range;
+use thin_vec::ThinVec;
 use traits::AdjustmentCoordinate;
 
 #[derive(Default, Debug, Clone)]
 pub struct SequenceOfReferences {
-    range_collection: Vec<Range>,
+    range_collection: ThinVec<Range>,
 }
 
 impl SequenceOfReferences {
-    pub fn get_range_collection(&self) -> &Vec<Range> {
+    pub fn get_range_collection(&self) -> &[Range] {
         &self.range_collection
     }
 
-    pub fn get_range_collection_mut(&mut self) -> &mut Vec<Range> {
+    pub fn get_range_collection_mut(&mut self) -> &mut ThinVec<Range> {
         &mut self.range_collection
     }
 
-    pub fn set_range_collection(&mut self, value: Vec<Range>) -> &mut Self {
-        self.range_collection = value;
+    pub fn set_range_collection(&mut self, value: impl Into<ThinVec<Range>>) -> &mut Self {
+        self.range_collection = value.into();
         self
     }
 

--- a/src/structs/shared_string_table.rs
+++ b/src/structs/shared_string_table.rs
@@ -10,21 +10,22 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct SharedStringTable {
-    shared_string_item: Vec<SharedStringItem>,
+    shared_string_item: ThinVec<SharedStringItem>,
     map: HashMap<u64, usize>,
     regist_count: usize,
 }
 
 impl SharedStringTable {
-    pub(crate) fn get_shared_string_item(&self) -> &Vec<SharedStringItem> {
+    pub(crate) fn get_shared_string_item(&self) -> &[SharedStringItem] {
         &self.shared_string_item
     }
 
-    pub(crate) fn get_shared_string_item_mut(&mut self) -> &mut Vec<SharedStringItem> {
+    pub(crate) fn get_shared_string_item_mut(&mut self) -> &mut ThinVec<SharedStringItem> {
         &mut self.shared_string_item
     }
 

--- a/src/structs/sheet_view.rs
+++ b/src/structs/sheet_view.rs
@@ -11,6 +11,7 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -24,7 +25,7 @@ pub struct SheetView {
     zoom_scale_page_layout_view: UInt32Value,
     zoom_scale_sheet_layout_view: UInt32Value,
     top_left_cell: StringValue,
-    selection: Vec<Selection>,
+    selection: ThinVec<Selection>,
 }
 
 impl SheetView {
@@ -113,11 +114,11 @@ impl SheetView {
         self
     }
 
-    pub fn get_selection(&self) -> &Vec<Selection> {
+    pub fn get_selection(&self) -> &[Selection] {
         &self.selection
     }
 
-    pub fn get_selection_mut(&mut self) -> &mut Vec<Selection> {
+    pub fn get_selection_mut(&mut self) -> &mut ThinVec<Selection> {
         &mut self.selection
     }
 

--- a/src/structs/sheet_view.rs
+++ b/src/structs/sheet_view.rs
@@ -18,7 +18,7 @@ use writer::driver::*;
 pub struct SheetView {
     tab_selected: BooleanValue,
     workbook_view_id: UInt32Value,
-    pane: Option<Pane>,
+    pane: Option<Box<Pane>>,
     view: EnumValue<SheetViewValues>,
     zoom_scale: UInt32Value,
     zoom_scale_normal: UInt32Value,
@@ -48,15 +48,15 @@ impl SheetView {
     }
 
     pub fn get_pane(&self) -> Option<&Pane> {
-        self.pane.as_ref()
+        self.pane.as_deref()
     }
 
     pub fn get_pane_mut(&mut self) -> Option<&mut Pane> {
-        self.pane.as_mut()
+        self.pane.as_deref_mut()
     }
 
     pub fn set_pane(&mut self, value: Pane) -> &mut Self {
-        self.pane = Some(value);
+        self.pane = Some(Box::new(value));
         self
     }
 

--- a/src/structs/sheet_views.rs
+++ b/src/structs/sheet_views.rs
@@ -5,19 +5,20 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct SheetViews {
-    sheet_view_list: Vec<SheetView>,
+    sheet_view_list: ThinVec<SheetView>,
 }
 
 impl SheetViews {
-    pub fn get_sheet_view_list(&self) -> &Vec<SheetView> {
+    pub fn get_sheet_view_list(&self) -> &[SheetView] {
         &self.sheet_view_list
     }
 
-    pub fn get_sheet_view_list_mut(&mut self) -> &mut Vec<SheetView> {
+    pub fn get_sheet_view_list_mut(&mut self) -> &mut ThinVec<SheetView> {
         &mut self.sheet_view_list
     }
 

--- a/src/structs/spreadsheet.rs
+++ b/src/structs/spreadsheet.rs
@@ -35,7 +35,7 @@ pub struct Spreadsheet {
     backup_context_types: ThinVec<(Box<str>, Box<str>)>,
     pivot_caches: ThinVec<(Box<str>, Box<str>, Box<str>)>,
     workbook_protection: Option<Box<WorkbookProtection>>,
-    defined_names: Vec<DefinedName>,
+    defined_names: ThinVec<DefinedName>,
 }
 
 impl Spreadsheet {
@@ -647,20 +647,20 @@ impl Spreadsheet {
     }
 
     /// Get Defined Name (Vec).
-    pub fn get_defined_names(&self) -> &Vec<DefinedName> {
+    pub fn get_defined_names(&self) -> &[DefinedName] {
         &self.defined_names
     }
 
     /// Get Defined Name (Vec) in mutable.
-    pub fn get_defined_names_mut(&mut self) -> &mut Vec<DefinedName> {
+    pub fn get_defined_names_mut(&mut self) -> &mut ThinVec<DefinedName> {
         &mut self.defined_names
     }
 
     /// Set Defined Name (Vec).
     /// # Arguments
     /// * `value` - Vec<DefinedName>.
-    pub fn set_defined_names(&mut self, value: Vec<DefinedName>) {
-        self.defined_names = value;
+    pub fn set_defined_names(&mut self, value: impl Into<ThinVec<DefinedName>>) {
+        self.defined_names = value.into();
     }
 
     /// Add Defined Name.

--- a/src/structs/spreadsheet.rs
+++ b/src/structs/spreadsheet.rs
@@ -15,6 +15,7 @@ use structs::Stylesheet;
 use structs::WorkbookProtection;
 use structs::WorkbookView;
 use structs::Worksheet;
+use thin_vec::ThinVec;
 use traits::AdjustmentCoordinate;
 use traits::AdjustmentCoordinateWithSheet;
 
@@ -23,17 +24,17 @@ use traits::AdjustmentCoordinateWithSheet;
 #[derive(Clone, Default, Debug)]
 pub struct Spreadsheet {
     properties: Properties,
-    work_sheet_collection: Vec<Worksheet>,
-    macros_code: Option<Vec<u8>>,
+    work_sheet_collection: ThinVec<Worksheet>,
+    macros_code: Option<ThinVec<u8>>,
     code_name: StringValue,
     ribbon_xml_data: StringValue,
     theme: Theme,
     stylesheet: Stylesheet,
     shared_string_table: Arc<RwLock<SharedStringTable>>,
     workbook_view: WorkbookView,
-    backup_context_types: Vec<(String, String)>,
-    pivot_caches: Vec<(String, String, String)>,
-    workbook_protection: Option<WorkbookProtection>,
+    backup_context_types: ThinVec<(Box<str>, Box<str>)>,
+    pivot_caches: ThinVec<(Box<str>, Box<str>, Box<str>)>,
+    workbook_protection: Option<Box<WorkbookProtection>>,
     defined_names: Vec<DefinedName>,
 }
 
@@ -207,15 +208,15 @@ impl Spreadsheet {
     /// Get Macros Code.
     /// # Return value
     /// * `Option<&Vec<u8>>` - Macros Code Raw Data.
-    pub fn get_macros_code(&self) -> Option<&Vec<u8>> {
-        self.macros_code.as_ref()
+    pub fn get_macros_code(&self) -> Option<&[u8]> {
+        self.macros_code.as_deref()
     }
 
     /// Set Macros Code.
     /// # Arguments
     /// * `value` - Macros Code Raw Data.
-    pub fn set_macros_code(&mut self, value: Vec<u8>) -> &mut Self {
-        self.macros_code = Some(value);
+    pub fn set_macros_code(&mut self, value: impl Into<ThinVec<u8>>) -> &mut Self {
+        self.macros_code = Some(value.into());
         self
     }
 
@@ -289,7 +290,7 @@ impl Spreadsheet {
     }
 
     /// Get Work Sheet List.
-    pub fn get_sheet_collection(&self) -> &Vec<Worksheet> {
+    pub fn get_sheet_collection(&self) -> &[Worksheet] {
         for worksheet in &self.work_sheet_collection {
             assert!(worksheet.is_deserialized(),"This Worksheet is Not Deserialized. Please exec to read_sheet(&mut self, index: usize);");
         }
@@ -298,12 +299,12 @@ impl Spreadsheet {
 
     /// Get Work Sheet List.
     /// No check deserialized.
-    pub fn get_sheet_collection_no_check(&self) -> &Vec<Worksheet> {
+    pub fn get_sheet_collection_no_check(&self) -> &[Worksheet] {
         &self.work_sheet_collection
     }
 
     /// Get Work Sheet List in mutable.
-    pub fn get_sheet_collection_mut(&mut self) -> &mut Vec<Worksheet> {
+    pub fn get_sheet_collection_mut(&mut self) -> &mut ThinVec<Worksheet> {
         self.read_sheet_collection();
         &mut self.work_sheet_collection
     }
@@ -575,12 +576,19 @@ impl Spreadsheet {
             .any(|sheet| sheet.has_defined_names())
     }
 
-    pub(crate) fn get_backup_context_types(&self) -> &Vec<(String, String)> {
+    pub(crate) fn get_backup_context_types(&self) -> &[(Box<str>, Box<str>)] {
         &self.backup_context_types
     }
 
-    pub(crate) fn set_backup_context_types(&mut self, value: Vec<(String, String)>) -> &mut Self {
-        self.backup_context_types = value;
+    pub(crate) fn set_backup_context_types(
+        &mut self,
+        value: impl Into<ThinVec<(String, String)>>,
+    ) -> &mut Self {
+        self.backup_context_types = value
+            .into()
+            .into_iter()
+            .map(|(a, b)| (a.into_boxed_str(), b.into_boxed_str()))
+            .collect();
         self
     }
 
@@ -591,9 +599,9 @@ impl Spreadsheet {
             for worksheet in self.get_sheet_collection_no_check() {
                 for pivot_cache_definition in worksheet.get_pivot_cache_definition_collection() {
                     if val3_up.as_str() == pivot_cache_definition
-                        && !result.iter().any(|(_, _, r_val3)| r_val3 == val3)
+                        && !result.iter().any(|(_, _, r_val3)| r_val3 == &**val3)
                     {
-                        result.push((val1.clone(), val2.clone(), val3.clone()));
+                        result.push((val1.to_string(), val2.to_string(), val3.to_string()));
                     }
                 }
             }
@@ -602,29 +610,34 @@ impl Spreadsheet {
     }
 
     pub(crate) fn add_pivot_caches(&mut self, value: (String, String, String)) -> &mut Self {
-        self.pivot_caches.push(value);
+        self.pivot_caches.push((
+            value.0.into_boxed_str(),
+            value.1.into_boxed_str(),
+            value.2.into_boxed_str(),
+        ));
         self
     }
 
     pub(crate) fn update_pivot_caches(&mut self, key: String, value: String) -> &mut Self {
         self.pivot_caches.iter_mut().for_each(|(val1, _, val3)| {
-            let result_value = if val1 == &key { &value } else { &val3 };
-            *val3 = result_value.to_string();
+            if &**val1 == &key {
+                *val3 = value.clone().into_boxed_str()
+            };
         });
         self
     }
 
     pub fn get_workbook_protection(&self) -> Option<&WorkbookProtection> {
-        self.workbook_protection.as_ref()
+        self.workbook_protection.as_deref()
     }
 
     pub fn get_workbook_protection_mut(&mut self) -> &mut WorkbookProtection {
         self.workbook_protection
-            .get_or_insert(WorkbookProtection::default())
+            .get_or_insert(Box::new(WorkbookProtection::default()))
     }
 
     pub fn set_workbook_protection(&mut self, value: WorkbookProtection) -> &mut Self {
-        self.workbook_protection = Some(value);
+        self.workbook_protection = Some(Box::new(value));
         self
     }
 

--- a/src/structs/string_value.rs
+++ b/src/structs/string_value.rs
@@ -1,6 +1,6 @@
 #[derive(Clone, Default, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct StringValue {
-    value: Option<String>,
+    value: Option<Box<str>>,
 }
 impl StringValue {
     pub(crate) fn get_value_str(&self) -> &str {
@@ -12,7 +12,7 @@ impl StringValue {
     }
 
     pub(crate) fn set_value<S: Into<String>>(&mut self, value: S) -> &mut StringValue {
-        self.value = Some(value.into());
+        self.value = Some(value.into().into_boxed_str());
         self
     }
 

--- a/src/structs/style.rs
+++ b/src/structs/style.rs
@@ -54,25 +54,25 @@ use crate::BooleanValue;
 /// ```
 #[derive(Clone, Default, Debug, PartialEq, PartialOrd)]
 pub struct Style {
-    font: Option<Font>,
-    fill: Option<Fill>,
-    borders: Option<Borders>,
+    font: Option<Box<Font>>,
+    fill: Option<Box<Fill>>,
+    borders: Option<Box<Borders>>,
     alignment: Option<Alignment>,
-    numbering_format: Option<NumberingFormat>,
+    numbering_format: Option<Box<NumberingFormat>>,
     format_id: UInt32Value,
     protection: Option<Protection>,
 }
 impl Style {
     pub fn get_font(&self) -> Option<&Font> {
-        self.font.as_ref()
+        self.font.as_deref()
     }
 
     pub fn get_font_mut(&mut self) -> &mut Font {
-        self.font.get_or_insert(Font::get_default_value())
+        self.font.get_or_insert(Box::new(Font::get_default_value()))
     }
 
     pub fn set_font(&mut self, value: Font) -> &mut Self {
-        self.font = Some(value);
+        self.font = Some(Box::new(value));
         self
     }
 
@@ -82,20 +82,20 @@ impl Style {
     }
 
     pub(crate) fn set_font_crate(&mut self, value: Option<Font>) -> &mut Self {
-        self.font = value;
+        self.font = value.map(Box::new);
         self
     }
 
     pub fn get_fill(&self) -> Option<&Fill> {
-        self.fill.as_ref()
+        self.fill.as_deref()
     }
 
     pub fn get_fill_mut(&mut self) -> &mut Fill {
-        self.fill.get_or_insert(Fill::get_default_value())
+        self.fill.get_or_insert(Box::new(Fill::get_default_value()))
     }
 
     pub fn set_fill(&mut self, value: Fill) -> &mut Self {
-        self.fill = Some(value);
+        self.fill = Some(Box::new(value));
         self
     }
 
@@ -143,20 +143,21 @@ impl Style {
     }
 
     pub(crate) fn set_fill_crate(&mut self, value: Option<Fill>) -> &mut Self {
-        self.fill = value;
+        self.fill = value.map(Box::new);
         self
     }
 
     pub fn get_borders(&self) -> Option<&Borders> {
-        self.borders.as_ref()
+        self.borders.as_deref()
     }
 
     pub fn get_borders_mut(&mut self) -> &mut Borders {
-        self.borders.get_or_insert(Borders::get_default_value())
+        self.borders
+            .get_or_insert(Box::new(Borders::get_default_value()))
     }
 
     pub fn set_borders(&mut self, value: Borders) -> &mut Self {
-        self.borders = Some(value);
+        self.borders = Some(Box::new(value));
         self
     }
 
@@ -166,7 +167,7 @@ impl Style {
     }
 
     pub(crate) fn set_borders_crate(&mut self, value: Option<Borders>) -> &mut Self {
-        self.borders = value;
+        self.borders = value.map(Box::new);
         self
     }
 
@@ -194,16 +195,16 @@ impl Style {
     }
 
     pub fn get_numbering_format(&self) -> Option<&NumberingFormat> {
-        self.numbering_format.as_ref()
+        self.numbering_format.as_deref()
     }
 
     pub fn get_numbering_format_mut(&mut self) -> &mut NumberingFormat {
         self.numbering_format
-            .get_or_insert(NumberingFormat::default())
+            .get_or_insert(Box::new(NumberingFormat::default()))
     }
 
     pub fn set_numbering_format(&mut self, value: NumberingFormat) -> &mut Self {
-        self.numbering_format = Some(value);
+        self.numbering_format = Some(Box::new(value));
         self
     }
 

--- a/src/structs/stylesheet.rs
+++ b/src/structs/stylesheet.rs
@@ -17,6 +17,7 @@ use quick_xml::Reader;
 use quick_xml::Writer;
 use reader::driver::*;
 use std::io::Cursor;
+use thin_vec::ThinVec;
 use writer::driver::*;
 
 #[derive(Clone, Default, Debug)]
@@ -30,7 +31,7 @@ pub(crate) struct Stylesheet {
     cell_styles: CellStyles,
     differential_formats: DifferentialFormats,
     colors: Colors,
-    maked_style_list: Vec<Style>,
+    maked_style_list: ThinVec<Style>,
 }
 
 impl Stylesheet {

--- a/src/structs/table.rs
+++ b/src/structs/table.rs
@@ -18,7 +18,7 @@ pub struct Table {
     area: (Coordinate, Coordinate),
     display_name: Box<str>,
     columns: ThinVec<TableColumn>,
-    style_info: Option<TableStyleInfo>,
+    style_info: Option<Box<TableStyleInfo>>,
     totals_row_shown: BooleanValue,
     totals_row_count: UInt32Value,
 }
@@ -97,11 +97,11 @@ impl Table {
     }
 
     pub fn get_style_info(&self) -> Option<&TableStyleInfo> {
-        self.style_info.as_ref()
+        self.style_info.as_deref()
     }
 
     pub fn set_style_info(&mut self, style_info: Option<TableStyleInfo>) {
-        self.style_info = style_info;
+        self.style_info = style_info.map(Box::new);
     }
 
     pub(crate) fn has_totals_row_shown(&self) -> bool {

--- a/src/structs/table.rs
+++ b/src/structs/table.rs
@@ -9,14 +9,15 @@ use super::{
     coordinate::*, BooleanValue, EnumValue, StringValue, TotalsRowFunctionValues, UInt32Value,
 };
 use crate::helper::coordinate::*;
+use thin_vec::ThinVec;
 //use reader::driver::*;
 
 #[derive(Clone, Default, Debug)]
 pub struct Table {
-    name: String,
+    name: Box<str>,
     area: (Coordinate, Coordinate),
-    display_name: String,
-    columns: Vec<TableColumn>,
+    display_name: Box<str>,
+    columns: ThinVec<TableColumn>,
     style_info: Option<TableStyleInfo>,
     totals_row_shown: BooleanValue,
     totals_row_count: UInt32Value,
@@ -28,12 +29,12 @@ impl Table {
     {
         let coord_beg = Self::cell_coord_to_coord(area.0);
         let coord_end = Self::cell_coord_to_coord(area.1);
-        let name = name.to_string();
+        let name: Box<str> = name.into();
         Self {
             area: (coord_beg, coord_end),
             name: name.clone(),
             display_name: name,
-            columns: Vec::<TableColumn>::default(),
+            columns: ThinVec::<TableColumn>::default(),
             style_info: None,
             totals_row_shown: BooleanValue::default(),
             totals_row_count: UInt32Value::default(),
@@ -52,22 +53,22 @@ impl Table {
     }
 
     pub fn get_name(&self) -> &str {
-        self.name.as_str()
+        &self.name
     }
 
     pub fn set_name(&mut self, name: &str) {
-        self.name = name.to_string();
+        self.name = name.into();
         if self.display_name.is_empty() {
-            self.display_name = name.to_string();
+            self.display_name = name.into();
         }
     }
 
     pub fn get_display_name(&self) -> &str {
-        self.display_name.as_str()
+        &self.display_name
     }
 
     pub fn set_display_name(&mut self, display_name: &str) {
-        self.display_name = display_name.to_string();
+        self.display_name = display_name.into();
     }
 
     pub fn get_area(&self) -> &(Coordinate, Coordinate) {
@@ -87,7 +88,7 @@ impl Table {
         self.columns.push(col);
     }
 
-    pub fn get_columns(&self) -> &Vec<TableColumn> {
+    pub fn get_columns(&self) -> &[TableColumn] {
         &self.columns
     }
 

--- a/src/structs/text.rs
+++ b/src/structs/text.rs
@@ -9,7 +9,7 @@ use writer::driver::*;
 
 #[derive(Clone, Default, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct Text {
-    value: String,
+    value: Box<str>,
 }
 
 impl Text {
@@ -18,12 +18,12 @@ impl Text {
     }
 
     pub(crate) fn set_value<S: Into<String>>(&mut self, value: S) -> &mut Self {
-        self.value = value.into();
+        self.value = value.into().into_boxed_str();
         self
     }
 
     pub(crate) fn get_hash_code(&self) -> String {
-        format!("{:x}", md5::Md5::digest(&self.value))
+        format!("{:x}", md5::Md5::digest(&*self.value))
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(
@@ -54,7 +54,7 @@ impl Text {
             attributes.push(("xml:space", "preserve"));
         }
         write_start_tag(writer, "t", attributes, false);
-        write_text_node(writer, &self.value);
+        write_text_node(writer, &*self.value);
         write_end_tag(writer, "t");
     }
 }

--- a/src/structs/text_element.rs
+++ b/src/structs/text_element.rs
@@ -12,7 +12,7 @@ use writer::driver::*;
 #[derive(Clone, Default, Debug, PartialEq, PartialOrd)]
 pub struct TextElement {
     text: Text,
-    run_properties: Option<Font>,
+    run_properties: Option<Box<Font>>,
 }
 
 impl TextElement {
@@ -26,7 +26,7 @@ impl TextElement {
     }
 
     pub fn get_run_properties(&self) -> Option<&Font> {
-        self.run_properties.as_ref()
+        self.run_properties.as_deref()
     }
 
     pub fn get_run_properties_mut(&mut self) -> &mut Font {
@@ -38,11 +38,11 @@ impl TextElement {
     }
 
     pub(crate) fn get_run_properties_crate(&mut self) -> Option<&mut Font> {
-        self.run_properties.as_mut()
+        self.run_properties.as_deref_mut()
     }
 
     pub fn set_run_properties(&mut self, value: Font) -> &mut Self {
-        self.run_properties = Some(value);
+        self.run_properties = Some(Box::new(value));
         self
     }
 

--- a/src/structs/vml/shape.rs
+++ b/src/structs/vml/shape.rs
@@ -29,12 +29,12 @@ pub struct Shape {
     stroke_color: StringValue,
     stroke_weight: StringValue,
     inset_mode: EnumValue<InsetMarginValues>,
-    fill: Option<Fill>,
-    image_data: Option<ImageData>,
-    stroke: Option<Stroke>,
-    shadow: Option<Shadow>,
-    path: Option<Path>,
-    text_box: Option<TextBox>,
+    fill: Option<Box<Fill>>,
+    image_data: Option<Box<ImageData>>,
+    stroke: Option<Box<Stroke>>,
+    shadow: Option<Box<Shadow>>,
+    path: Option<Box<Path>>,
+    text_box: Option<Box<TextBox>>,
     client_data: ClientData,
     optional_number: Int32Value,
     coordinate_size: StringValue,
@@ -114,80 +114,80 @@ impl Shape {
     }
 
     pub fn get_fill(&self) -> Option<&Fill> {
-        self.fill.as_ref()
+        self.fill.as_deref()
     }
 
     pub fn get_fill_mut(&mut self) -> Option<&mut Fill> {
-        self.fill.as_mut()
+        self.fill.as_deref_mut()
     }
 
     pub fn set_fill(&mut self, value: Fill) -> &mut Self {
-        self.fill = Some(value);
+        self.fill = Some(Box::new(value));
         self
     }
 
     pub fn get_image_data(&self) -> Option<&ImageData> {
-        self.image_data.as_ref()
+        self.image_data.as_deref()
     }
 
     pub fn get_image_data_mut(&mut self) -> Option<&mut ImageData> {
-        self.image_data.as_mut()
+        self.image_data.as_deref_mut()
     }
 
     pub fn set_image_data(&mut self, value: ImageData) -> &mut Self {
-        self.image_data = Some(value);
+        self.image_data = Some(Box::new(value));
         self
     }
 
     pub fn get_stroke(&self) -> Option<&Stroke> {
-        self.stroke.as_ref()
+        self.stroke.as_deref()
     }
 
     pub fn get_stroke_mut(&mut self) -> Option<&mut Stroke> {
-        self.stroke.as_mut()
+        self.stroke.as_deref_mut()
     }
 
     pub fn set_stroke(&mut self, value: Stroke) -> &mut Self {
-        self.stroke = Some(value);
+        self.stroke = Some(Box::new(value));
         self
     }
 
     pub fn get_shadow(&self) -> Option<&Shadow> {
-        self.shadow.as_ref()
+        self.shadow.as_deref()
     }
 
     pub fn get_shadow_mut(&mut self) -> Option<&mut Shadow> {
-        self.shadow.as_mut()
+        self.shadow.as_deref_mut()
     }
 
     pub fn set_shadow(&mut self, value: Shadow) -> &mut Self {
-        self.shadow = Some(value);
+        self.shadow = Some(Box::new(value));
         self
     }
 
     pub fn get_path(&self) -> Option<&Path> {
-        self.path.as_ref()
+        self.path.as_deref()
     }
 
     pub fn get_path_mut(&mut self) -> Option<&mut Path> {
-        self.path.as_mut()
+        self.path.as_deref_mut()
     }
 
     pub fn set_path(&mut self, value: Path) -> &mut Self {
-        self.path = Some(value);
+        self.path = Some(Box::new(value));
         self
     }
 
     pub fn get_text_box(&self) -> Option<&TextBox> {
-        self.text_box.as_ref()
+        self.text_box.as_deref()
     }
 
     pub fn get_text_box_mut(&mut self) -> Option<&mut TextBox> {
-        self.text_box.as_mut()
+        self.text_box.as_deref_mut()
     }
 
     pub fn set_text_box(&mut self, value: TextBox) -> &mut Self {
-        self.text_box = Some(value);
+        self.text_box = Some(Box::new(value));
         self
     }
 

--- a/src/structs/worksheet.rs
+++ b/src/structs/worksheet.rs
@@ -43,6 +43,7 @@ use structs::SheetViews;
 use structs::Style;
 use structs::Stylesheet;
 use structs::Table;
+use thin_vec::ThinVec;
 use traits::AdjustmentCoordinate;
 use traits::AdjustmentCoordinateWith2Sheet;
 use traits::AdjustmentCoordinateWithSheet;
@@ -54,32 +55,32 @@ use super::EnumTrait;
 #[derive(Clone, Debug, Default)]
 pub struct Worksheet {
     raw_data_of_worksheet: Option<RawWorksheet>,
-    r_id: String,
-    sheet_id: String,
-    title: String,
+    r_id: Box<str>,
+    sheet_id: Box<str>,
+    title: Box<str>,
     state: EnumValue<SheetStateValues>,
     cell_collection: Cells,
     row_dimensions: Rows,
     column_dimensions: Columns,
-    worksheet_drawing: Box<WorksheetDrawing>,
-    sheet_state: String,
+    worksheet_drawing: WorksheetDrawing,
+    sheet_state: Box<str>,
     page_setup: PageSetup,
     page_margins: PageMargins,
     header_footer: HeaderFooter,
     sheet_views: SheetViews,
-    conditional_formatting_collection: Vec<ConditionalFormatting>,
+    conditional_formatting_collection: ThinVec<ConditionalFormatting>,
     merge_cells: MergeCells,
     auto_filter: Option<AutoFilter>,
-    comments: Vec<Comment>,
-    active_cell: String,
+    comments: ThinVec<Comment>,
+    active_cell: Box<str>,
     tab_color: Option<Color>,
     code_name: StringValue,
     ole_objects: OleObjects,
-    defined_names: Vec<DefinedName>,
+    defined_names: ThinVec<DefinedName>,
     print_options: PrintOptions,
     column_breaks: ColumnBreaks,
     row_breaks: RowBreaks,
-    tables: Vec<Table>,
+    tables: ThinVec<Table>,
     data_validations: Option<DataValidations>,
     data_validations_2010: Option<DataValidations2010>,
     sheet_format_properties: SheetFormatProperties,
@@ -174,11 +175,11 @@ impl Worksheet {
         self.cell_collection.get_collection_mut()
     }
 
-    pub fn get_collection_to_hashmap(&self) -> &HashMap<(u32, u32), Cell> {
+    pub fn get_collection_to_hashmap(&self) -> &HashMap<(u32, u32), Box<Cell>> {
         self.cell_collection.get_collection_to_hashmap()
     }
 
-    pub fn get_collection_to_hashmap_mut(&mut self) -> &mut HashMap<(u32, u32), Cell> {
+    pub fn get_collection_to_hashmap_mut(&mut self) -> &mut HashMap<(u32, u32), Box<Cell>> {
         self.cell_collection.get_collection_to_hashmap_mut()
     }
 
@@ -453,12 +454,12 @@ impl Worksheet {
     // Comment
     // ************************
     /// Get Comments
-    pub fn get_comments(&self) -> &Vec<Comment> {
+    pub fn get_comments(&self) -> &[Comment] {
         &self.comments
     }
 
     /// Get Comments in mutable.
-    pub fn get_comments_mut(&mut self) -> &mut Vec<Comment> {
+    pub fn get_comments_mut(&mut self) -> &mut ThinVec<Comment> {
         &mut self.comments
     }
 
@@ -475,8 +476,8 @@ impl Worksheet {
     /// Set Comments.
     /// # Arguments
     /// * `value` - Comment List (Vec)
-    pub fn set_comments(&mut self, value: Vec<Comment>) {
-        self.comments = value;
+    pub fn set_comments(&mut self, value: impl Into<ThinVec<Comment>>) {
+        self.comments = value.into();
     }
 
     /// Add Comments.
@@ -495,15 +496,18 @@ impl Worksheet {
     // Conditional
     // ************************
     /// Get ConditionalFormatting list.
-    pub fn get_conditional_formatting_collection(&self) -> &Vec<ConditionalFormatting> {
+    pub fn get_conditional_formatting_collection(&self) -> &[ConditionalFormatting] {
         &self.conditional_formatting_collection
     }
 
     /// Set ConditionalFormatting.
     /// # Arguments
     /// * `value` - ConditionalSet List (Vec)
-    pub fn set_conditional_formatting_collection(&mut self, value: Vec<ConditionalFormatting>) {
-        self.conditional_formatting_collection = value;
+    pub fn set_conditional_formatting_collection(
+        &mut self,
+        value: impl Into<ThinVec<ConditionalFormatting>>,
+    ) {
+        self.conditional_formatting_collection = value.into();
     }
 
     /// Add ConditionalFormatting.
@@ -542,12 +546,12 @@ impl Worksheet {
     // Merge Cells
     // ************************
     // Get Merge Cells
-    pub fn get_merge_cells(&self) -> &Vec<Range> {
+    pub fn get_merge_cells(&self) -> &[Range] {
         self.merge_cells.get_range_collection()
     }
 
     // Get Merge Cells in mutable.
-    pub fn get_merge_cells_mut(&mut self) -> &mut Vec<Range> {
+    pub fn get_merge_cells_mut(&mut self) -> &mut ThinVec<Range> {
         self.merge_cells.get_range_collection_mut()
     }
 
@@ -614,12 +618,12 @@ impl Worksheet {
     // Column Dimensions
     // ************************
     /// Get Column Dimension List.
-    pub fn get_column_dimensions(&self) -> &Vec<Column> {
+    pub fn get_column_dimensions(&self) -> &[Column] {
         self.column_dimensions.get_column_collection()
     }
 
     /// Get Column Dimension List in mutable.
-    pub fn get_column_dimensions_mut(&mut self) -> &mut Vec<Column> {
+    pub fn get_column_dimensions_mut(&mut self) -> &mut ThinVec<Column> {
         self.column_dimensions.get_column_collection_mut()
     }
 
@@ -701,11 +705,11 @@ impl Worksheet {
     }
 
     /// Get Row Dimension convert Hashmap.
-    pub fn get_row_dimensions_to_hashmap(&self) -> &HashMap<u32, Row> {
+    pub fn get_row_dimensions_to_hashmap(&self) -> &HashMap<u32, Box<Row>> {
         self.row_dimensions.get_row_dimensions_to_hashmap()
     }
 
-    pub fn get_row_dimensions_to_hashmap_mut(&mut self) -> &mut HashMap<u32, Row> {
+    pub fn get_row_dimensions_to_hashmap_mut(&mut self) -> &mut HashMap<u32, Box<Row>> {
         self.row_dimensions.get_row_dimensions_to_hashmap_mut()
     }
 
@@ -755,7 +759,7 @@ impl Worksheet {
     /// # Arguments
     /// * `value` - WorksheetDrawing
     pub fn set_worksheet_drawing(&mut self, value: WorksheetDrawing) {
-        self.worksheet_drawing = Box::new(value);
+        self.worksheet_drawing = value;
     }
 
     /// Has WorksheetDrawing.
@@ -777,9 +781,9 @@ impl Worksheet {
     /// worksheet.insert_new_row(&2, &3);
     /// ```
     pub fn insert_new_row(&mut self, row_index: &u32, num_rows: &u32) {
-        let title = self.title.clone();
+        let title = &*self.title.clone();
         self.adjustment_insert_coordinate(&0, &0, row_index, num_rows);
-        self.adjustment_insert_coordinate_with_sheet(title.as_str(), &0, &0, row_index, num_rows);
+        self.adjustment_insert_coordinate_with_sheet(title, &0, &0, row_index, num_rows);
     }
 
     /// Adjust for references to other sheets.
@@ -832,15 +836,9 @@ impl Worksheet {
     /// worksheet.insert_new_column_by_index(&2, &3);
     /// ```
     pub fn insert_new_column_by_index(&mut self, column_index: &u32, num_columns: &u32) {
-        let title = self.title.clone();
+        let title = &*self.title.clone();
         self.adjustment_insert_coordinate(column_index, num_columns, &0, &0);
-        self.adjustment_insert_coordinate_with_sheet(
-            title.as_str(),
-            column_index,
-            num_columns,
-            &0,
-            &0,
-        );
+        self.adjustment_insert_coordinate_with_sheet(title, column_index, num_columns, &0, &0);
     }
 
     /// Adjust for references to other sheets.
@@ -865,9 +863,9 @@ impl Worksheet {
     /// worksheet.remove_row(&2, &3);
     /// ```
     pub fn remove_row(&mut self, row_index: &u32, num_rows: &u32) {
-        let title = self.title.clone();
+        let title = &*self.title.clone();
         self.adjustment_remove_coordinate(&0, &0, row_index, num_rows);
-        self.adjustment_remove_coordinate_with_sheet(title.as_str(), &0, &0, row_index, num_rows);
+        self.adjustment_remove_coordinate_with_sheet(title, &0, &0, row_index, num_rows);
     }
 
     /// Adjust for references to other sheets.
@@ -921,15 +919,9 @@ impl Worksheet {
     /// worksheet.remove_column_by_index(&2, &3);
     /// ```
     pub fn remove_column_by_index(&mut self, column_index: &u32, num_columns: &u32) {
-        let title = self.title.clone();
+        let title = &*self.title.clone();
         self.adjustment_remove_coordinate(column_index, num_columns, &0, &0);
-        self.adjustment_remove_coordinate_with_sheet(
-            title.as_str(),
-            column_index,
-            num_columns,
-            &0,
-            &0,
-        );
+        self.adjustment_remove_coordinate_with_sheet(title, column_index, num_columns, &0, &0);
     }
 
     /// Adjust for references to other sheets.
@@ -982,29 +974,29 @@ impl Worksheet {
     /// # Arguments
     /// * `cell` - Cell ex) "A1"
     pub fn set_active_cell<S: Into<String>>(&mut self, cell: S) {
-        self.active_cell = cell.into();
+        self.active_cell = cell.into().into_boxed_str();
     }
 
     /// Get R Id.
     pub(crate) fn get_r_id(&self) -> &str {
-        self.r_id.as_str()
+        &self.r_id
     }
 
     /// (This method is crate only.)
     /// Set r Id.
     pub(crate) fn set_r_id<S: Into<String>>(&mut self, value: S) {
-        self.r_id = value.into();
+        self.r_id = value.into().into_boxed_str();
     }
 
     /// Get Sheet Id.
     pub fn get_sheet_id(&self) -> &str {
-        self.sheet_id.as_str()
+        &self.sheet_id
     }
 
     /// (This method is crate only.)
     /// Set Sheet Id.
     pub(crate) fn set_sheet_id<S: Into<String>>(&mut self, value: S) {
-        self.sheet_id = value.into();
+        self.sheet_id = value.into().into_boxed_str();
     }
 
     /// Has Code Name.
@@ -1078,7 +1070,7 @@ impl Worksheet {
     /// # Arguments
     /// * `sheet_name` - Sheet Name. [Caution] no duplicate other worksheet.
     pub fn set_name<S: Into<String>>(&mut self, sheet_name: S) -> &mut Self {
-        self.title = sheet_name.into();
+        self.title = sheet_name.into().into_boxed_str();
         let title = self.get_name().to_string();
         for defined_name in self.get_defined_names_mut() {
             defined_name.set_sheet_name(&title);
@@ -1117,7 +1109,7 @@ impl Worksheet {
     /// # Arguments
     /// * `value` - Sheet State.
     pub fn set_sheet_state(&mut self, value: String) -> &mut Self {
-        self.sheet_state = value;
+        self.sheet_state = value.into_boxed_str();
         self
     }
 
@@ -1194,20 +1186,20 @@ impl Worksheet {
     }
 
     /// Get Defined Name (Vec).
-    pub fn get_defined_names(&self) -> &Vec<DefinedName> {
+    pub fn get_defined_names(&self) -> &[DefinedName] {
         &self.defined_names
     }
 
     /// Get Defined Name (Vec) in mutable.
-    pub fn get_defined_names_mut(&mut self) -> &mut Vec<DefinedName> {
+    pub fn get_defined_names_mut(&mut self) -> &mut ThinVec<DefinedName> {
         &mut self.defined_names
     }
 
     /// Set Defined Name (Vec).
     /// # Arguments
     /// * `value` - Vec<DefinedName>.
-    pub fn set_defined_names(&mut self, value: Vec<DefinedName>) {
-        self.defined_names = value;
+    pub fn set_defined_names(&mut self, value: impl Into<ThinVec<DefinedName>>) {
+        self.defined_names = value.into();
     }
 
     /// Add Defined Name.
@@ -1291,11 +1283,11 @@ impl Worksheet {
         self.tables.push(table);
     }
 
-    pub fn get_tables(&self) -> &Vec<Table> {
+    pub fn get_tables(&self) -> &[Table] {
         &self.tables
     }
 
-    pub fn get_tables_mut(&mut self) -> &mut Vec<Table> {
+    pub fn get_tables_mut(&mut self) -> &mut ThinVec<Table> {
         &mut self.tables
     }
 
@@ -1351,14 +1343,14 @@ impl Worksheet {
     /// Outputs all images contained in the worksheet.
     /// # Return value
     /// * `&Vec<Image>` - Image Object List.
-    pub fn get_image_collection(&self) -> &Vec<Image> {
+    pub fn get_image_collection(&self) -> &[Image] {
         self.get_worksheet_drawing().get_image_collection()
     }
 
     /// Outputs all images contained in the worksheet.
     /// # Return value
     /// * `&mut Vec<Image>` - Image Object List.
-    pub fn get_image_collection_mut(&mut self) -> &mut Vec<Image> {
+    pub fn get_image_collection_mut(&mut self) -> &mut ThinVec<Image> {
         self.get_worksheet_drawing_mut().get_image_collection_mut()
     }
 
@@ -1406,14 +1398,14 @@ impl Worksheet {
     /// Outputs all Charts contained in the worksheet.
     /// # Return value
     /// * `&Vec<Chart>` - Chart Object List.
-    pub fn get_chart_collection(&self) -> &Vec<Chart> {
+    pub fn get_chart_collection(&self) -> &[Chart] {
         self.get_worksheet_drawing().get_chart_collection()
     }
 
     /// Outputs all Charts contained in the worksheet.
     /// # Return value
     /// * `&mut Vec<Chart>` - Chart Object List.
-    pub fn get_chart_collection_mut(&mut self) -> &mut Vec<Chart> {
+    pub fn get_chart_collection_mut(&mut self) -> &mut ThinVec<Chart> {
         self.get_worksheet_drawing_mut().get_chart_collection_mut()
     }
 

--- a/src/structs/writer_manager.rs
+++ b/src/structs/writer_manager.rs
@@ -272,7 +272,7 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
             // Override Unsupported
             if content_type.is_empty() {
                 for (old_part_name, old_content_type) in spreadsheet.get_backup_context_types() {
-                    if old_part_name == &file {
+                    if &**old_part_name == &file {
                         content_type = old_content_type;
                     }
                 }


### PR DESCRIPTION
This PR attempts to reduce the memory footprint of using this crate.

* `String` types are changed to `Box<str>` to save 8 bytes each.
* The `thin-vec` crate is used to replace `Vec`'s, saving 16 bytes each.
* Many large `Option`'s are `Box`ed
* Many large types in `HashMap`s are `Box`ed

I try to avoid making code-breaking changes, but some return types are changed, such as `&Vec<T>` to `&[T]`... in most cases that shouldn't matter.  The entire test suite compiles are run without change.

The current API design prevents more involved optimizations without breaking code.  For example, returning `&bool`, `&u32` etc. prevents those fields from being replaced by smaller, packed data types like `bitflags`. A future major version should really change those to return non-references instead.

I have given up on optimizing chart data types because they are simply too tedious, and there shouldn't really be more than a few charts in a typical spreadsheet.
