### PR TITLE
Add indices to Cells.

### DIFF
--- a/src/structs/cells.rs
+++ b/src/structs/cells.rs
@@ -34,6 +34,22 @@ impl Cells {
         self.iter_collection().collect()
     }
 
+    #[inline]
+    pub fn is_row_empty(&self, row_num: u32) -> bool {
+        self.row_column_index
+            .range((row_num, 0)..=(row_num, u32::MAX))
+            .next()
+            .is_none()
+    }
+
+    #[inline]
+    pub fn is_col_empty(&self, col_num: u32) -> bool {
+        self.column_row_index
+            .range((col_num, 0)..=(col_num, u32::MAX))
+            .next()
+            .is_none()
+    }
+
     /// Iterates all cell coordinates, sorted by row then by column.
     /// Coordinate returned is (column, row).
     #[inline(always)]

--- a/src/structs/cells.rs
+++ b/src/structs/cells.rs
@@ -8,33 +8,72 @@ use crate::structs::Row;
 use crate::traits::AdjustmentCoordinate;
 use crate::traits::AdjustmentCoordinateWith2Sheet;
 use crate::traits::AdjustmentCoordinateWithSheet;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 #[derive(Clone, Default, Debug)]
 pub struct Cells {
     map: HashMap<(u32, u32), Box<Cell>>,
+    row_column_index: BTreeSet<(u32, u32)>,
+    column_row_index: BTreeSet<(u32, u32)>,
     default_cell_value: CellValue,
     default_style: Style,
 }
 impl Cells {
+    /// Iterates all [`Cell`]s in arbitrary order (not sorted).
     #[inline]
-    pub fn get_collection(&self) -> Vec<&Cell> {
-        self.map.values().map(Box::as_ref).collect()
+    pub fn iter_collection(&self) -> impl Iterator<Item = &Cell> {
+        self.map.values().map(Box::as_ref)
     }
 
+    #[deprecated(
+        since = "2.2.4",
+        note = "Please use iter_collection().collect::<Vec<_>>() instead"
+    )]
+    #[inline(always)]
+    pub fn get_collection(&self) -> Vec<&Cell> {
+        self.iter_collection().collect()
+    }
+
+    /// Iterates all cell coordinates, sorted by row then by column.
+    /// Coordinate returned is (column, row).
+    #[inline(always)]
+    pub fn iter_coordinates_sorted_by_row_column(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
+        self.row_column_index
+            .iter()
+            .copied()
+            .map(|(row, col)| (col, row))
+    }
+
+    /// Iterates all [`Cell`]s, sorted by row then by column.
+    /// Coordinate returned is (column, row).
+    #[inline]
+    pub fn iter_cells_sorted_by_row_column(&self) -> impl Iterator<Item = &Cell> {
+        self.iter_coordinates_sorted_by_row_column()
+            .map(|(col, row)| self.map.get(&(row, col)).unwrap().as_ref())
+    }
+
+    /// Iterates all cell coordinates, sorted by column then by row.
+    /// Coordinate returned is (column, row).
+    #[inline(always)]
+    pub fn iter_coordinates_sorted_by_column_row(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
+        self.column_row_index.iter().copied()
+    }
+
+    /// Iterates all [`Cell`]s, sorted by column then by row.
+    /// Coordinate returned is (column, row).
+    #[inline]
+    pub fn iter_cells_sorted_by_column_row(&self) -> impl Iterator<Item = &Cell> {
+        self.iter_coordinates_sorted_by_column_row()
+            .map(|(col, row)| self.map.get(&(row, col)).unwrap().as_ref())
+    }
+
+    #[deprecated(
+        since = "2.2.4",
+        note = "Please use iter_cells_sorted_by_row_column().collect::<Vec<_>>() instead"
+    )]
+    #[inline(always)]
     pub fn get_collection_sorted(&self) -> Vec<&Cell> {
-        let mut cells = self.get_collection();
-        cells.sort_by(|a, b| {
-            (
-                a.get_coordinate().get_row_num(),
-                a.get_coordinate().get_col_num(),
-            )
-                .cmp(&(
-                    b.get_coordinate().get_row_num(),
-                    b.get_coordinate().get_col_num(),
-                ))
-        });
-        cells
+        self.iter_cells_sorted_by_row_column().collect()
     }
 
     #[inline]
