### PR TITLE
Fix formula cached-value typing and add typed formula result setters

### DIFF
--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -351,6 +351,39 @@ impl Cell {
     }
 
     #[inline]
+    pub fn set_formula_result_number<T>(&mut self, value: T) -> &mut Self
+    where
+        T: Into<f64>,
+    {
+        self.cell_value.set_formula_result_number(value);
+        self
+    }
+
+    #[inline]
+    pub fn set_formula_result_bool(&mut self, value: bool) -> &mut Self {
+        self.cell_value.set_formula_result_bool(value);
+        self
+    }
+
+    #[inline]
+    pub fn set_formula_result_error(&mut self, value: crate::CellErrorType) -> &mut Self {
+        self.cell_value.set_formula_result_error(value);
+        self
+    }
+
+    #[inline]
+    pub fn set_formula_result_string<S: Into<String>>(&mut self, value: S) -> &mut Self {
+        self.cell_value.set_formula_result_string(value);
+        self
+    }
+
+    #[inline]
+    pub fn set_formula_result_blank(&mut self) -> &mut Self {
+        self.cell_value.set_formula_result_blank();
+        self
+    }
+
+    #[inline]
     pub fn set_blank(&mut self) -> &mut Self {
         self.cell_value.set_blank();
         self

--- a/src/structs/cell_value.rs
+++ b/src/structs/cell_value.rs
@@ -274,6 +274,59 @@ impl CellValue {
         self
     }
 
+    /// Sets a formula cached result as a numeric value.
+    ///
+    /// This method only updates the cached value (`<v>`) and does not remove
+    /// the formula object (`<f>`).
+    #[inline]
+    pub fn set_formula_result_number<T>(&mut self, value: T) -> &mut Self
+    where
+        T: Into<f64>,
+    {
+        self.raw_value = CellRawValue::Numeric(value.into());
+        self
+    }
+
+    /// Sets a formula cached result as a boolean value.
+    ///
+    /// This method only updates the cached value (`<v>`) and does not remove
+    /// the formula object (`<f>`).
+    #[inline]
+    pub fn set_formula_result_bool(&mut self, value: bool) -> &mut Self {
+        self.raw_value = CellRawValue::Bool(value);
+        self
+    }
+
+    /// Sets a formula cached result as an Excel error value.
+    ///
+    /// This method only updates the cached value (`<v>`) and does not remove
+    /// the formula object (`<f>`).
+    #[inline]
+    pub fn set_formula_result_error(&mut self, value: CellErrorType) -> &mut Self {
+        self.raw_value = CellRawValue::Error(value);
+        self
+    }
+
+    /// Sets a formula cached result as a string value.
+    ///
+    /// This method only updates the cached value (`<v>`) and does not remove
+    /// the formula object (`<f>`).
+    #[inline]
+    pub fn set_formula_result_string<S: Into<String>>(&mut self, value: S) -> &mut Self {
+        self.raw_value = CellRawValue::String(value.into().into_boxed_str());
+        self
+    }
+
+    /// Sets a formula cached result as blank.
+    ///
+    /// This method only updates the cached value (`<v>`) and does not remove
+    /// the formula object (`<f>`).
+    #[inline]
+    pub fn set_formula_result_blank(&mut self) -> &mut Self {
+        self.raw_value = CellRawValue::Empty;
+        self
+    }
+
     #[inline]
     pub fn set_error<S: Into<String>>(&mut self, value: S) -> &mut Self {
         self.set_value_crate(value);
@@ -471,5 +524,34 @@ mod tests {
         obj.remove_formula();
         obj.set_value_string("OK");
         assert_eq!(obj.data_type_crate(), "s");
+    }
+
+    #[test]
+    fn typed_formula_result_helpers_preserve_formula() {
+        let mut obj = CellValue::default();
+        obj.set_formula("A1+1");
+
+        obj.set_formula_result_number(3.5);
+        assert_eq!(obj.formula(), "A1+1");
+        assert_eq!(obj.raw_value, CellRawValue::Numeric(3.5));
+
+        obj.set_formula_result_bool(false);
+        assert_eq!(obj.formula(), "A1+1");
+        assert_eq!(obj.raw_value, CellRawValue::Bool(false));
+
+        obj.set_formula_result_error(CellErrorType::Ref);
+        assert_eq!(obj.formula(), "A1+1");
+        assert_eq!(obj.raw_value, CellRawValue::Error(CellErrorType::Ref));
+
+        obj.set_formula_result_string("OK");
+        assert_eq!(obj.formula(), "A1+1");
+        assert!(matches!(
+            &obj.raw_value,
+            CellRawValue::String(value) if value.as_ref() == "OK"
+        ));
+
+        obj.set_formula_result_blank();
+        assert_eq!(obj.formula(), "A1+1");
+        assert_eq!(obj.raw_value, CellRawValue::Empty);
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2425,3 +2425,52 @@ fn write_keeps_shared_formula_metadata_stable() {
 
     assert_eq!(rewritten_shared, source_shared);
 }
+
+#[test]
+fn typed_formula_result_helpers_write_expected_types() {
+    let mut book = new_file();
+    let sheet = book.sheet_mut(0).unwrap();
+
+    sheet
+        .get_cell_mut("B1")
+        .set_formula("10/2")
+        .set_formula_result_number(5.0);
+    sheet
+        .get_cell_mut("B2")
+        .set_formula("1=2")
+        .set_formula_result_bool(false);
+    sheet
+        .get_cell_mut("B3")
+        .set_formula("NA()")
+        .set_formula_result_error(CellErrorType::NA);
+    sheet
+        .get_cell_mut("B4")
+        .set_formula("T(\"value\")")
+        .set_formula_result_string("value");
+    sheet
+        .get_cell_mut("B5")
+        .set_formula("1/0")
+        .set_formula_result_blank();
+
+    let xlsx = workbook_to_xlsx_bytes(&book);
+    let sheet_xml = zip_entry_to_string(&xlsx, "xl/worksheets/sheet1.xml");
+
+    let b1 = cell_fragment(&sheet_xml, "B1");
+    assert!(!b1.contains("t=\"str\""));
+    assert!(b1.contains("<v>5</v>"));
+
+    let b2 = cell_fragment(&sheet_xml, "B2");
+    assert!(b2.contains("t=\"b\""));
+    assert!(b2.contains("<v>0</v>"));
+
+    let b3 = cell_fragment(&sheet_xml, "B3");
+    assert!(b3.contains("t=\"e\""));
+    assert!(b3.contains("<v>#N/A</v>"));
+
+    let b4 = cell_fragment(&sheet_xml, "B4");
+    assert!(b4.contains("t=\"str\""));
+    assert!(b4.contains("<v>value</v>"));
+
+    let b5 = cell_fragment(&sheet_xml, "B5");
+    assert!(b5.contains("<v/>"));
+}


### PR DESCRIPTION
## Summary

This PR improves formula cached-value writeback correctness and adds explicit APIs for typed cached results.

It is intentionally split into two commits:

1. **fix(cell): serialize formula cache with correct cell types**
2. **feat(cell): add typed formula cached-result setters**

## Motivation

This work is grounded in a concrete downstream integration need from **Formualizer**.

Formualizer recently added Rust-native workbook recalculation/writeback (`recalculate_file`) using `umya-spreadsheet` as the writer path. During validation, formula cached values written back to XLSX were observed as string-typed payloads in XML (`t="str"`) even when the computed result was numeric, boolean, or error.

That behavior creates type drift in `sheet*.xml` and can degrade interoperability with Excel/OpenXML consumers that rely on correct cached value typing.

Additionally, Formualizer needed an explicit, type-safe way to set formula cached results (number/bool/error/string/blank) while preserving formula metadata.

While this was identified through Formualizer, the fix is broadly useful: it improves formula-cache correctness for all `umya-spreadsheet` users.

## What changed

### 1) Typed formula cached-value serialization

- Formula cells now emit type according to cached raw value kind:
  - numeric -> numeric path (no forced `t="str"`)
  - bool -> `t="b"` + `1/0`
  - error -> `t="e"` + actual error token
  - string -> `t="str"`
  - blank -> empty value
- Error serialization now writes the **actual cached error value** (e.g. `#N/A`) instead of hardcoding `#VALUE!`.

### 2) New typed API helpers (backwards-compatible)

Added on both `CellValue` and `Cell`:

- `set_formula_result_number(...)`
- `set_formula_result_bool(...)`
- `set_formula_result_error(...)`
- `set_formula_result_string(...)`
- `set_formula_result_blank()`

These methods update cached value (`<v>`) **without removing formula metadata** (`<f>`).

Existing `set_formula_result_default(...)` remains unchanged.

## Tests

Added regression coverage for:

- formula cached-value type mapping
- typed XML output for number/bool/error/string/blank formula caches
- roundtrip read behavior
- shared-formula metadata stability after write
- typed helper behavior preserving formula text

### Commands run

- `cargo test` (full suite) ✅
- targeted tests for new scenarios ✅

> Note: clippy `-D warnings` currently has pre-existing baseline failures on upstream `master` unrelated to this PR. This PR does not introduce new clippy debt in touched logic.

## Backwards compatibility

- No breaking API changes.
- Existing methods and call patterns continue to work.
- Output changes are correctness-oriented (typed cache serialization) while preserving formula objects/metadata.

## Why this helps

- Fixes a real production integration path in **Formualizer** (single-call workbook recalc + cache writeback).
- Better Excel/OpenXML interoperability via correctly typed formula cached values.
- Cleaner writeback semantics for any engine that computes and persists formula caches.
- More explicit and safer API for setting cached results programmatically.