### PR TITLE
Add mutable function to get Table Columns

### DIFF
--- a/src/structs/table.rs
+++ b/src/structs/table.rs
@@ -128,6 +128,12 @@ impl Table {
 
     #[inline]
     #[must_use]
+    pub fn columns_mut(&mut self) -> &mut [TableColumn] {
+        &mut self.columns
+    }
+
+    #[inline]
+    #[must_use]
     #[deprecated(since = "3.0.0", note = "Use columns()")]
     pub fn get_columns(&self) -> &[TableColumn] {
         self.columns()


### PR DESCRIPTION
Hello, this crate has been very useful!  However, I found when working with Tables, I was unable to adjust Columns after creation.

This PR simply adds a `columns_mut` function to `Table`.

Thank you very much!