@@ -47,39 +86,130 @@ impl Cells {
         &self.map
     }
 
+    /// Iterates all rows cells in a given column, sorted by the row index.
     #[inline]
-    pub fn get_collection_by_column(&self, column_num: &u32) -> Vec<&Cell> {
-        self.map
-            .values()
-            .filter(|k| k.get_coordinate().get_col_num() == column_num)
-            .map(Box::as_ref)
-            .collect()
+    pub fn iter_rows_with_cells_by_column(
+        &self,
+        column_num: u32,
+    ) -> impl Iterator<Item = u32> + '_ {
+        self.column_row_index
+            .range((column_num, 0)..=(column_num, u32::MAX))
+            .copied()
+            .map(|(_, row)| row)
     }
 
+    /// Iterates all [`Cell`]s in a given column, sorted by the row index.
     #[inline]
+    pub fn iter_cells_by_column(&self, column_num: u32) -> impl Iterator<Item = &Cell> {
+        self.iter_rows_with_cells_by_column(column_num)
+            .map(move |row| self.map.get(&(row, column_num)).unwrap().as_ref())
+    }
+
+    #[deprecated(
+        since = "2.2.4",
+        note = "Please use iter_cells_by_column(column_num).collect::<Vec<_>>() instead"
+    )]
+    #[inline(always)]
+    pub fn get_collection_by_column(&self, column_num: &u32) -> Vec<&Cell> {
+        self.iter_cells_by_column(*column_num).collect()
+    }
+
+    /// Iterates all column cells in a given column, sorted by the column index.
+    #[inline]
+    pub fn iter_columns_with_cells_by_row(&self, row_num: u32) -> impl Iterator<Item = u32> + '_ {
+        self.row_column_index
+            .range((row_num, 0)..=(row_num, u32::MAX))
+            .copied()
+            .map(|(_, col)| col)
+    }
+
+    /// Iterates all [`Cell`]s in a given column, sorted by the column index.
+    #[inline]
+    pub fn iter_cells_by_row(&self, row_num: u32) -> impl Iterator<Item = &Cell> {
+        self.iter_columns_with_cells_by_row(row_num)
+            .map(move |col| self.map.get(&(row_num, col)).unwrap().as_ref())
+    }
+
+    #[deprecated(
+        since = "2.2.4",
+        note = "Please use iter_cells_by_row(row_num).collect::<Vec<_>>() instead"
+    )]
+    #[inline(always)]
     pub fn get_collection_by_row(&self, row_num: &u32) -> Vec<&Cell> {
-        self.map
-            .values()
-            .filter(|k| k.get_coordinate().get_row_num() == row_num)
-            .map(Box::as_ref)
-            .collect()
+        self.iter_cells_by_row(*row_num).collect()
+    }
+
+    /// Iterates all coordinates in a range, sorted by row then by column.
+    /// Coordinate returned is (column, row).
+    #[inline]
+    pub fn iter_coordinates_by_range_sorted_by_row(
+        &self,
+        row_start: u32,
+        row_end: u32,
+        col_start: u32,
+        col_end: u32,
+    ) -> impl Iterator<Item = (u32, u32)> + '_ {
+        self.row_column_index
+            .range((row_start, col_start)..=(row_end, col_end))
+            .copied()
+            .filter(move |(_, col)| (col_start..=col_end).contains(col))
+            .map(|(row, col)| (col, row))
+    }
+
+    /// Iterates all [`Cell`]s in a range, sorted by row then by column.
+    #[inline]
+    pub fn iter_cells_by_range_sorted_by_row(
+        &self,
+        row_start: u32,
+        row_end: u32,
+        col_start: u32,
+        col_end: u32,
+    ) -> impl Iterator<Item = &Cell> {
+        self.iter_coordinates_by_range_sorted_by_row(row_start, row_end, col_start, col_end)
+            .map(move |(col, row)| self.map.get(&(row, col)).unwrap().as_ref())
+    }
+
+    /// Iterates all coordinates in a range, sorted by column then by row.
+    /// Coordinate returned is (column, row).
+    #[inline]
+    pub fn iter_coordinates_by_range_sorted_by_column(
+        &self,
+        col_start: u32,
+        col_end: u32,
+        row_start: u32,
+        row_end: u32,
+    ) -> impl Iterator<Item = (u32, u32)> + '_ {
+        self.column_row_index
+            .range((col_start, row_start)..=(col_end, row_end))
+            .copied()
+            .filter(move |(_, row)| (row_start..=row_end).contains(row))
+    }
+
+    /// Iterates all [`Cell`]s in a range, sorted by column then by row.
+    /// Coordinate returned is (column, row).
+    #[inline]
+    pub fn iter_cells_by_range_sorted_by_column(
+        &self,
+        col_start: u32,
+        col_end: u32,
+        row_start: u32,
+        row_end: u32,
+    ) -> impl Iterator<Item = &Cell> {
+        self.iter_coordinates_by_range_sorted_by_column(col_start, col_end, row_start, row_end)
+            .map(move |(col, row)| self.map.get(&(row, col)).unwrap().as_ref())
     }
 
     #[inline]
     pub fn get_collection_by_column_to_hashmap(&self, column_num: &u32) -> HashMap<u32, &Cell> {
-        self.map
-            .iter()
-            .filter(|(k, _v)| &k.1 == column_num)
-            .map(|(k, v)| (k.0, v.as_ref()))
+        self.iter_cells_by_column(*column_num)
+            .map(|cell| (*cell.get_coordinate().get_row_num(), cell))
             .collect()
     }
 
     #[inline]
     pub fn get_collection_by_row_to_hashmap(&self, row_num: &u32) -> HashMap<u32, &Cell> {
-        self.map
-            .iter()
-            .filter(|(k, _v)| &k.0 == row_num)
-            .map(|(k, v)| (k.1, v.as_ref()))
+        self.iter_cells_by_row(*row_num)
+            .map(|cell| (*cell.get_coordinate().get_col_num(), cell))
             .collect()
     }
 
