### PR TITLE
changes for optimisation

### DIFF
--- a/src/helper/formula.rs
+++ b/src/helper/formula.rs
@@ -207,7 +207,7 @@ pub(crate) fn parse_to_tokens<S: Into<String>>(formula: S) -> Vec<FormulaToken> 
         if in_error {
             value = format!("{}{}", value, formula.chars().nth(index).unwrap());
             index += 1;
-            if self::ERRORS.iter().any(|&x| x == value.as_str()) {
+            if self::ERRORS.iter().any(|&x| x == &value) {
                 in_error = false;
                 let mut obj = FormulaToken::default();
                 obj.set_value(value);
@@ -362,12 +362,12 @@ pub(crate) fn parse_to_tokens<S: Into<String>>(formula: S) -> Vec<FormulaToken> 
                 value = String::new();
             }
 
-            let mut obj = stack.pop().unwrap().clone();
+            let mut obj = stack.pop().unwrap();
             obj.set_value("");
             obj.set_token_sub_type(FormulaTokenSubTypes::Stop);
             tokens1.push(obj);
 
-            let mut obj = stack.pop().unwrap().clone();
+            let mut obj = stack.pop().unwrap();
             obj.set_value("");
             obj.set_token_sub_type(FormulaTokenSubTypes::Stop);
             tokens1.push(obj);

--- a/src/helper/number_format.rs
+++ b/src/helper/number_format.rs
@@ -125,21 +125,15 @@ fn split_format(sections: Vec<&str>, value: &f64) -> (String, String, String) {
     //   3 sections:  [POSITIVE/TEXT] [NEGATIVE] [ZERO]
     //   4 sections:  [POSITIVE] [NEGATIVE] [ZERO] [TEXT]
     let cnt: usize = sections.len();
-    let color_regex: String = format!("{}{}{}", "\\[(", Color::NAMED_COLORS.join("|"), ")\\]");
+    let color_regex = format!("{}{}{}", "\\[(", Color::NAMED_COLORS.join("|"), ")\\]");
     let cond_regex = r"\[(>|>=|<|<=|=|<>)([+-]?\d+([.]\d+)?)\]";
     let color_re = Regex::new(&color_regex).unwrap();
     let cond_re = Regex::new(cond_regex).unwrap();
 
-    let mut colors = [const { String::new() }; 5];
-    let mut condops = [const { String::new() }; 5];
+    let mut colors = [""; 5];
+    let mut condops = [""; 5];
 
-    let mut condvals = [
-        String::from("0"),
-        String::from("0"),
-        String::from("0"),
-        String::from("0"),
-        String::from("0"),
-    ];
+    let mut condvals = ["0"; 5];
     sections.into_iter().enumerate().for_each(|(idx, section)| {
         let mut converted_section = section.to_string();
         if color_re.find(section).ok().flatten().is_some() {
@@ -147,7 +141,7 @@ fn split_format(sections: Vec<&str>, value: &f64) -> (String, String, String) {
             for ite in color_re.captures(section).ok().flatten().unwrap().iter() {
                 item.push(ite.unwrap().as_str());
             }
-            std::mem::replace(&mut colors[idx], item.get(0).unwrap().to_string());
+            std::mem::replace(&mut colors[idx], item.first().unwrap());
             converted_section = color_re.replace_all(section, "").to_string();
         }
         if cond_re.find(section).ok().flatten().is_some() {
@@ -160,13 +154,13 @@ fn split_format(sections: Vec<&str>, value: &f64) -> (String, String, String) {
             }
             match item.get(1) {
                 Some(v) => {
-                    std::mem::replace(&mut condops[idx], v.to_string());
+                    std::mem::replace(&mut condops[idx], v);
                 }
                 None => {}
             }
             match item.get(2) {
                 Some(v) => {
-                    std::mem::replace(&mut condvals[idx], v.to_string());
+                    std::mem::replace(&mut condvals[idx], v);
                 }
                 None => {}
             }
@@ -175,8 +169,8 @@ fn split_format(sections: Vec<&str>, value: &f64) -> (String, String, String) {
         converted_sections.insert(idx, converted_section);
     });
 
-    let mut color = &colors[0];
-    let mut format: &str = &converted_sections[0];
+    let mut color = colors[0];
+    let mut format = &converted_sections[0];
     let mut absval = *value;
     match cnt {
         2 => {

--- a/src/helper/number_format.rs
+++ b/src/helper/number_format.rs
@@ -141,7 +141,7 @@ fn split_format(sections: Vec<&str>, value: &f64) -> (String, String, String) {
             for ite in color_re.captures(section).ok().flatten().unwrap().iter() {
                 item.push(ite.unwrap().as_str());
             }
-            std::mem::replace(&mut colors[idx], item.first().unwrap());
+            std::mem::replace(&mut colors[idx], item[0]);
             converted_section = color_re.replace_all(section, "").to_string();
         }
         if cond_re.find(section).ok().flatten().is_some() {

--- a/src/helper/number_format/date_formater.rs
+++ b/src/helper/number_format/date_formater.rs
@@ -90,7 +90,7 @@ pub(crate) fn format_as_date<'input>(value: &f64, format: &'input str) -> Cow<'i
                 // when [h]:mm format, the [h] should replace to the hours of the value * 24
                 if block.contains("[h]") {
                     let hours = value * 24f64;
-                    block = block.replace("[h]", hours.to_string().as_str());
+                    block = block.replace("[h]", &hours.to_string());
                     converted_blocks.push(block);
                     continue;
                 }

--- a/src/helper/number_format/number_formater.rs
+++ b/src/helper/number_format/number_formater.rs
@@ -121,7 +121,7 @@ fn format_straight_numeric_value(
         value = value.parse::<f64>().unwrap().separate_with_commas();
     }
     let blocks: Vec<&str> = value.split('.').collect();
-    let left_value = blocks.first().unwrap().to_string();
+    let left_value = blocks[0].to_string();
     let mut right_value = match blocks.get(1) {
         Some(v) => v.to_string(),
         None => String::from("0"),

--- a/src/helper/number_format/number_formater.rs
+++ b/src/helper/number_format/number_formater.rs
@@ -88,7 +88,7 @@ pub(crate) fn format_as_number<'input>(value: &f64, format: &'input str) -> Cow<
 
     let re = Regex::new(r"\$[^0-9]*").unwrap();
     if re.find(&format).ok().flatten().is_some() {
-        let mut item: Vec<&str> = re
+        let item: Vec<&str> = re
             .captures(&format)
             .ok()
             .flatten()
@@ -96,7 +96,7 @@ pub(crate) fn format_as_number<'input>(value: &f64, format: &'input str) -> Cow<
             .iter()
             .map(|ite| ite.unwrap().as_str())
             .collect();
-        value = format!("{}{}", item.get(0).unwrap(), value);
+        value = format!("{}{}", item[0], value);
         //    //  Currency or Accounting
         //    let currency_code = item.get(1).unwrap().to_string();
         //    value = Regex::new(r#"\[\$([^\]]*)\]"#).unwrap().replace_all(&value, currency_code.as_str()).to_string();
@@ -194,10 +194,10 @@ fn process_complex_number_format_mask(number: &f64, mask: &str) -> String {
     let mut masking_blocks: Vec<(&str, usize)> = Vec::new();
     let mut masking_str: Vec<&str> = Vec::new();
     let mut masking_beg: Vec<usize> = Vec::new();
-    for ite in re.captures(&mask).ok().flatten().unwrap().iter() {
+    for ite in re.captures(mask).ok().flatten().unwrap().iter() {
         masking_str.push(ite.unwrap().as_str());
     }
-    for pos in re.captures(&mask).ok().flatten().unwrap().iter() {
+    for pos in re.captures(mask).ok().flatten().unwrap().iter() {
         let beg = pos.unwrap().start();
         masking_beg.push(beg);
     }

--- a/src/reader/xlsx.rs
+++ b/src/reader/xlsx.rs
@@ -119,7 +119,7 @@ pub fn lazy_read(path: &Path) -> Result<Spreadsheet, XlsxError> {
 
 pub(crate) fn raw_to_deserialize_by_worksheet(
     worksheet: &mut Worksheet,
-    shared_string_table: Arc<RwLock<SharedStringTable>>,
+    shared_string_table: &RwLock<SharedStringTable>,
     stylesheet: &Stylesheet,
 ) {
     if worksheet.is_deserialized() {

--- a/src/structs/cache_field.rs
+++ b/src/structs/cache_field.rs
@@ -80,10 +80,7 @@ impl CacheField {
             "pivotField",
             vec![
                 ("name", self.name.get_value_str()),
-                (
-                    "numFmtId",
-                    self.number_format_id.get_value_string().as_str(),
-                ),
+                ("numFmtId", &self.number_format_id.get_value_string()),
             ],
             false,
         );

--- a/src/structs/cache_fields.rs
+++ b/src/structs/cache_fields.rs
@@ -57,7 +57,7 @@ impl CacheFields {
         write_start_tag(
             writer,
             "cacheFields",
-            vec![("count", self.list.len().to_string().as_str())],
+            vec![("count", &self.list.len().to_string())],
             false,
         );
 

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -450,7 +450,7 @@ impl Cell {
     pub(crate) fn write_to(
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
-        shared_string_table: &Arc<RwLock<SharedStringTable>>,
+        shared_string_table: &RwLock<SharedStringTable>,
         stylesheet: &mut Stylesheet,
         formula_shared_list: &HashMap<&u32, (String, Option<String>)>,
     ) {

--- a/src/structs/cells.rs
+++ b/src/structs/cells.rs
@@ -108,9 +108,7 @@ impl Cells {
         T: Into<CellCoordinates>,
     {
         let CellCoordinates { col, row } = coordinate.into();
-        self.map
-            .get(&(row.to_owned(), col.to_owned()))
-            .map(Box::as_ref)
+        self.map.get(&(row, col)).map(Box::as_ref)
     }
 
     pub(crate) fn get_mut<T>(
@@ -123,20 +121,18 @@ impl Cells {
         T: Into<CellCoordinates>,
     {
         let CellCoordinates { col, row } = coordinate.into();
-        self.map
-            .entry((row.to_owned(), col.to_owned()))
-            .or_insert_with(|| {
-                let mut c = Cell::default();
-                c.get_coordinate_mut().set_col_num(col);
-                c.get_coordinate_mut().set_row_num(row);
-                if col_dimenshon.has_style() {
-                    c.set_style(col_dimenshon.get_style().clone());
-                }
-                if row_dimenshon.has_style() {
-                    c.set_style(row_dimenshon.get_style().clone());
-                }
-                Box::new(c)
-            })
+        self.map.entry((row, col)).or_insert_with(|| {
+            let mut c = Cell::default();
+            c.get_coordinate_mut().set_col_num(col);
+            c.get_coordinate_mut().set_row_num(row);
+            if col_dimenshon.has_style() {
+                c.set_style(col_dimenshon.get_style().clone());
+            }
+            if row_dimenshon.has_style() {
+                c.set_style(row_dimenshon.get_style().clone());
+            }
+            Box::new(c)
+        })
     }
 
     #[inline]
@@ -146,7 +142,7 @@ impl Cells {
     {
         let CellCoordinates { col, row } = coordinate.into();
         self.map
-            .get(&(row.to_owned(), col.to_owned()))
+            .get(&(row, col))
             .map(|c| c.get_cell_value())
             .unwrap_or(&self.default_cell_value)
     }
@@ -158,7 +154,7 @@ impl Cells {
     {
         let CellCoordinates { col, row } = coordinate.into();
         self.map
-            .get(&(row.to_owned(), col.to_owned()))
+            .get(&(row, col))
             .map(|c| c.get_style())
             .unwrap_or(&self.default_style)
     }
@@ -187,8 +183,7 @@ impl Cells {
     pub(crate) fn add(&mut self, cell: Cell) {
         let col_num = cell.get_coordinate().get_col_num();
         let row_num = cell.get_coordinate().get_row_num();
-        let k = (row_num.to_owned(), col_num.to_owned());
-        self.map.insert(k, Box::new(cell));
+        self.map.insert((*row_num, *col_num), Box::new(cell));
     }
 
     #[inline]

--- a/src/structs/color.rs
+++ b/src/structs/color.rs
@@ -129,7 +129,7 @@ impl Color {
             return self.get_argb().to_owned().into();
         }
         if self.theme_index.has_value() {
-            let key = self.theme_index.get_value().clone();
+            let key = *self.theme_index.get_value();
             match theme
                 .get_theme_elements()
                 .get_color_scheme()

--- a/src/structs/column_breaks.rs
+++ b/src/structs/column_breaks.rs
@@ -73,8 +73,8 @@ impl ColumnBreaks {
                 writer,
                 "colBreaks",
                 vec![
-                    ("count", count.to_string().as_str()),
-                    ("manualBreakCount", manual_count.to_string().as_str()),
+                    ("count", &count.to_string()),
+                    ("manualBreakCount", &manual_count.to_string()),
                 ],
                 false,
             );

--- a/src/structs/column_fields.rs
+++ b/src/structs/column_fields.rs
@@ -59,7 +59,7 @@ impl ColumnFields {
         write_start_tag(
             writer,
             "colFields",
-            vec![("count", self.list.len().to_string().as_str())],
+            vec![("count", &self.list.len().to_string())],
             false,
         );
 

--- a/src/structs/column_items.rs
+++ b/src/structs/column_items.rs
@@ -66,7 +66,7 @@ impl ColumnItems {
         write_start_tag(
             writer,
             "colItems",
-            vec![("count", self.list.len().to_string().as_str())],
+            vec![("count", &self.list.len().to_string())],
             false,
         );
 

--- a/src/structs/columns.rs
+++ b/src/structs/columns.rs
@@ -159,8 +159,8 @@ impl Columns {
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         let min_str = min.to_string();
         let max_str = max.to_string();
-        attributes.push(("min", min_str.as_str()));
-        attributes.push(("max", max_str.as_str()));
+        attributes.push(("min", &min_str));
+        attributes.push(("max", &max_str));
         let width = column.width.get_value_string();
         attributes.push(("width", &width));
         if *column.hidden.get_value() {

--- a/src/structs/data_field.rs
+++ b/src/structs/data_field.rs
@@ -83,9 +83,9 @@ impl DataField {
             "dataField",
             vec![
                 ("name", self.name.get_value_str()),
-                ("fld", self.fie_id.get_value_string().as_str()),
-                ("baseField", self.base_fie_id.get_value_string().as_str()),
-                ("baseItem", self.base_item.get_value_string().as_str()),
+                ("fld", &self.fie_id.get_value_string()),
+                ("baseField", &self.base_fie_id.get_value_string()),
+                ("baseItem", &self.base_item.get_value_string()),
             ],
             true,
         );

--- a/src/structs/data_fields.rs
+++ b/src/structs/data_fields.rs
@@ -59,7 +59,7 @@ impl DataFields {
         write_start_tag(
             writer,
             "dataFields",
-            vec![("count", self.list.len().to_string().as_str())],
+            vec![("count", &self.list.len().to_string())],
             false,
         );
 

--- a/src/structs/defined_name.rs
+++ b/src/structs/defined_name.rs
@@ -186,7 +186,7 @@ impl DefinedName {
                 },
                 Event::End(ref e) => {
                     if e.name().into_inner() == b"definedName" {
-                        self.set_address(value.clone());
+                        self.set_address(value);
                         return
                     }
                 },

--- a/src/structs/drawing/blip.rs
+++ b/src/structs/drawing/blip.rs
@@ -86,7 +86,7 @@ impl Blip {
         let r_id_str = format!("rId{}", r_id);
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         attributes.push(("xmlns:r", REL_OFC_NS));
-        attributes.push(("r:embed", r_id_str.as_str()));
+        attributes.push(("r:embed", &r_id_str));
         if !&self.cstate.is_empty() {
             attributes.push(("cstate", &self.cstate));
         }

--- a/src/structs/drawing/charts/numbering_cache.rs
+++ b/src/structs/drawing/charts/numbering_cache.rs
@@ -64,21 +64,11 @@ impl NumberingCache {
         self.format_code.write_to(writer);
 
         // c:ptCount
-        write_start_tag(
-            writer,
-            "c:ptCount",
-            vec![("val", coll_value_count.as_str())],
-            true,
-        );
+        write_start_tag(writer, "c:ptCount", vec![("val", &coll_value_count)], true);
 
         for (idx, cell_value) in cell_value_list.into_iter().enumerate() {
             // c:pt
-            write_start_tag(
-                writer,
-                "c:pt",
-                vec![("idx", idx.to_string().as_str())],
-                false,
-            );
+            write_start_tag(writer, "c:pt", vec![("idx", &idx.to_string())], false);
 
             // c:v
             write_start_tag(writer, "c:v", vec![], false);

--- a/src/structs/drawing/charts/string_cache.rs
+++ b/src/structs/drawing/charts/string_cache.rs
@@ -40,21 +40,11 @@ impl StringCache {
         write_start_tag(writer, "c:strCache", vec![], false);
 
         // c:ptCount
-        write_start_tag(
-            writer,
-            "c:ptCount",
-            vec![("val", coll_value_count.as_str())],
-            true,
-        );
+        write_start_tag(writer, "c:ptCount", vec![("val", &coll_value_count)], true);
 
         for (idx, cell_value) in cell_value_list.into_iter().enumerate() {
             // c:pt
-            write_start_tag(
-                writer,
-                "c:pt",
-                vec![("idx", idx.to_string().as_str())],
-                false,
-            );
+            write_start_tag(writer, "c:pt", vec![("idx", &idx.to_string())], false);
 
             // c:v
             write_start_tag(writer, "c:v", vec![], false);

--- a/src/structs/drawing/charts/string_literal.rs
+++ b/src/structs/drawing/charts/string_literal.rs
@@ -56,7 +56,7 @@ impl StringLiteral {
 
         // c:ptCount
         let count = self.string_point_list.len().to_string();
-        write_start_tag(writer, "c:ptCount", vec![("val", count.as_str())], true);
+        write_start_tag(writer, "c:ptCount", vec![("val", &count)], true);
 
         // c:pt
         for (index, obj) in self.string_point_list.iter().enumerate() {

--- a/src/structs/drawing/charts/string_point.rs
+++ b/src/structs/drawing/charts/string_point.rs
@@ -51,7 +51,7 @@ impl StringPoint {
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>, index: &u32) {
         // c:pt
         let index_str = index.to_string();
-        write_start_tag(writer, "c:pt", vec![("idx", index_str.as_str())], false);
+        write_start_tag(writer, "c:pt", vec![("idx", &index_str)], false);
 
         // c:v
         self.numeric_value._write_to(writer);

--- a/src/structs/drawing/spreadsheet/non_visual_drawing_properties.rs
+++ b/src/structs/drawing/spreadsheet/non_visual_drawing_properties.rs
@@ -97,7 +97,7 @@ impl NonVisualDrawingProperties {
                 vec![("uri", "{63B3BB69-23CF-44E3-9099-C40C66FF867C}")],
                 false,
             );
-            write_start_tag(writer, "a14:compatExt", vec![("spid", spid.as_str())], true);
+            write_start_tag(writer, "a14:compatExt", vec![("spid", &spid)], true);
 
             write_end_tag(writer, "a:ext");
             write_end_tag(writer, "a:extLst");

--- a/src/structs/embedded_object_properties.rs
+++ b/src/structs/embedded_object_properties.rs
@@ -140,7 +140,7 @@ impl EmbeddedObjectProperties {
             attributes.push(("autoPict", self.auto_pict.get_value_string()));
         }
         let r_id_str = format!("rId{}", r_id);
-        attributes.push(("r:id", r_id_str.as_str()));
+        attributes.push(("r:id", &r_id_str));
         write_start_tag(writer, "objectPr", attributes, false);
 
         // anchor

--- a/src/structs/field.rs
+++ b/src/structs/field.rs
@@ -34,7 +34,7 @@ impl Field {
         write_start_tag(
             writer,
             "field",
-            vec![("x", self.x.get_value_string().as_str())],
+            vec![("x", &self.x.get_value_string())],
             true,
         );
     }

--- a/src/structs/formula.rs
+++ b/src/structs/formula.rs
@@ -67,7 +67,7 @@ impl Formula {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.set_address_str(e.unescape().unwrap().to_string());
+                self.set_address_str(e.unescape().unwrap());
             },
             Event::End(ref e) => {
                 if e.name().into_inner() == b"formula" {

--- a/src/structs/gradient_fill.rs
+++ b/src/structs/gradient_fill.rs
@@ -48,7 +48,7 @@ impl GradientFill {
     pub(crate) fn get_hash_code(&self) -> String {
         let mut value = String::new();
         for stop in &self.gradient_stop {
-            write!(value, "{}", stop.get_hash_code().as_str()).unwrap();
+            write!(value, "{}", stop.get_hash_code()).unwrap();
         }
         format!(
             "{:x}",

--- a/src/structs/location.rs
+++ b/src/structs/location.rs
@@ -69,18 +69,9 @@ impl Location {
             "location",
             vec![
                 ("ref", self.reference.get_value_str()),
-                (
-                    "firstHeaderRow",
-                    self.first_header_row.get_value_string().as_str(),
-                ),
-                (
-                    "firstDataRow",
-                    self.first_data_row.get_value_string().as_str(),
-                ),
-                (
-                    "firstDataCol",
-                    self.first_data_col.get_value_string().as_str(),
-                ),
+                ("firstHeaderRow", &self.first_header_row.get_value_string()),
+                ("firstDataRow", &self.first_data_row.get_value_string()),
+                ("firstDataCol", &self.first_data_col.get_value_string()),
             ],
             true,
         );

--- a/src/structs/media_object.rs
+++ b/src/structs/media_object.rs
@@ -40,16 +40,14 @@ impl MediaObject {
         self
     }
 
-    pub(crate) fn get_rid(&self, rel_list: &mut Vec<(String, String)>) -> i32 {
-        let find = rel_list
+    pub(crate) fn get_rid(&self, rel_list: &mut Vec<(String, String)>) -> u32 {
+        rel_list
             .iter()
-            .position(|(k, v)| k == "IMAGE" && v == &*self.image_name);
-        match find {
-            Some(v) => return (v + 1) as i32,
-            None => {
+            .position(|(k, v)| k == "IMAGE" && v == &*self.image_name)
+            .map(|index| (index + 1) as u32)
+            .unwrap_or_else(|| {
                 rel_list.push((String::from("IMAGE"), self.image_name.to_string()));
-                return rel_list.len() as i32;
-            }
-        }
+                rel_list.len() as u32
+            })
     }
 }

--- a/src/structs/merge_cells.rs
+++ b/src/structs/merge_cells.rs
@@ -84,10 +84,7 @@ impl MergeCells {
             write_start_tag(
                 writer,
                 "mergeCells",
-                vec![(
-                    "count",
-                    self.get_range_collection().len().to_string().as_str(),
-                )],
+                vec![("count", &self.get_range_collection().len().to_string())],
                 false,
             );
 
@@ -96,7 +93,7 @@ impl MergeCells {
                 write_start_tag(
                     writer,
                     "mergeCell",
-                    vec![("ref", merge_cell.get_range().as_str())],
+                    vec![("ref", &merge_cell.get_range())],
                     true,
                 );
             }

--- a/src/structs/numbering_format.rs
+++ b/src/structs/numbering_format.rs
@@ -168,7 +168,7 @@ impl NumberingFormat {
             writer,
             "numFmt",
             vec![
-                ("numFmtId", number_format_id.to_string().as_str()),
+                ("numFmtId", &number_format_id.to_string()),
                 ("formatCode", &self.format_code),
             ],
             true,

--- a/src/structs/ole_object.rs
+++ b/src/structs/ole_object.rs
@@ -205,8 +205,8 @@ impl OleObject {
         let shape_id_str = format!("{}", ole_id);
         let attributes = vec![
             ("progId", self.prog_id.get_value_str()),
-            ("shapeId", shape_id_str.as_str()),
-            ("r:id", r_id_str.as_str()),
+            ("shapeId", &shape_id_str),
+            ("r:id", &r_id_str),
         ];
         write_start_tag(writer, "oleObject", attributes, false);
 
@@ -225,8 +225,8 @@ impl OleObject {
         let r_id_str = format!("rId{}", r_id);
         let attributes = vec![
             ("progId", self.prog_id.get_value_str()),
-            ("shapeId", shape_id_str.as_str()),
-            ("r:id", r_id_str.as_str()),
+            ("shapeId", &shape_id_str),
+            ("r:id", &r_id_str),
         ];
         write_start_tag(writer, "oleObject", attributes, true);
 

--- a/src/structs/page_setup.rs
+++ b/src/structs/page_setup.rs
@@ -185,7 +185,7 @@ impl PageSetup {
                 attributes.push(("verticalDpi", &vertical_dpi));
             }
             if self.object_data.is_some() {
-                attributes.push(("r:id", r_id_str.as_str()));
+                attributes.push(("r:id", &r_id_str));
                 *r_id += 1;
             }
             write_start_tag(writer, "pageSetup", attributes, true);

--- a/src/structs/pane.rs
+++ b/src/structs/pane.rs
@@ -107,7 +107,7 @@ impl Pane {
         if self.vertical_split.has_value() {
             attributes.push(("ySplit", &vertical_split));
         }
-        attributes.push(("topLeftCell", coordinate.as_str()));
+        attributes.push(("topLeftCell", &coordinate));
         attributes.push(("activePane", self.active_pane.get_value_string()));
         attributes.push(("state", self.state.get_value_string()));
         write_start_tag(writer, "pane", attributes, true);

--- a/src/structs/pivot_cache_definition.rs
+++ b/src/structs/pivot_cache_definition.rs
@@ -198,26 +198,23 @@ impl PivotCacheDefinition {
         }
         let refreshed_date_str = self.refreshed_date.get_value_string();
         if self.refreshed_date.has_value() {
-            attributes.push(("refreshedDate", refreshed_date_str.as_str()));
+            attributes.push(("refreshedDate", &refreshed_date_str));
         }
         let created_version_str = self.created_version.get_value_string();
         if self.created_version.has_value() {
-            attributes.push(("createdVersion", created_version_str.as_str()));
+            attributes.push(("createdVersion", &created_version_str));
         }
         let refreshed_version_str = self.refreshed_version.get_value_string();
         if self.refreshed_version.has_value() {
-            attributes.push(("refreshedVersion", refreshed_version_str.as_str()));
+            attributes.push(("refreshedVersion", &refreshed_version_str));
         }
         let min_refreshable_version_str = self.min_refreshable_version.get_value_string();
         if self.min_refreshable_version.has_value() {
-            attributes.push((
-                "minRefreshableVersion",
-                min_refreshable_version_str.as_str(),
-            ));
+            attributes.push(("minRefreshableVersion", &min_refreshable_version_str));
         }
         let record_count_str = self.record_count.get_value_string();
         if self.record_count.has_value() {
-            attributes.push(("recordCount", record_count_str.as_str()));
+            attributes.push(("recordCount", &record_count_str));
         }
 
         write_start_tag(writer, "pivotTableDefinition", attributes, false);

--- a/src/structs/pivot_fields.rs
+++ b/src/structs/pivot_fields.rs
@@ -63,7 +63,7 @@ impl PivotFields {
         write_start_tag(
             writer,
             "pivotFields",
-            vec![("count", self.list.len().to_string().as_str())],
+            vec![("count", &self.list.len().to_string())],
             false,
         );
 

--- a/src/structs/pivot_table_definition.rs
+++ b/src/structs/pivot_table_definition.rs
@@ -462,7 +462,7 @@ impl PivotTableDefinition {
         }
         let cache_id_str = self.cache_id.get_value_string();
         if self.cache_id.has_value() {
-            attributes.push(("cacheId", cache_id_str.as_str()));
+            attributes.push(("cacheId", &cache_id_str));
         }
         if self.apply_number_formats.has_value() {
             attributes.push((
@@ -505,14 +505,11 @@ impl PivotTableDefinition {
         }
         let updated_version_str = self.updated_version.get_value_string();
         if self.updated_version.has_value() {
-            attributes.push(("updatedVersion", updated_version_str.as_str()));
+            attributes.push(("updatedVersion", &updated_version_str));
         }
         let min_refreshable_version_str = self.min_refreshable_version.get_value_string();
         if self.min_refreshable_version.has_value() {
-            attributes.push((
-                "minRefreshableVersion",
-                min_refreshable_version_str.as_str(),
-            ));
+            attributes.push(("minRefreshableVersion", &min_refreshable_version_str));
         }
         if self.use_auto_formatting.has_value() {
             attributes.push((
@@ -525,11 +522,11 @@ impl PivotTableDefinition {
         }
         let created_version_str = self.created_version.get_value_string();
         if self.created_version.has_value() {
-            attributes.push(("createdVersion", created_version_str.as_str()));
+            attributes.push(("createdVersion", &created_version_str));
         }
         let indent_str = self.indent.get_value_string();
         if self.indent.has_value() {
-            attributes.push(("indent", indent_str.as_str()));
+            attributes.push(("indent", &indent_str));
         }
         if self.outline.has_value() {
             attributes.push(("outline", self.outline.get_value_string()));

--- a/src/structs/raw/raw_file.rs
+++ b/src/structs/raw/raw_file.rs
@@ -13,10 +13,10 @@ pub(crate) struct RawFile {
 }
 impl RawFile {
     #[inline]
-    pub(crate) fn get_file_name(&self) -> String {
+    pub(crate) fn get_file_name(&self) -> &str {
         let v: Vec<&str> = self.get_file_target().split('/').collect();
         let object_name = v.last().unwrap();
-        object_name.to_string()
+        *object_name
     }
 
     #[inline]

--- a/src/structs/row.rs
+++ b/src/structs/row.rs
@@ -189,7 +189,7 @@ impl Row {
         &self,
         writer: &mut Writer<Cursor<Vec<u8>>>,
         stylesheet: &mut Stylesheet,
-        spans: String,
+        spans: &str,
         empty_flag: bool,
     ) {
         let xf_index_str: String;
@@ -200,7 +200,7 @@ impl Row {
         let row_num = self.row_num.get_value_string();
         attributes.push(("r", &row_num));
         if !empty_flag {
-            attributes.push(("spans", &spans));
+            attributes.push(("spans", spans));
         }
         let height = self.height.get_value_string();
         if self.height.get_value() != &0f64 {

--- a/src/structs/row_breaks.rs
+++ b/src/structs/row_breaks.rs
@@ -75,8 +75,8 @@ impl RowBreaks {
             writer,
             "rowBreaks",
             vec![
-                ("count", count.to_string().as_str()),
-                ("manualBreakCount", manual_count.to_string().as_str()),
+                ("count", &count.to_string()),
+                ("manualBreakCount", &manual_count.to_string()),
             ],
             false,
         );

--- a/src/structs/row_item.rs
+++ b/src/structs/row_item.rs
@@ -107,14 +107,14 @@ impl RowItem {
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         let index_str = self.index.get_value_string();
         if self.index.has_value() {
-            attributes.push(("i", index_str.as_str()));
+            attributes.push(("i", &index_str));
         }
         if self.item_type.has_value() {
             attributes.push(("t", self.item_type.get_value_string()));
         }
         let repeated_item_count_str = self.repeated_item_count.get_value_string();
         if self.repeated_item_count.has_value() {
-            attributes.push(("r", repeated_item_count_str.as_str()));
+            attributes.push(("r", &repeated_item_count_str));
         }
         write_start_tag(writer, "i", attributes, empty_flg);
         if empty_flg == false {

--- a/src/structs/row_items.rs
+++ b/src/structs/row_items.rs
@@ -70,7 +70,7 @@ impl RowItems {
         write_start_tag(
             writer,
             "rowItems",
-            vec![("count", self.list.len().to_string().as_str())],
+            vec![("count", &self.list.len().to_string())],
             false,
         );
 

--- a/src/structs/rows.rs
+++ b/src/structs/rows.rs
@@ -44,7 +44,7 @@ impl Rows {
     /// Get Row Dimension in mutable.
     #[inline]
     pub(crate) fn get_row_dimension_mut(&mut self, row: &u32) -> &mut Row {
-        self.rows.entry(row.to_owned()).or_insert_with(|| {
+        self.rows.entry(*row).or_insert_with(|| {
             let mut obj = Row::default();
             obj.set_row_num(*row);
             Box::new(obj)
@@ -56,7 +56,7 @@ impl Rows {
     #[inline]
     pub(crate) fn set_row_dimension(&mut self, value: Row) -> &mut Self {
         let row = value.get_row_num();
-        self.rows.insert(row.to_owned(), Box::new(value));
+        self.rows.insert(*row, Box::new(value));
         self
     }
 

--- a/src/structs/selection.rs
+++ b/src/structs/selection.rs
@@ -86,7 +86,7 @@ impl Selection {
         if let Some(active_cell) = &self.active_cell {
             for range in self.sequence_of_references.get_range_collection() {
                 let range_str = range.get_range();
-                if range_str.contains(active_cell.to_string().as_str()) {
+                if range_str.contains(&active_cell.to_string()) {
                     break;
                 }
                 active_cell_id += 1;
@@ -102,17 +102,17 @@ impl Selection {
             None => String::new(),
         };
         if !active_cell_str.is_empty() {
-            attributes.push(("activeCell", active_cell_str.as_str()));
+            attributes.push(("activeCell", &active_cell_str));
         }
 
         let active_cell_id_str = active_cell_id.to_string();
         if active_cell_id > 0 {
-            attributes.push(("activeCellId", active_cell_id_str.as_str()));
+            attributes.push(("activeCellId", &active_cell_id_str));
         }
 
         let sqref = self.sequence_of_references.get_sqref();
         if !sqref.is_empty() {
-            attributes.push(("sqref", sqref.as_str()));
+            attributes.push(("sqref", &sqref));
         }
 
         write_start_tag(writer, "selection", attributes, true);

--- a/src/structs/shared_items.rs
+++ b/src/structs/shared_items.rs
@@ -98,8 +98,8 @@ impl SharedItems {
                 ("containsString", self.contains_string.get_value_string()),
                 ("containsNumber", self.contains_number.get_value_string()),
                 ("containsInteger", self.contains_integer.get_value_string()),
-                ("minValue", self.min_value.get_value_string().as_str()),
-                ("maxValue", self.max_value.get_value_string().as_str()),
+                ("minValue", &self.min_value.get_value_string()),
+                ("maxValue", &self.max_value.get_value_string()),
             ],
             true,
         );

--- a/src/structs/shared_string_table.rs
+++ b/src/structs/shared_string_table.rs
@@ -56,7 +56,7 @@ impl SharedStringTable {
 
         let hash_code = shared_string_item.get_hash_u64();
         let n = match self.map.get(&hash_code) {
-            Some(v) => v.to_owned(),
+            Some(v) => *v,
             None => {
                 let n = self.shared_string_item.len();
                 self.map.insert(hash_code, n);
@@ -103,11 +103,8 @@ impl SharedStringTable {
             "sst",
             vec![
                 ("xmlns", SHEET_MAIN_NS),
-                ("count", self.regist_count.to_string().as_str()),
-                (
-                    "uniqueCount",
-                    self.shared_string_item.len().to_string().as_str(),
-                ),
+                ("count", &self.regist_count.to_string()),
+                ("uniqueCount", &self.shared_string_item.len().to_string()),
             ],
             false,
         );

--- a/src/structs/spreadsheet.rs
+++ b/src/structs/spreadsheet.rs
@@ -346,7 +346,7 @@ impl Spreadsheet {
         let shared_string_table = self.get_shared_string_table();
         let stylesheet = self.get_stylesheet().clone();
         for worksheet in &mut self.work_sheet_collection {
-            raw_to_deserialize_by_worksheet(worksheet, shared_string_table.clone(), &stylesheet);
+            raw_to_deserialize_by_worksheet(worksheet, &shared_string_table, &stylesheet);
         }
         self
     }
@@ -357,7 +357,7 @@ impl Spreadsheet {
         let shared_string_table = self.get_shared_string_table();
         let stylesheet = self.get_stylesheet().clone();
         let worksheet = self.work_sheet_collection.get_mut(index).unwrap();
-        raw_to_deserialize_by_worksheet(worksheet, shared_string_table, &stylesheet);
+        raw_to_deserialize_by_worksheet(worksheet, &shared_string_table, &stylesheet);
         self
     }
 
@@ -423,7 +423,7 @@ impl Spreadsheet {
         let shared_string_table = self.get_shared_string_table();
         let stylesheet = self.get_stylesheet().clone();
         self.work_sheet_collection.get_mut(*index).map(|v| {
-            raw_to_deserialize_by_worksheet(v, shared_string_table, &stylesheet);
+            raw_to_deserialize_by_worksheet(v, &shared_string_table, &stylesheet);
             v
         })
     }
@@ -642,7 +642,7 @@ impl Spreadsheet {
             let val3_up = format!("xl/{}", &val3);
             for worksheet in self.get_sheet_collection_no_check() {
                 for pivot_cache_definition in worksheet.get_pivot_cache_definition_collection() {
-                    if val3_up.as_str() == pivot_cache_definition
+                    if &val3_up == pivot_cache_definition
                         && !result.iter().any(|(_, _, r_val3)| r_val3 == &**val3)
                     {
                         result.push((val1.to_string(), val2.to_string(), val3.to_string()));

--- a/src/structs/vml/fill.rs
+++ b/src/structs/vml/fill.rs
@@ -128,7 +128,7 @@ impl Fill {
             let r_id = image.get_rid(rel_list);
             r_id_str = format!("rId{}", r_id);
             attributes.push(("o:title", image.get_image_title()));
-            attributes.push(("o:relid", r_id_str.as_str()));
+            attributes.push(("o:relid", &r_id_str));
             attributes.push(("recolor", "t"));
             attributes.push(("rotate", "t"));
             attributes.push(("type", "frame"));

--- a/src/structs/vml/image_data.rs
+++ b/src/structs/vml/image_data.rs
@@ -66,10 +66,8 @@ impl ImageData {
     ) {
         // v:imagedata
         let mut attributes: Vec<(&str, &str)> = Vec::new();
-        let mut r_id_str = String::new();
-        let r_id = &self.image.get_rid(rel_list);
-        r_id_str = format!("rId{}", r_id);
-        attributes.push(("o:relid", r_id_str.as_str()));
+        let r_id_str = format!("rId{}", self.image.get_rid(rel_list));
+        attributes.push(("o:relid", &r_id_str));
         if self.title.has_value() {
             attributes.push(("o:title", self.title.get_value_str()));
         }

--- a/src/structs/vml/spreadsheet/anchor.rs
+++ b/src/structs/vml/spreadsheet/anchor.rs
@@ -180,7 +180,7 @@ impl Anchor {
     #[inline]
     fn get_number(value: Option<&&str>) -> u32 {
         match value {
-            Some(v) => v.to_string().trim().parse::<u32>().unwrap_or(0),
+            Some(v) => v.trim().parse::<u32>().unwrap_or(0),
             None => 0,
         }
     }

--- a/src/structs/vml/text_box.rs
+++ b/src/structs/vml/text_box.rs
@@ -94,7 +94,7 @@ impl TextBox {
                     inner_text = format!("{}<{}>", inner_text, tag);
                 }
                 Ok(Event::Text(ref e)) => {
-                    let s = e.unescape().unwrap().to_string();
+                    let s = e.unescape().unwrap();
                     inner_text = format!("{}{}", inner_text, s);
                 }
                 Ok(Event::End(ref e)) => {

--- a/src/structs/worksheet.rs
+++ b/src/structs/worksheet.rs
@@ -495,8 +495,7 @@ impl Worksheet {
     pub fn get_comments_to_hashmap(&self) -> HashMap<String, &Comment> {
         let mut result = HashMap::default();
         for comment in &self.comments {
-            let coordinate = comment.get_coordinate().to_string();
-            result.insert(coordinate, comment);
+            result.insert(comment.get_coordinate().to_string(), comment);
         }
         result
     }
@@ -1971,22 +1970,20 @@ impl AdjustmentCoordinate for Worksheet {
         }
 
         // cell
-        self.get_cell_collection_crate_mut()
-            .adjustment_insert_coordinate(
-                root_col_num,
-                offset_col_num,
-                root_row_num,
-                offset_row_num,
-            );
+        self.cell_collection.adjustment_insert_coordinate(
+            root_col_num,
+            offset_col_num,
+            root_row_num,
+            offset_row_num,
+        );
 
         // worksheet_drawing
-        self.get_worksheet_drawing_mut()
-            .adjustment_insert_coordinate(
-                root_col_num,
-                offset_col_num,
-                root_row_num,
-                offset_row_num,
-            );
+        self.worksheet_drawing.adjustment_insert_coordinate(
+            root_col_num,
+            offset_col_num,
+            root_row_num,
+            offset_row_num,
+        );
 
         // comments
         for comment in &mut self.comments {
@@ -2043,7 +2040,7 @@ impl AdjustmentCoordinate for Worksheet {
         }
         if offset_row_num != &0 {
             // row dimensions
-            self.get_row_dimensions_crate_mut()
+            self.row_dimensions
                 .adjustment_remove_value(root_row_num, offset_row_num);
         }
         if (offset_col_num == &0 && offset_row_num == &0) {
@@ -2073,13 +2070,12 @@ impl AdjustmentCoordinate for Worksheet {
         }
 
         // cell
-        self.get_cell_collection_crate_mut()
-            .adjustment_remove_coordinate(
-                root_col_num,
-                offset_col_num,
-                root_row_num,
-                offset_row_num,
-            );
+        self.cell_collection.adjustment_remove_coordinate(
+            root_col_num,
+            offset_col_num,
+            root_row_num,
+            offset_row_num,
+        );
 
         // worksheet_drawing
         self.get_worksheet_drawing_mut()

--- a/src/structs/worksheet_source.rs
+++ b/src/structs/worksheet_source.rs
@@ -46,7 +46,7 @@ impl WorksheetSource {
         // worksheetSource
         let mut attributes: Vec<(&str, &str)> = Vec::new();
         let ref_str = self.address.get_range().get_range();
-        attributes.push(("ref", ref_str.as_str()));
+        attributes.push(("ref", &ref_str));
         if self.address.get_sheet_name() != "" {
             attributes.push(("sheet", self.address.get_sheet_name()));
         }

--- a/src/writer/csv.rs
+++ b/src/writer/csv.rs
@@ -50,7 +50,6 @@ pub fn write_writer<W: io::Seek + io::Write>(
     }
 
     // encoding.
-    let res_into: Vec<u8>;
     let data_bytes = match *option.get_csv_encode_value() {
         CsvEncodeValues::ShiftJis => encoding_rs::SHIFT_JIS.encode(&data).0.into_owned(),
         CsvEncodeValues::Koi8u => encoding_rs::KOI8_U.encode(&data).0.into_owned(),

--- a/src/writer/driver.rs
+++ b/src/writer/driver.rs
@@ -54,9 +54,7 @@ pub(crate) fn write_text_node_conversion<'a, S>(writer: &mut Writer<Cursor<Vec<u
 where
     S: Into<Cow<'a, str>>,
 {
-    let data = data.into().to_string();
-    let data = partial_escape(&data);
-    write_text_node_no_escape(writer, data);
+    write_text_node_no_escape(writer, partial_escape(data.into()));
 }
 
 #[inline]

--- a/src/writer/xlsx.rs
+++ b/src/writer/xlsx.rs
@@ -69,7 +69,7 @@ fn make_buffer(spreadsheet: &Spreadsheet, is_light: bool) -> Result<std::vec::Ve
             worksheet::write(
                 &worksheet_no,
                 worksheet,
-                shared_string_table.clone(),
+                &shared_string_table,
                 &mut stylesheet,
                 spreadsheet.get_has_macros(),
                 &mut writer_manager,
@@ -156,7 +156,7 @@ fn make_buffer(spreadsheet: &Spreadsheet, is_light: bool) -> Result<std::vec::Ve
     writer_manager.file_list_sort();
 
     // Add SharedStrings
-    shared_strings::write(shared_string_table.clone(), &mut writer_manager)?;
+    shared_strings::write(&shared_string_table, &mut writer_manager)?;
 
     // Add Styles
     styles::write(&stylesheet, &mut writer_manager)?;

--- a/src/writer/xlsx/comment.rs
+++ b/src/writer/xlsx/comment.rs
@@ -52,7 +52,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
         write_start_tag(
             &mut writer,
             "comment",
-            vec![("ref", &coordinate), ("authorId", author_id.as_str())],
+            vec![("ref", &coordinate), ("authorId", &author_id)],
             false,
         );
 

--- a/src/writer/xlsx/rels.rs
+++ b/src/writer/xlsx/rels.rs
@@ -71,7 +71,7 @@ fn write_relationship(
     let tag_name = "Relationship";
     let mut attributes: Vec<(&str, &str)> = Vec::new();
     let r_id = format!("rId{}", p_id);
-    attributes.push(("Id", r_id.as_str()));
+    attributes.push(("Id", &r_id));
     attributes.push(("Type", p_type));
     attributes.push(("Target", p_target));
     if !p_target_mode.is_empty() {

--- a/src/writer/xlsx/shared_strings.rs
+++ b/src/writer/xlsx/shared_strings.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::sync::RwLock;
 
 pub(crate) fn write<W: io::Seek + io::Write>(
-    shared_string_table: Arc<RwLock<SharedStringTable>>,
+    shared_string_table: &RwLock<SharedStringTable>,
     writer_mng: &mut WriterManager<W>,
 ) -> result::Result<(), XlsxError> {
     if shared_string_table

--- a/src/writer/xlsx/workbook_rels.rs
+++ b/src/writer/xlsx/workbook_rels.rs
@@ -43,7 +43,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
             &mut writer,
             &index.to_string(),
             PIVOT_CACHE_DEF_NS,
-            pivot_cache_definition.as_str(),
+            &pivot_cache_definition,
             "",
         );
         index += 1;
@@ -107,7 +107,7 @@ fn write_relationship(
     let tag_name = "Relationship";
     let mut attributes: Vec<(&str, &str)> = Vec::new();
     let r_id = format!("rId{}", p_id);
-    attributes.push(("Id", r_id.as_str()));
+    attributes.push(("Id", &r_id));
     attributes.push(("Type", p_type));
     attributes.push(("Target", p_target));
     if !p_target_mode.is_empty() {

--- a/src/writer/xlsx/worksheet.rs
+++ b/src/writer/xlsx/worksheet.rs
@@ -16,7 +16,7 @@ use std::sync::RwLock;
 pub(crate) fn write<W: io::Seek + io::Write>(
     sheet_no: &i32,
     worksheet: &Worksheet,
-    shared_string_table: Arc<RwLock<SharedStringTable>>,
+    shared_string_table: &RwLock<SharedStringTable>,
     stylesheet: &mut Stylesheet,
     has_macros: bool,
     writer_mng: &mut WriterManager<W>,
@@ -81,7 +81,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     write_start_tag(
         &mut writer,
         "dimension",
-        vec![("ref", worksheet.calculate_worksheet_dimension().as_str())],
+        vec![("ref", &worksheet.calculate_worksheet_dimension())],
         true,
     );
 
@@ -150,7 +150,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
 
         // row
         if cells_in_row.is_empty() {
-            let spans = "0:0".to_string();
+            let spans = "0:0";
             row.write_to(&mut writer, stylesheet, spans, true);
         } else {
             let (first_num, last_num) = (
@@ -159,7 +159,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
             );
             let spans = format!("{first_num}:{last_num}");
 
-            row.write_to(&mut writer, stylesheet, spans, false);
+            row.write_to(&mut writer, stylesheet, &spans, false);
             // c
             for cell in cells_in_row {
                 cell.write_to(
@@ -223,7 +223,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
             if *hyperlink.get_location() {
                 attributes.push(("location", hyperlink.get_url()));
             } else {
-                attributes.push(("r:id", r_id_str.as_str()));
+                attributes.push(("r:id", &r_id_str));
                 r_id += 1;
             }
             write_start_tag(&mut writer, "hyperlink", attributes, true);
@@ -255,12 +255,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     if worksheet.has_drawing_object() {
         // drawing
         let r_id_str = format!("rId{}", &r_id);
-        write_start_tag(
-            &mut writer,
-            "drawing",
-            vec![("r:id", r_id_str.as_str())],
-            true,
-        );
+        write_start_tag(&mut writer, "drawing", vec![("r:id", &r_id_str)], true);
         r_id += 1;
     }
 
@@ -270,7 +265,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
         write_start_tag(
             &mut writer,
             "legacyDrawing",
-            vec![("r:id", r_id_str.as_str())],
+            vec![("r:id", &r_id_str)],
             true,
         );
         r_id += 1;
@@ -287,12 +282,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
         );
         for table in worksheet.get_tables().iter() {
             let r_id_str = format!("rId{}", &r_id);
-            write_start_tag(
-                &mut writer,
-                "tablePart",
-                vec![("r:id", r_id_str.as_str())],
-                true,
-            );
+            write_start_tag(&mut writer, "tablePart", vec![("r:id", &r_id_str)], true);
             r_id += 1;
         }
         write_end_tag(&mut writer, "tableParts");

--- a/src/writer/xlsx/worksheet_rels.rs
+++ b/src/writer/xlsx/worksheet_rels.rs
@@ -42,7 +42,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
         if !*hyperlink.get_location() {
             is_write = write_relationship(
                 &mut writer,
-                r_id.to_string().as_str(),
+                &r_id.to_string(),
                 HYPERLINK_NS,
                 hyperlink.get_url(),
                 "External",
@@ -56,7 +56,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
         let object_name = format!("printerSettings{}.bin", printer_settings_no);
         is_write = write_relationship(
             &mut writer,
-            r_id.to_string().as_str(),
+            &r_id.to_string(),
             PRINTER_SETTINGS_NS,
             format!("../printerSettings/{}", object_name).as_str(),
             "",
@@ -68,9 +68,9 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     if worksheet.has_drawing_object() {
         is_write = write_relationship(
             &mut writer,
-            r_id.to_string().as_str(),
+            &r_id.to_string(),
             DRAWINGS_NS,
-            format!("../drawings/drawing{}.xml", drawing_no.to_string().as_str()).as_str(),
+            format!("../drawings/drawing{}.xml", drawing_no).as_str(),
             "",
         );
         r_id += 1;
@@ -80,13 +80,9 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     if worksheet.has_legacy_drawing() {
         is_write = write_relationship(
             &mut writer,
-            r_id.to_string().as_str(),
+            &r_id.to_string(),
             VML_DRAWING_NS,
-            format!(
-                "../drawings/vmlDrawing{}.vml",
-                vml_drawing_no.to_string().as_str()
-            )
-            .as_str(),
+            format!("../drawings/vmlDrawing{}.vml", vml_drawing_no).as_str(),
             "",
         );
         r_id += 1;
@@ -96,9 +92,9 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     for table_no in table_no_list.iter() {
         is_write = write_relationship(
             &mut writer,
-            r_id.to_string().as_str(),
+            &r_id.to_string(),
             TABLE_NS,
-            format!("../tables/table{}.xml", table_no.to_string().as_str()).as_str(),
+            format!("../tables/table{}.xml", table_no).as_str(),
             "",
         );
         r_id += 1;
@@ -113,7 +109,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
             let object_name = format!("Microsoft_Excel_Worksheet{}.xlsx", excel_no);
             write_relationship(
                 &mut writer,
-                r_id.to_string().as_str(),
+                &r_id.to_string(),
                 PACKAGE_NS,
                 format!("../embeddings/{}", object_name).as_str(),
                 "",
@@ -125,7 +121,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
             let object_name = format!("oleObject{}.bin", ole_object_no);
             write_relationship(
                 &mut writer,
-                r_id.to_string().as_str(),
+                &r_id.to_string(),
                 OLE_OBJECT_NS,
                 format!("../embeddings/{}", object_name).as_str(),
                 "",
@@ -139,7 +135,7 @@ pub(crate) fn write<W: io::Seek + io::Write>(
             .get_image_name();
         is_write = write_relationship(
             &mut writer,
-            r_id.to_string().as_str(),
+            &r_id.to_string(),
             IMAGE_NS,
             format!("../media/{}", image_name).as_str(),
             "",
@@ -151,9 +147,9 @@ pub(crate) fn write<W: io::Seek + io::Write>(
     if !worksheet.get_comments().is_empty() {
         is_write = write_relationship(
             &mut writer,
-            r_id.to_string().as_str(),
+            &r_id.to_string(),
             COMMENTS_NS,
-            format!("../comments{}.xml", comment_no.to_string().as_str()).as_str(),
+            format!("../comments{}.xml", comment_no).as_str(),
             "",
         );
     }
@@ -177,7 +173,7 @@ fn write_relationship(
     let tag_name = "Relationship";
     let mut attributes: Vec<(&str, &str)> = Vec::new();
     let r_id = format!("rId{}", p_id);
-    attributes.push(("Id", r_id.as_str()));
+    attributes.push(("Id", &r_id));
     attributes.push(("Type", p_type));
     attributes.push(("Target", p_target));
     if !p_target_mode.is_empty() {


### PR DESCRIPTION
This PR contains following:
- Removed unnecessary data cloning into as `String` where the primitives can be used.
- Removed call to `.as_str()` where reference is suffice.
- Changed function signature for  some `pub(crate)` functions to accept primitive types.
- Simplified functions by removing unnecessary getters where `&mut Self` is passed into the function.
- Other minor improvements