@@ -88,18 +218,18 @@ impl Cells {
         &mut self.map
     }
 
+    #[inline(always)]
     pub fn get_highest_column_and_row(&self) -> (u32, u32) {
-        self.map
-            .keys()
-            .fold((0, 0), |(col_max, row_max), &(row, col)| {
-                (col.max(col_max), row.max(row_max))
-            })
+        (
+            self.column_row_index.last().copied().unwrap_or((0, 0)).0,
+            self.row_column_index.last().copied().unwrap_or((0, 0)).0,
+        )
     }
 
     /// Has Hyperlink
     #[inline]
     pub fn has_hyperlink(&self) -> bool {
-        self.map.values().any(|c| c.get_hyperlink().is_some())
+        self.map.values().find_map(|c| c.get_hyperlink()).is_some()
     }
 
     #[inline]
@@ -114,8 +244,8 @@ impl Cells {
     pub(crate) fn get_mut<T>(
         &mut self,
         coordinate: T,
-        row_dimenshon: &Row,
-        col_dimenshon: &Column,
+        row_dimension: &Row,
+        col_dimension: &Column,
     ) -> &mut Cell
     where
         T: Into<CellCoordinates>,
@@ -125,12 +255,16 @@ impl Cells {
             let mut c = Cell::default();
             c.get_coordinate_mut().set_col_num(col);
             c.get_coordinate_mut().set_row_num(row);
-            if col_dimenshon.has_style() {
-                c.set_style(col_dimenshon.get_style().clone());
+            if col_dimension.has_style() {
+                c.set_style(col_dimension.get_style().clone());
             }
-            if row_dimenshon.has_style() {
-                c.set_style(row_dimenshon.get_style().clone());
+            if row_dimension.has_style() {
+                c.set_style(row_dimension.get_style().clone());
             }
+
+            self.row_column_index.insert((row, col));
+            self.column_row_index.insert((col, row));
+
             Box::new(c)
         })
     }
@@ -163,12 +297,12 @@ impl Cells {
     pub(crate) fn set(
         &mut self,
         cell: Cell,
-        row_dimenshon: &Row,
-        col_dimenshon: &Column,
+        row_dimension: &Row,
+        col_dimension: &Column,
     ) -> &mut Self {
         let col_num = cell.get_coordinate().get_col_num();
         let row_num = cell.get_coordinate().get_row_num();
-        let target_cell = self.get_mut((col_num, row_num), row_dimenshon, col_dimenshon);
+        let target_cell = self.get_mut((col_num, row_num), row_dimension, col_dimension);
         target_cell.set_obj(cell);
         self
     }
@@ -179,35 +313,138 @@ impl Cells {
         self
     }
 
-    #[inline]
     pub(crate) fn add(&mut self, cell: Cell) {
-        let col_num = cell.get_coordinate().get_col_num();
-        let row_num = cell.get_coordinate().get_row_num();
-        self.map.insert((*row_num, *col_num), Box::new(cell));
+        let col_num = *cell.get_coordinate().get_col_num();
+        let row_num = *cell.get_coordinate().get_row_num();
+        self.map.insert((row_num, col_num), Box::new(cell));
+        self.row_column_index.insert((row_num, col_num));
+        self.column_row_index.insert((col_num, row_num));
     }
 
     #[inline]
     pub(crate) fn remove(&mut self, col_num: &u32, row_num: &u32) -> bool {
         let k = (*row_num, *col_num);
-        self.map.remove(&k).is_some()
+        let r = self.map.remove(&k).is_some();
+        if r {
+            self.row_column_index.remove(&k);
+            self.column_row_index.remove(&(k.1, k.0));
+        }
+        r
     }
 
+    pub fn iter_all_coordinates_by_range_sorted_by_row(
+        &self,
+        range: &str,
+    ) -> impl Iterator<Item = Option<(u32, u32)>> + '_ {
+        let (row_start, row_end, col_start, col_end) = get_start_and_end_point(range);
+
+        let mut iter =
+            self.iter_coordinates_by_range_sorted_by_row(row_start, row_end, col_start, col_end);
+
+        let mut current = iter.next();
+
+        (row_start..=row_end)
+            .flat_map(move |row| (col_start..=col_end).map(move |col| (row, col)))
+            .map(move |x| {
+                if let Some((cur_col, cur_row)) = current {
+                    if x < (cur_row, cur_col) {
+                        None
+                    } else {
+                        current = iter.next();
+                        Some((x.1, x.0))
+                    }
+                } else {
+                    None
+                }
+            })
+    }
+
+    pub fn iter_all_cells_by_range_sorted_by_row(
+        &self,
+        range: &str,
+    ) -> impl Iterator<Item = Option<&Cell>> + '_ {
+        self.iter_all_coordinates_by_range_sorted_by_row(range)
+            .map(move |coordinate| {
+                coordinate.map(move |(col, row)| self.map.get(&(row, col)).unwrap().as_ref())
+            })
+    }
+
+    #[inline]
+    pub fn iter_all_cell_values_by_range_sorted_by_row(
+        &self,
+        range: &str,
+    ) -> impl Iterator<Item = &CellValue> + '_ {
+        self.iter_all_coordinates_by_range_sorted_by_row(range)
+            .map(|coordinate| {
+                coordinate.map_or(&self.default_cell_value, |c| self.get_cell_value(c))
+            })
+    }
+
+    pub fn iter_all_coordinates_by_range_sorted_by_column(
+        &self,
+        range: &str,
+    ) -> impl Iterator<Item = Option<(u32, u32)>> + '_ {
+        let (row_start, row_end, col_start, col_end) = get_start_and_end_point(range);
+
+        let mut iter =
+            self.iter_coordinates_by_range_sorted_by_column(col_start, col_end, row_start, row_end);
+
+        let mut current = iter.next();
+
+        (col_start..=col_end)
+            .flat_map(move |col| (row_start..=row_end).map(move |row| (col, row)))
+            .map(move |coordinate| {
+                if let Some(cur) = current {
+                    if coordinate < cur {
+                        None
+                    } else {
+                        current = iter.next();
+                        Some(coordinate)
+                    }
+                } else {
+                    None
+                }
+            })
+    }
+
+    pub fn iter_all_cells_by_range_sorted_by_column(
+        &self,
+        range: &str,
+    ) -> impl Iterator<Item = Option<&Cell>> + '_ {
+        self.iter_all_coordinates_by_range_sorted_by_column(range)
+            .map(move |coordinate| {
+                coordinate.map(move |(col, row)| self.map.get(&(row, col)).unwrap().as_ref())
+            })
+    }
+
+    #[inline]
+    pub fn iter_all_cell_values_by_range_sorted_by_column(
+        &self,
+        range: &str,
+    ) -> impl Iterator<Item = &CellValue> + '_ {
+        self.iter_all_coordinates_by_range_sorted_by_column(range)
+            .map(|coordinate| {
+                coordinate.map_or(&self.default_cell_value, |c| self.get_cell_value(c))
+            })
+    }
+
+    #[deprecated(
+        since = "2.2.4",
+        note = "Please use iter_all_cells_by_range_sorted_by_row(range).collect::<Vec<_>>() instead"
+    )]
+    #[inline(always)]
     pub fn get_cell_by_range(&self, range: &str) -> Vec<Option<&Cell>> {
-        let mut result: Vec<Option<&Cell>> = Vec::new();
-        let coordinate_list = get_coordinate_list(&range);
-        for (col_num, row_num) in coordinate_list {
-            result.push(self.get((&col_num, &row_num)));
-        }
-        result
+        self.iter_all_cells_by_range_sorted_by_row(range).collect()
     }
 
+    #[deprecated(
+        since = "2.2.4",
+        note = "Please use iter_all_cell_values_by_range_sorted_by_row(range).collect::<Vec<_>>() instead"
+    )]
+    #[inline(always)]
     pub fn get_cell_value_by_range(&self, range: &str) -> Vec<&CellValue> {
-        let mut result: Vec<&CellValue> = Vec::new();
-        let coordinate_list = get_coordinate_list(&range);
-        for (col_num, row_num) in coordinate_list {
-            result.push(self.get_cell_value((&col_num, &row_num)));
-        }
-        result
+        self.iter_all_cell_values_by_range_sorted_by_row(range)
+            .collect::<Vec<_>>()
     }
 
     #[inline]
@@ -218,7 +455,7 @@ impl Cells {
         }
     }
 
-    pub(crate) fn rebuild_map(&mut self) {
+    pub(crate) fn rebuild_map_and_indices(&mut self) {
         self.map = self
             .get_collection_to_hashmap_mut()
             .iter_mut()
@@ -231,7 +468,16 @@ impl Cells {
                     std::mem::take(cell),
                 )
             })
-            .collect()
+            .collect();
+
+        self.row_column_index = self.map.keys().copied().collect();
+
+        self.column_row_index = self
+            .map
+            .keys()
+            .copied()
+            .map(|(col, row)| (row, col))
+            .collect();
     }
 }
 impl AdjustmentCoordinate for Cells {
@@ -244,7 +490,7 @@ impl AdjustmentCoordinate for Cells {
         offset_row_num: &u32,
     ) {
         // update cell
-        for ((_, _), cell) in self.get_collection_to_hashmap_mut() {
+        for cell in self.get_collection_to_hashmap_mut().values_mut() {
             cell.adjustment_insert_coordinate(
                 root_col_num,
                 offset_col_num,
@@ -252,7 +498,7 @@ impl AdjustmentCoordinate for Cells {
                 offset_row_num,
             );
         }
-        self.rebuild_map();
+        self.rebuild_map_and_indices();
     }
 
     #[inline]
@@ -280,7 +526,7 @@ impl AdjustmentCoordinate for Cells {
                 offset_row_num,
             );
         }
-        self.rebuild_map();
+        self.rebuild_map_and_indices();
     }
 }
 impl AdjustmentCoordinateWith2Sheet for Cells {
@@ -294,7 +540,7 @@ impl AdjustmentCoordinateWith2Sheet for Cells {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        for ((_, _), cell) in self.get_collection_to_hashmap_mut() {
+        for cell in self.get_collection_to_hashmap_mut().values_mut() {
             cell.adjustment_insert_coordinate_with_2sheet(
                 self_sheet_name,
                 sheet_name,
@@ -316,7 +562,7 @@ impl AdjustmentCoordinateWith2Sheet for Cells {
         root_row_num: &u32,
         offset_row_num: &u32,
     ) {
-        for ((_, _), cell) in self.get_collection_to_hashmap_mut() {
+        for cell in self.get_collection_to_hashmap_mut().values_mut() {
             cell.adjustment_remove_coordinate_with_2sheet(
                 self_sheet_name,
                 sheet_name,

--- a/src/structs/column.rs
+++ b/src/structs/column.rs
@@ -136,7 +136,7 @@ impl Column {
             None => 11f64,
         };
 
-        let mut cell_list = cells.get_collection_by_column(self.get_col_num());
+        let mut cell_list: Vec<_> = cells.iter_cells_by_column(*self.get_col_num()).collect();
         cell_list.sort_by(|a, b| {
             a.get_coordinate()
                 .get_row_num()

--- a/src/structs/column.rs
+++ b/src/structs/column.rs
@@ -136,13 +136,7 @@ impl Column {
             None => 11f64,
         };
 
-        let mut cell_list: Vec<_> = cells.iter_cells_by_column(*self.get_col_num()).collect();
-        cell_list.sort_by(|a, b| {
-            a.get_coordinate()
-                .get_row_num()
-                .cmp(b.get_coordinate().get_row_num())
-        });
-        for cell in cell_list {
+        for cell in cells.iter_cells_by_column(*self.get_col_num()) {
             let column_width = cell.get_width_point(&column_font_size);
 
             if column_width > column_width_max {

--- a/src/structs/worksheet.rs
+++ b/src/structs/worksheet.rs
@@ -169,12 +169,14 @@ impl Worksheet {
     /// Get Cell List.
     #[inline]
     pub fn get_cell_collection(&self) -> Vec<&Cell> {
-        self.cell_collection.get_collection()
+        self.cell_collection.iter_collection().collect()
     }
 
     #[inline]
     pub fn get_cell_collection_sorted(&self) -> Vec<&Cell> {
-        self.cell_collection.get_collection_sorted()
+        self.cell_collection
+            .iter_cells_sorted_by_row_column()
+            .collect()
     }
 
     /// Get Cell List in mutable.
@@ -272,12 +274,14 @@ impl Worksheet {
 
     #[inline]
     pub fn get_collection_by_column(&self, column_num: &u32) -> Vec<&Cell> {
-        self.cell_collection.get_collection_by_column(column_num)
+        self.cell_collection
+            .iter_cells_by_column(*column_num)
+            .collect()
     }
 
     #[inline]
     pub fn get_collection_by_row(&self, row_num: &u32) -> Vec<&Cell> {
-        self.cell_collection.get_collection_by_row(row_num)
+        self.cell_collection.iter_cells_by_row(*row_num).collect()
     }
 
     #[inline]
@@ -380,7 +384,9 @@ impl Worksheet {
     /// ```
     #[inline]
     pub fn get_cell_value_by_range(&self, range: &str) -> Vec<&CellValue> {
-        self.cell_collection.get_cell_value_by_range(range)
+        self.cell_collection
+            .iter_all_cell_values_by_range_sorted_by_row(range)
+            .collect()
     }
 
     /// Get style.
@@ -557,7 +563,7 @@ impl Worksheet {
     /// Get Hyperlink convert to hashmap.
     pub(crate) fn get_hyperlink_collection_to_hashmap(&self) -> HashMap<String, &Hyperlink> {
         let mut result: HashMap<String, &Hyperlink> = HashMap::new();
-        for cell in self.cell_collection.get_collection() {
+        for cell in self.cell_collection.iter_collection() {
             if let Some(hyperlink) = cell.get_hyperlink() {
                 let coordition = coordinate_from_index(
                     cell.get_coordinate().get_col_num(),
@@ -1799,9 +1805,9 @@ impl Worksheet {
         }
 
         // Iterate row by row, collecting cell information (do I copy)
-        let cells = self.cell_collection.get_cell_by_range(range);
-        let mut copy_cells: Vec<Cell> = cells
-            .into_iter()
+        let mut copy_cells: Vec<Cell> = self
+            .cell_collection
+            .iter_all_cells_by_range_sorted_by_row(range)
             .flatten()
             .map(|cell| cell.clone())
             .collect();
@@ -1839,7 +1845,7 @@ impl Worksheet {
             if self.row_dimensions.get_row_dimension(&row).is_some() {
                 let mut indexes: Vec<(u32, u32)> = Vec::new();
                 {
-                    let cells: Vec<&Cell> = self.cell_collection.get_collection_by_row(&row);
+                    let cells: Vec<&Cell> = self.cell_collection.iter_cells_by_row(row).collect();
                     for cell in cells {
                         if !cell.is_visually_empty() {
                             return;


### PR DESCRIPTION
This PR adds two indices to the `Cells` type: one sorted by row then by column, the other sorted by column then by row.

Iterators are provided for different styles of sorting.

It is now extremely easy to iterate through all the cells of a particular row or column, and to iterate through cells in order.

Original methods that create `Vec`'s are deprecated in favor of using iterators as much as possible.
