### PR TITLE
perf: memory perf, lazy read & stream read

### DIFF
--- a/src/reader/xlsx.rs
+++ b/src/reader/xlsx.rs
@@ -18,6 +18,7 @@ use crate::{
         VML_DRAWING_NS,
     },
     structs::{
+        Cell,
         SharedStringTable,
         Stylesheet,
         Workbook,
@@ -58,6 +59,14 @@ pub fn read_reader<R: io::Read + io::Seek>(
     reader: R,
     with_sheet_read: bool,
 ) -> Result<Workbook, XlsxError> {
+    read_reader_with_source(reader, with_sheet_read, None)
+}
+
+fn read_reader_with_source<R: io::Read + io::Seek>(
+    reader: R,
+    with_sheet_read: bool,
+    source_file: Option<&Path>,
+) -> Result<Workbook, XlsxError> {
     let mut arv = zip::read::ZipArchive::new(reader)?;
 
     let mut book = workbook::read(&mut arv)?;
@@ -86,7 +95,10 @@ pub fn read_reader<R: io::Read + io::Seek>(
                 continue;
             }
             let mut raw_worksheet = RawWorksheet::default();
-            raw_worksheet.read(&mut arv, rel_target);
+            match source_file {
+                Some(source_file) => raw_worksheet.read_lazy(&mut arv, rel_target, source_file),
+                None => raw_worksheet.read(&mut arv, rel_target),
+            }
             sheet.set_raw_data_of_worksheet(raw_worksheet);
         }
     }
@@ -129,7 +141,42 @@ pub fn read<P: AsRef<Path>>(path: P) -> Result<Workbook, XlsxError> {
 #[inline]
 pub fn lazy_read(path: &Path) -> Result<Workbook, XlsxError> {
     let file = File::open(path)?;
-    read_reader(file, false)
+    read_reader_with_source(file, false, Some(path))
+}
+
+/// Stream cells from a worksheet without deserializing the worksheet into
+/// memory.
+///
+/// This is intended for very large sheets where building a full [`Worksheet`]
+/// would allocate too much memory. The callback receives one parsed [`Cell`] at
+/// a time; the cell is dropped before the next cell is parsed.
+pub fn read_sheet_by_name_stream<P, F>(
+    path: P,
+    sheet_name: &str,
+    callback: F,
+) -> Result<(), XlsxError>
+where
+    P: AsRef<Path>,
+    F: FnMut(&Cell),
+{
+    let book = lazy_read(path.as_ref())?;
+    let Some(worksheet) = book
+        .sheet_collection_no_check()
+        .iter()
+        .find(|worksheet| worksheet.name() == sheet_name)
+    else {
+        return Err(XlsxError::CellError(format!(
+            "Worksheet '{sheet_name}' not found."
+        )));
+    };
+    let shared_string_table = book.shared_string_table();
+    let shared_string_table = &*shared_string_table.read().unwrap();
+    worksheet::read_cells_stream(
+        worksheet.raw_data_of_worksheet(),
+        shared_string_table,
+        book.stylesheet(),
+        callback,
+    )
 }
 
 pub(crate) fn raw_to_deserialize_by_worksheet(
@@ -141,7 +188,7 @@ pub(crate) fn raw_to_deserialize_by_worksheet(
         return;
     }
 
-    let raw_data_of_worksheet = worksheet.raw_data_of_worksheet().clone();
+    let mut raw_data_of_worksheet = worksheet.take_raw_data_of_worksheet();
     let shared_string_table = &*shared_string_table.read().unwrap();
     worksheet::read(
         worksheet,
@@ -150,6 +197,9 @@ pub(crate) fn raw_to_deserialize_by_worksheet(
         stylesheet,
     )
     .unwrap();
+    raw_data_of_worksheet
+        .load_relationship_file_data_from_source()
+        .unwrap();
 
     if let Some(v) = raw_data_of_worksheet.worksheet_relationships() {
         for relationship in v.relationship_list() {
@@ -196,6 +246,4 @@ pub(crate) fn raw_to_deserialize_by_worksheet(
             }
         }
     }
-
-    worksheet.remove_raw_data_of_worksheet();
 }

--- a/src/reader/xlsx/worksheet.rs
+++ b/src/reader/xlsx/worksheet.rs
@@ -376,8 +376,7 @@ fn read_cells_stream_from_reader<R, F>(
     shared_string_table: &SharedStringTable,
     stylesheet: &Stylesheet,
     mut callback: F,
-) -> ()
-where
+) where
     R: io::BufRead,
     F: FnMut(&Cell),
 {

--- a/src/reader/xlsx/worksheet.rs
+++ b/src/reader/xlsx/worksheet.rs
@@ -361,17 +361,14 @@ where
                 raw_data_of_worksheet.worksheet_file().file_target(),
             )?;
             let reader = io::BufReader::new(source);
-            return read_cells_stream_from_reader(
-                reader,
-                shared_string_table,
-                stylesheet,
-                callback,
-            );
+            read_cells_stream_from_reader(reader, shared_string_table, stylesheet, callback);
+            return Ok(());
         }
     }
 
     let data = io::Cursor::new(raw_data_of_worksheet.worksheet_file().file_data());
-    read_cells_stream_from_reader(data, shared_string_table, stylesheet, callback)
+    read_cells_stream_from_reader(data, shared_string_table, stylesheet, callback);
+    Ok(())
 }
 
 fn read_cells_stream_from_reader<R, F>(
@@ -379,7 +376,7 @@ fn read_cells_stream_from_reader<R, F>(
     shared_string_table: &SharedStringTable,
     stylesheet: &Stylesheet,
     mut callback: F,
-) -> Result<(), XlsxError>
+) -> ()
 where
     R: io::BufRead,
     F: FnMut(&Cell),
@@ -403,8 +400,6 @@ where
         },
         Event::Eof => break,
     );
-
-    Ok(())
 }
 
 fn read_row_cells_stream<R, F>(

--- a/src/reader/xlsx/worksheet.rs
+++ b/src/reader/xlsx/worksheet.rs
@@ -1,4 +1,8 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    fs::File,
+    io,
+};
 
 use quick_xml::{
     Reader,
@@ -12,11 +16,13 @@ use super::{
         get_attribute,
         get_attribute_value,
         xml_read_loop,
+        zip_by_name,
     },
 };
 use crate::{
     helper::formula::FormulaToken,
     structs::{
+        Cell,
         Cells,
         Columns,
         ConditionalFormatting,
@@ -42,7 +48,42 @@ pub(crate) fn read(
     shared_string_table: &SharedStringTable,
     stylesheet: &Stylesheet,
 ) -> Result<(), XlsxError> {
-    let data = std::io::Cursor::new(raw_data_of_worksheet.worksheet_file().file_data());
+    if let Some(source_file) = raw_data_of_worksheet.worksheet_file().source_file() {
+        if !raw_data_of_worksheet.worksheet_file().has_file_data() {
+            let file = File::open(source_file)?;
+            let mut archive = zip::read::ZipArchive::new(file)?;
+            let source = zip_by_name(
+                &mut archive,
+                raw_data_of_worksheet.worksheet_file().file_target(),
+            )?;
+            let reader = io::BufReader::new(source);
+            return read_from_reader(
+                worksheet,
+                reader,
+                raw_data_of_worksheet,
+                shared_string_table,
+                stylesheet,
+            );
+        }
+    }
+
+    let data = io::Cursor::new(raw_data_of_worksheet.worksheet_file().file_data());
+    read_from_reader(
+        worksheet,
+        data,
+        raw_data_of_worksheet,
+        shared_string_table,
+        stylesheet,
+    )
+}
+
+fn read_from_reader<R: io::BufRead>(
+    worksheet: &mut Worksheet,
+    data: R,
+    raw_data_of_worksheet: &RawWorksheet,
+    shared_string_table: &SharedStringTable,
+    stylesheet: &Stylesheet,
+) -> Result<(), XlsxError> {
     let mut reader = Reader::from_reader(data);
     reader.config_mut().trim_text(true);
     let mut formula_shared_list: HashMap<u32, (String, Vec<FormulaToken>)> = HashMap::new();
@@ -238,7 +279,29 @@ pub(crate) fn read_lite(
     shared_string_table: &SharedStringTable,
     stylesheet: &Stylesheet,
 ) -> Cells {
-    let data = std::io::Cursor::new(raw_data_of_worksheet.worksheet_file().file_data());
+    if let Some(source_file) = raw_data_of_worksheet.worksheet_file().source_file() {
+        if !raw_data_of_worksheet.worksheet_file().has_file_data() {
+            let file = File::open(source_file).unwrap();
+            let mut archive = zip::read::ZipArchive::new(file).unwrap();
+            let source = zip_by_name(
+                &mut archive,
+                raw_data_of_worksheet.worksheet_file().file_target(),
+            )
+            .unwrap();
+            let reader = io::BufReader::new(source);
+            return read_lite_from_reader(reader, shared_string_table, stylesheet);
+        }
+    }
+
+    let data = io::Cursor::new(raw_data_of_worksheet.worksheet_file().file_data());
+    read_lite_from_reader(data, shared_string_table, stylesheet)
+}
+
+fn read_lite_from_reader<R: io::BufRead>(
+    data: R,
+    shared_string_table: &SharedStringTable,
+    stylesheet: &Stylesheet,
+) -> Cells {
     let mut reader = Reader::from_reader(data);
     reader.config_mut().trim_text(true);
 
@@ -278,6 +341,119 @@ pub(crate) fn read_lite(
     );
 
     cells
+}
+
+pub(crate) fn read_cells_stream<F>(
+    raw_data_of_worksheet: &RawWorksheet,
+    shared_string_table: &SharedStringTable,
+    stylesheet: &Stylesheet,
+    callback: F,
+) -> Result<(), XlsxError>
+where
+    F: FnMut(&Cell),
+{
+    if let Some(source_file) = raw_data_of_worksheet.worksheet_file().source_file() {
+        if !raw_data_of_worksheet.worksheet_file().has_file_data() {
+            let file = File::open(source_file)?;
+            let mut archive = zip::read::ZipArchive::new(file)?;
+            let source = zip_by_name(
+                &mut archive,
+                raw_data_of_worksheet.worksheet_file().file_target(),
+            )?;
+            let reader = io::BufReader::new(source);
+            return read_cells_stream_from_reader(
+                reader,
+                shared_string_table,
+                stylesheet,
+                callback,
+            );
+        }
+    }
+
+    let data = io::Cursor::new(raw_data_of_worksheet.worksheet_file().file_data());
+    read_cells_stream_from_reader(data, shared_string_table, stylesheet, callback)
+}
+
+fn read_cells_stream_from_reader<R, F>(
+    data: R,
+    shared_string_table: &SharedStringTable,
+    stylesheet: &Stylesheet,
+    mut callback: F,
+) -> Result<(), XlsxError>
+where
+    R: io::BufRead,
+    F: FnMut(&Cell),
+{
+    let mut reader = Reader::from_reader(data);
+    reader.config_mut().trim_text(true);
+    let mut formula_shared_list: HashMap<u32, (String, Vec<FormulaToken>)> = HashMap::new();
+
+    xml_read_loop!(
+        reader,
+        Event::Start(ref e) => {
+            if e.name().into_inner() == b"row" {
+                read_row_cells_stream(
+                    &mut reader,
+                    shared_string_table,
+                    stylesheet,
+                    &mut formula_shared_list,
+                    &mut callback,
+                );
+            }
+        },
+        Event::Eof => break,
+    );
+
+    Ok(())
+}
+
+fn read_row_cells_stream<R, F>(
+    reader: &mut Reader<R>,
+    shared_string_table: &SharedStringTable,
+    stylesheet: &Stylesheet,
+    formula_shared_list: &mut HashMap<u32, (String, Vec<FormulaToken>)>,
+    callback: &mut F,
+) where
+    R: io::BufRead,
+    F: FnMut(&Cell),
+{
+    xml_read_loop!(
+        reader,
+        Event::Empty(ref e) => {
+            if e.name().into_inner() == b"c" {
+                let mut obj = Cell::default();
+                obj.set_attributes(
+                    reader,
+                    e,
+                    shared_string_table,
+                    stylesheet,
+                    true,
+                    formula_shared_list,
+                );
+                callback(&obj);
+            }
+        },
+        Event::Start(ref e) => {
+            if e.name().into_inner() == b"c" {
+                let mut obj = Cell::default();
+                obj.set_attributes(
+                    reader,
+                    e,
+                    shared_string_table,
+                    stylesheet,
+                    false,
+                    formula_shared_list,
+                );
+                callback(&obj);
+            }
+        },
+        Event::End(ref e) => {
+            if e.name().into_inner() == b"row" {
+                return
+            }
+        },
+        Event::Eof => panic!("Error: Could not find {} end element", "row")
+    );
 }
 
 fn get_hyperlink(

--- a/src/structs/raw/raw_file.rs
+++ b/src/structs/raw/raw_file.rs
@@ -1,6 +1,11 @@
 use std::{
+    fs::File,
     io,
     io::Read,
+    path::{
+        Path,
+        PathBuf,
+    },
 };
 
 use crate::{
@@ -19,6 +24,7 @@ use crate::{
 pub(crate) struct RawFile {
     file_target: StringValue,
     file_data:   Vec<u8>,
+    source_file: Option<PathBuf>,
 }
 impl RawFile {
     #[inline]
@@ -89,6 +95,16 @@ impl RawFile {
     }
 
     #[inline]
+    pub(crate) fn has_file_data(&self) -> bool {
+        !self.file_data.is_empty()
+    }
+
+    #[inline]
+    pub(crate) fn source_file(&self) -> Option<&Path> {
+        self.source_file.as_deref()
+    }
+
+    #[inline]
     #[deprecated(since = "3.0.0", note = "Use file_data()")]
     pub(crate) fn get_file_data(&self) -> &[u8] {
         self.file_data()
@@ -108,6 +124,12 @@ impl RawFile {
     #[inline]
     pub(crate) fn set_file_data(&mut self, value: &[u8]) -> &mut Self {
         self.file_data = value.into();
+        self
+    }
+
+    #[inline]
+    pub(crate) fn set_source_file<P: AsRef<Path>>(&mut self, value: P) -> &mut Self {
+        self.source_file = Some(value.as_ref().to_path_buf());
         self
     }
 
@@ -131,16 +153,60 @@ impl RawFile {
         }
 
         self.set_file_target(path_str);
-        self.set_file_data(&buf);
+        self.file_data = buf;
+    }
+
+    pub(crate) fn set_attributes_from_source<R: Read + io::Seek, P: AsRef<Path>>(
+        &mut self,
+        arv: &mut zip::read::ZipArchive<R>,
+        base_path: &str,
+        target: &str,
+        source_file: P,
+    ) {
+        let path_str = join_paths(base_path, target);
+        if zip_by_name(arv, &path_str).is_err() {
+            self.set_file_target(path_str);
+            return;
+        }
+
+        self.set_file_target(path_str);
+        self.set_source_file(source_file);
+    }
+
+    pub(crate) fn load_file_data_from_source(&mut self) -> Result<(), XlsxError> {
+        if !self.file_data.is_empty() || self.file_target().is_empty() {
+            return Ok(());
+        }
+        let Some(source_file) = self.source_file.as_ref() else {
+            return Ok(());
+        };
+
+        let file = File::open(source_file)?;
+        let mut archive = zip::read::ZipArchive::new(file)?;
+        let mut source = zip_by_name(&mut archive, self.file_target())?;
+        let mut buf = Vec::new();
+        source.read_to_end(&mut buf)?;
+        self.file_data = buf;
+        Ok(())
+    }
+
+    pub(crate) fn write_to_target<W: io::Seek + io::Write>(
+        &self,
+        target: &str,
+        writer_mng: &mut WriterManager<W>,
+    ) -> Result<(), XlsxError> {
+        if !self.file_data().is_empty() {
+            writer_mng.add_bin(target, self.file_data())?;
+        } else if let Some(source_file) = self.source_file.as_ref() {
+            writer_mng.add_raw_copy(target, source_file, self.file_target())?;
+        }
+        Ok(())
     }
 
     pub(crate) fn write_to<W: io::Seek + io::Write>(
         &self,
         writer_mng: &mut WriterManager<W>,
     ) -> Result<(), XlsxError> {
-        if !self.file_data().is_empty() {
-            writer_mng.add_bin(self.file_target(), self.file_data())?;
-        }
-        Ok(())
+        self.write_to_target(self.file_target(), writer_mng)
     }
 }

--- a/src/structs/raw/raw_relationship.rs
+++ b/src/structs/raw/raw_relationship.rs
@@ -1,6 +1,7 @@
 use std::{
     io,
     io::Cursor,
+    path::Path,
 };
 
 use quick_xml::{
@@ -126,6 +127,7 @@ impl RawRelationship {
         e: &BytesStart,
         arv: &mut zip::read::ZipArchive<A>,
         base_path: &str,
+        source_file: Option<&Path>,
     ) {
         let Some(id) = get_attribute(e, b"Id") else {
             return;
@@ -144,7 +146,15 @@ impl RawRelationship {
         }
         if self.target_mode() != "External" {
             let target = self.target().to_string();
-            self.raw_file_mut().set_attributes(arv, base_path, &target);
+            match source_file {
+                Some(source_file) => self.raw_file_mut().set_attributes_from_source(
+                    arv,
+                    base_path,
+                    &target,
+                    source_file,
+                ),
+                None => self.raw_file_mut().set_attributes(arv, base_path, &target),
+            };
         }
     }
 

--- a/src/structs/raw/raw_relationship.rs
+++ b/src/structs/raw/raw_relationship.rs
@@ -154,7 +154,7 @@ impl RawRelationship {
                     source_file,
                 ),
                 None => self.raw_file_mut().set_attributes(arv, base_path, &target),
-            };
+            }
         }
     }
 

--- a/src/structs/raw/raw_relationships.rs
+++ b/src/structs/raw/raw_relationships.rs
@@ -1,6 +1,7 @@
 use std::{
     io,
     io::Read,
+    path::Path,
 };
 
 use quick_xml::{
@@ -121,6 +122,7 @@ impl RawRelationships {
         arv: &mut zip::read::ZipArchive<R>,
         base_path: &str,
         target: &str,
+        source_file: Option<&Path>,
     ) -> bool {
         let data = {
             let path_str = join_paths(base_path, target);
@@ -141,7 +143,7 @@ impl RawRelationships {
             Event::Empty(ref e) => {
                 if e.name().into_inner() == b"Relationship" {
                     let mut obj = RawRelationship::default();
-                    obj.set_attributes(&mut reader, e, arv, base_path);
+                    obj.set_attributes(&mut reader, e, arv, base_path, source_file);
                     self.add_relationship_list(obj);
                 }
             },

--- a/src/structs/raw/raw_worksheet.rs
+++ b/src/structs/raw/raw_worksheet.rs
@@ -1,4 +1,7 @@
-use std::io;
+use std::{
+    io,
+    path::Path,
+};
 
 use crate::{
     helper::const_str::{
@@ -137,7 +140,25 @@ impl RawWorksheet {
 
         let base_path = self.worksheet_file().path();
         let target = self.worksheet_file().make_rel_name();
-        self.read_rawrelationships(arv, &base_path, &target);
+        self.read_rawrelationships(arv, &base_path, &target, None);
+    }
+
+    pub(crate) fn read_lazy<R: io::Read + io::Seek, P: AsRef<Path>>(
+        &mut self,
+        arv: &mut zip::read::ZipArchive<R>,
+        target: &str,
+        source_file: P,
+    ) {
+        self.worksheet_file_mut().set_attributes_from_source(
+            arv,
+            "xl",
+            target,
+            source_file.as_ref(),
+        );
+
+        let base_path = self.worksheet_file().path();
+        let target = self.worksheet_file().make_rel_name();
+        self.read_rawrelationships(arv, &base_path, &target, Some(source_file.as_ref()));
     }
 
     pub(crate) fn read_rawrelationships<R: io::Read + io::Seek>(
@@ -145,16 +166,31 @@ impl RawWorksheet {
         arv: &mut zip::read::ZipArchive<R>,
         base_path: &str,
         target: &str,
+        source_file: Option<&Path>,
     ) {
         let mut obj = RawRelationships::default();
-        if obj.set_attributes(arv, base_path, target) {
+        if obj.set_attributes(arv, base_path, target, source_file) {
             for relationship in obj.relationship_list() {
                 let rels_base_path = relationship.raw_file().path();
                 let rels_target = relationship.raw_file().make_rel_name();
-                self.read_rawrelationships(arv, &rels_base_path, &rels_target);
+                self.read_rawrelationships(arv, &rels_base_path, &rels_target, source_file);
             }
             self.set_relationships(obj);
         }
+    }
+
+    pub(crate) fn load_file_data_from_source(&mut self) -> Result<(), XlsxError> {
+        self.worksheet_file_mut().load_file_data_from_source()?;
+        self.load_relationship_file_data_from_source()
+    }
+
+    pub(crate) fn load_relationship_file_data_from_source(&mut self) -> Result<(), XlsxError> {
+        for relationships in self.relationships_list_mut() {
+            for relationship in relationships.relationship_list_mut() {
+                relationship.raw_file_mut().load_file_data_from_source()?;
+            }
+        }
+        Ok(())
     }
 
     pub(crate) fn write<W: io::Seek + io::Write>(
@@ -164,7 +200,7 @@ impl RawWorksheet {
     ) -> Result<(), XlsxError> {
         // Add worksheet
         let target = format!("{PKG_SHEET}{sheet_no}.xml");
-        writer_mng.add_bin(&target, self.worksheet_file().file_data())?;
+        self.worksheet_file().write_to_target(&target, writer_mng)?;
 
         // Add worksheet rels
         for relationships in self.relationships_list() {

--- a/src/structs/worksheet.rs
+++ b/src/structs/worksheet.rs
@@ -2640,6 +2640,13 @@ impl Worksheet {
     }
 
     #[inline]
+    pub(crate) fn take_raw_data_of_worksheet(&mut self) -> RawWorksheet {
+        self.raw_data_of_worksheet
+            .take()
+            .expect("Not found at raw data of worksheet.")
+    }
+
+    #[inline]
     pub(crate) fn remove_raw_data_of_worksheet(&mut self) -> &mut Self {
         self.raw_data_of_worksheet = None;
         self

--- a/src/structs/writer_manager.rs
+++ b/src/structs/writer_manager.rs
@@ -1,6 +1,8 @@
 use std::{
+    fs::File,
     io,
     io::Cursor,
+    path::Path,
 };
 
 use quick_xml::Writer;
@@ -34,6 +36,7 @@ use crate::{
         Workbook,
         XlsxError,
     },
+    reader::driver::zip_by_name,
     writer::driver::{
         make_file_from_bin,
         make_file_from_writer,
@@ -118,6 +121,23 @@ impl<'a, W: io::Seek + io::Write> WriterManager<'a, W> {
     pub(crate) fn add_bin(&mut self, target: &str, data: &[u8]) -> Result<(), XlsxError> {
         if !self.check_file_exist(target) {
             make_file_from_bin(target, self.arv, data, None, self.is_light)?;
+            self.files.push(target.to_string());
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub(crate) fn add_raw_copy<P: AsRef<Path>>(
+        &mut self,
+        target: &str,
+        source_path: P,
+        source_target: &str,
+    ) -> Result<(), XlsxError> {
+        if !self.check_file_exist(target) {
+            let file = File::open(source_path)?;
+            let mut archive = zip::read::ZipArchive::new(file)?;
+            let source = zip_by_name(&mut archive, source_target)?;
+            self.arv.raw_copy_file_rename(source, target)?;
             self.files.push(target.to_string());
         }
         Ok(())

--- a/src/writer/xlsx.rs
+++ b/src/writer/xlsx.rs
@@ -45,138 +45,156 @@ mod workbook_rels;
 mod worksheet;
 mod worksheet_rels;
 
-fn make_buffer(wb: &Workbook, is_light: bool) -> Result<Vec<u8>, XlsxError> {
-    let cursor = io::Cursor::new(Vec::new());
-    let mut arv = zip::ZipWriter::new(cursor);
-    let mut writer_manager = WriterManager::new(&mut arv);
-    writer_manager.set_is_light(is_light);
+fn write_zip_to_writer<W: io::Write + io::Seek>(
+    wb: &Workbook,
+    writer: W,
+    is_light: bool,
+) -> Result<(), XlsxError> {
+    let mut arv = zip::ZipWriter::new(writer);
+    {
+        let mut writer_manager = WriterManager::new(&mut arv);
+        writer_manager.set_is_light(is_light);
 
-    // Add docProps
-    doc_props_app::write(wb, &mut writer_manager)?;
-    doc_props_core::write(wb, &mut writer_manager)?;
-    doc_props_custom::write(wb, &mut writer_manager)?;
-    vba_project_bin::write(wb, &mut writer_manager)?;
-    jsa_project_bin::write(wb, &mut writer_manager)?;
-    rels::write(wb, &mut writer_manager)?;
-    theme::write(wb.theme(), &mut writer_manager)?;
-    person::write(wb, &mut writer_manager)?;
+        // Add docProps
+        doc_props_app::write(wb, &mut writer_manager)?;
+        doc_props_core::write(wb, &mut writer_manager)?;
+        doc_props_custom::write(wb, &mut writer_manager)?;
+        vba_project_bin::write(wb, &mut writer_manager)?;
+        jsa_project_bin::write(wb, &mut writer_manager)?;
+        rels::write(wb, &mut writer_manager)?;
+        theme::write(wb.theme(), &mut writer_manager)?;
+        person::write(wb, &mut writer_manager)?;
 
-    let shared_string_table = wb.shared_string_table();
-    let mut stylesheet = wb.stylesheet().clone();
+        let shared_string_table = wb.shared_string_table();
+        let mut stylesheet = wb.stylesheet().clone();
 
-    // Process each worksheet
-    wb.sheet_collection_no_check()
-        .iter()
-        .enumerate()
-        .try_for_each(|(index, worksheet)| {
-            let worksheet_no = index + 1;
-            if worksheet.is_deserialized() {
-                worksheet::write(
-                    worksheet_no.try_into().unwrap(),
+        // Process each worksheet
+        wb.sheet_collection_no_check()
+            .iter()
+            .enumerate()
+            .try_for_each(|(index, worksheet)| {
+                let worksheet_no = index + 1;
+                if worksheet.is_deserialized() {
+                    worksheet::write(
+                        worksheet_no.try_into().unwrap(),
+                        worksheet,
+                        &shared_string_table,
+                        &mut stylesheet,
+                        wb.has_macros(),
+                        &mut writer_manager,
+                    )
+                } else {
+                    worksheet
+                        .raw_data_of_worksheet()
+                        .write(worksheet_no.try_into().unwrap(), &mut writer_manager)
+                }
+            })?;
+
+        // Process objects associated with worksheets
+        wb.sheet_collection_no_check()
+            .iter()
+            .enumerate()
+            .try_for_each(|(index, worksheet)| {
+                let worksheet_no = index + 1;
+                if !worksheet.is_deserialized() {
+                    return Ok(());
+                }
+
+                // Add charts
+                let chart_no_list: Result<Vec<String>, XlsxError> = worksheet
+                    .worksheet_drawing()
+                    .chart_collection()
+                    .iter()
+                    .map(|chart| chart::write(chart.chart_space(), wb, &mut writer_manager))
+                    .collect();
+
+                let chart_no_list = chart_no_list?;
+
+                // Add drawing and its relationships
+                let (drawing_no, rel_list) = drawing::write(worksheet, &mut writer_manager)?;
+                drawing_rels::write(
                     worksheet,
-                    &shared_string_table,
-                    &mut stylesheet,
-                    wb.has_macros(),
+                    &drawing_no,
+                    &chart_no_list,
+                    &rel_list,
+                    &mut writer_manager,
+                )?;
+
+                // Add vml drawing and its relationships
+                let (vml_drawing_no, rel_list) =
+                    vml_drawing::write(worksheet, &mut writer_manager)?;
+                vml_drawing_rels::write(
+                    worksheet,
+                    &vml_drawing_no,
+                    &rel_list,
+                    &mut writer_manager,
+                )?;
+
+                // Add comments
+                let comment_no = comment::write(worksheet, &mut writer_manager)?;
+
+                // Add threaded_comment
+                let threaded_comment_no = threaded_comment::write(worksheet, &mut writer_manager)?;
+
+                // Add ole_object and excel
+                let (ole_object_no_list, excel_no_list) =
+                    embeddings::write(worksheet, &mut writer_manager)?;
+
+                // Add Media
+                media::write(worksheet, &mut writer_manager)?;
+
+                // Add printer settings
+                let printer_settings_no = worksheet
+                    .page_setup()
+                    .object_data()
+                    .map_or_else(String::new, |_| {
+                        printer_settings::write(worksheet, &mut writer_manager).unwrap_or_default()
+                    });
+
+                // Add tables
+                let table_no_list = table::write(worksheet, &mut writer_manager)?;
+
+                // Add pivot tables and caches
+                let pivot_table_no_list = pivot_table::write(worksheet, &mut writer_manager)?;
+                let pivot_cache_no_list = pivot_cache::write(worksheet, &mut writer_manager)?;
+
+                // Add worksheet relationships
+                worksheet_rels::write(
+                    worksheet,
+                    &worksheet_no.to_string(),
+                    &drawing_no,
+                    &vml_drawing_no,
+                    &comment_no,
+                    &threaded_comment_no,
+                    &ole_object_no_list,
+                    &excel_no_list,
+                    &printer_settings_no,
+                    &table_no_list,
+                    &pivot_table_no_list,
+                    &pivot_cache_no_list,
                     &mut writer_manager,
                 )
-            } else {
-                worksheet
-                    .raw_data_of_worksheet()
-                    .write(worksheet_no.try_into().unwrap(), &mut writer_manager)
-            }
-        })?;
+            })?;
 
-    // Process objects associated with worksheets
-    wb.sheet_collection_no_check()
-        .iter()
-        .enumerate()
-        .try_for_each(|(index, worksheet)| {
-            let worksheet_no = index + 1;
-            if !worksheet.is_deserialized() {
-                return Ok(());
-            }
+        // Finalize file list and add remaining components
+        writer_manager.file_list_sort();
+        shared_strings::write(&shared_string_table, &mut writer_manager)?;
+        styles::write(&stylesheet, &mut writer_manager)?;
+        workbook::write(wb, &mut writer_manager)?;
 
-            // Add charts
-            let chart_no_list: Result<Vec<String>, XlsxError> = worksheet
-                .worksheet_drawing()
-                .chart_collection()
-                .iter()
-                .map(|chart| chart::write(chart.chart_space(), wb, &mut writer_manager))
-                .collect();
+        let has_shared_string_table = shared_string_table.read().unwrap().has_value();
+        workbook_rels::write(wb, has_shared_string_table, &mut writer_manager)?;
+        content_types::write(wb, &mut writer_manager)?;
+    }
 
-            let chart_no_list = chart_no_list?;
+    arv.finish()?;
+    Ok(())
+}
 
-            // Add drawing and its relationships
-            let (drawing_no, rel_list) = drawing::write(worksheet, &mut writer_manager)?;
-            drawing_rels::write(
-                worksheet,
-                &drawing_no,
-                &chart_no_list,
-                &rel_list,
-                &mut writer_manager,
-            )?;
-
-            // Add vml drawing and its relationships
-            let (vml_drawing_no, rel_list) = vml_drawing::write(worksheet, &mut writer_manager)?;
-            vml_drawing_rels::write(worksheet, &vml_drawing_no, &rel_list, &mut writer_manager)?;
-
-            // Add comments
-            let comment_no = comment::write(worksheet, &mut writer_manager)?;
-
-            // Add threaded_comment
-            let threaded_comment_no = threaded_comment::write(worksheet, &mut writer_manager)?;
-
-            // Add ole_object and excel
-            let (ole_object_no_list, excel_no_list) =
-                embeddings::write(worksheet, &mut writer_manager)?;
-
-            // Add Media
-            media::write(worksheet, &mut writer_manager)?;
-
-            // Add printer settings
-            let printer_settings_no = worksheet
-                .page_setup()
-                .object_data()
-                .map_or_else(String::new, |_| {
-                    printer_settings::write(worksheet, &mut writer_manager).unwrap_or_default()
-                });
-
-            // Add tables
-            let table_no_list = table::write(worksheet, &mut writer_manager)?;
-
-            // Add pivot tables and caches
-            let pivot_table_no_list = pivot_table::write(worksheet, &mut writer_manager)?;
-            let pivot_cache_no_list = pivot_cache::write(worksheet, &mut writer_manager)?;
-
-            // Add worksheet relationships
-            worksheet_rels::write(
-                worksheet,
-                &worksheet_no.to_string(),
-                &drawing_no,
-                &vml_drawing_no,
-                &comment_no,
-                &threaded_comment_no,
-                &ole_object_no_list,
-                &excel_no_list,
-                &printer_settings_no,
-                &table_no_list,
-                &pivot_table_no_list,
-                &pivot_cache_no_list,
-                &mut writer_manager,
-            )
-        })?;
-
-    // Finalize file list and add remaining components
-    writer_manager.file_list_sort();
-    shared_strings::write(&shared_string_table, &mut writer_manager)?;
-    styles::write(&stylesheet, &mut writer_manager)?;
-    workbook::write(wb, &mut writer_manager)?;
-
-    let has_shared_string_table = shared_string_table.read().unwrap().has_value();
-    workbook_rels::write(wb, has_shared_string_table, &mut writer_manager)?;
-    content_types::write(wb, &mut writer_manager)?;
-
-    arv.finish().map(io::Cursor::into_inner).map_err(Into::into)
+fn make_buffer(wb: &Workbook, is_light: bool) -> Result<Vec<u8>, XlsxError> {
+    let mut cursor = io::Cursor::new(Vec::new());
+    write_zip_to_writer(wb, &mut cursor, is_light)?;
+    Ok(cursor.into_inner())
 }
 
 /// write spreadsheet file to arbitrary writer.
@@ -222,7 +240,7 @@ pub fn write<P: AsRef<Path>>(wb: &Workbook, path: P) -> Result<(), XlsxError> {
     let path_tmp = path
         .as_ref()
         .with_extension(format!("{}{}", extension, "tmp"));
-    if let Err(v) = write_writer(wb, &mut io::BufWriter::new(File::create(&path_tmp)?)) {
+    if let Err(v) = write_zip_to_writer(wb, io::BufWriter::new(File::create(&path_tmp)?), false) {
         fs::remove_file(path_tmp)?;
         return Err(v);
     }
@@ -247,7 +265,7 @@ pub fn write_light<P: AsRef<Path>>(wb: &Workbook, path: P) -> Result<(), XlsxErr
     let path_tmp = path
         .as_ref()
         .with_extension(format!("{}{}", extension, "tmp"));
-    if let Err(v) = write_writer_light(wb, &mut io::BufWriter::new(File::create(&path_tmp)?)) {
+    if let Err(v) = write_zip_to_writer(wb, io::BufWriter::new(File::create(&path_tmp)?), true) {
         fs::remove_file(path_tmp)?;
         return Err(v);
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,13 +4,161 @@
 extern crate chrono;
 extern crate umya_spreadsheet;
 use std::{
-    io::Read,
+    env,
+    ffi::c_void,
+    fs::File,
+    io::{
+        BufWriter,
+        Read,
+    },
+    path::PathBuf,
     time::Instant,
 };
 
 use umya_spreadsheet::*;
 
 use crate::helper::color;
+
+#[cfg(target_os = "linux")]
+fn current_process_memory_mb() -> Option<f64> {
+    process_status_memory_mb("VmRSS:")
+}
+
+#[cfg(target_os = "linux")]
+fn peak_process_memory_mb() -> Option<f64> {
+    process_status_memory_mb("VmHWM:")
+}
+
+#[cfg(target_os = "linux")]
+fn process_status_memory_mb(prefix: &str) -> Option<f64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    status.lines().find_map(|line| {
+        let value = line.strip_prefix(prefix)?.trim();
+        let kb = value.split_whitespace().next()?.parse::<f64>().ok()?;
+        Some(kb / 1024.0)
+    })
+}
+
+#[cfg(windows)]
+fn current_process_memory_mb() -> Option<f64> {
+    process_memory_mb().map(|(_, working_set)| working_set)
+}
+
+#[cfg(windows)]
+fn peak_process_memory_mb() -> Option<f64> {
+    process_memory_mb().map(|(peak_working_set, _)| peak_working_set)
+}
+
+#[cfg(windows)]
+#[repr(C)]
+struct ProcessMemoryCounters {
+    cb:                              u32,
+    page_fault_count:                u32,
+    peak_working_set_size:           usize,
+    working_set_size:                usize,
+    quota_peak_paged_pool_usage:     usize,
+    quota_paged_pool_usage:          usize,
+    quota_peak_non_paged_pool_usage: usize,
+    quota_non_paged_pool_usage:      usize,
+    pagefile_usage:                  usize,
+    peak_pagefile_usage:             usize,
+}
+
+#[cfg(windows)]
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn GetCurrentProcess() -> *mut c_void;
+}
+
+#[cfg(windows)]
+#[link(name = "psapi")]
+unsafe extern "system" {
+    fn GetProcessMemoryInfo(
+        process: *mut c_void,
+        counters: *mut ProcessMemoryCounters,
+        size: u32,
+    ) -> i32;
+}
+
+#[cfg(windows)]
+fn process_memory_mb() -> Option<(f64, f64)> {
+    let mut counters = ProcessMemoryCounters {
+        cb:                              std::mem::size_of::<ProcessMemoryCounters>() as u32,
+        page_fault_count:                0,
+        peak_working_set_size:           0,
+        working_set_size:                0,
+        quota_peak_paged_pool_usage:     0,
+        quota_paged_pool_usage:          0,
+        quota_peak_non_paged_pool_usage: 0,
+        quota_non_paged_pool_usage:      0,
+        pagefile_usage:                  0,
+        peak_pagefile_usage:             0,
+    };
+    let ok = unsafe {
+        GetProcessMemoryInfo(
+            GetCurrentProcess(),
+            &mut counters,
+            std::mem::size_of::<ProcessMemoryCounters>() as u32,
+        )
+    };
+    if ok == 0 {
+        return None;
+    }
+    Some((
+        counters.peak_working_set_size as f64 / 1024.0 / 1024.0,
+        counters.working_set_size as f64 / 1024.0 / 1024.0,
+    ))
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn current_process_memory_mb() -> Option<f64> {
+    let output = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &std::process::id().to_string()])
+        .output()
+        .ok()?;
+    let kb = String::from_utf8(output.stdout)
+        .ok()?
+        .trim()
+        .parse::<f64>()
+        .ok()?;
+    Some(kb / 1024.0)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn peak_process_memory_mb() -> Option<f64> {
+    None
+}
+
+#[cfg(not(any(unix, windows)))]
+fn current_process_memory_mb() -> Option<f64> {
+    None
+}
+
+#[cfg(not(any(unix, windows)))]
+fn peak_process_memory_mb() -> Option<f64> {
+    None
+}
+
+fn print_large_file_checkpoint(label: &str, start: Instant) {
+    let elapsed = start.elapsed();
+    let memory = current_process_memory_mb()
+        .map(|value| format!("{value:.1}MB"))
+        .unwrap_or_else(|| "unknown".to_string());
+    let peak_memory = peak_process_memory_mb()
+        .map(|value| format!("{value:.1}MB"))
+        .unwrap_or_else(|| "unknown".to_string());
+    println!(
+        "{label}:{}.{:03}sec memory:{memory} peak:{peak_memory}",
+        elapsed.as_secs(),
+        elapsed.subsec_millis()
+    );
+}
+
+fn profile_input_path() -> PathBuf {
+    env::var_os("UMYA_PROFILE_FILE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("./tests/test_files/aaa_large_string.xlsx"))
+}
 
 #[test]
 fn read_and_wite() {
@@ -113,6 +261,72 @@ fn lazy_read_and_wite_large_string() {
     let _unused = writer::xlsx::write(&book, path);
     let end = start.elapsed();
     println!("write:{}.{:03}sec.", end.as_secs(), end.subsec_millis());
+}
+
+#[test]
+#[ignore]
+fn profile_large_string_memory() {
+    let total = Instant::now();
+    print_large_file_checkpoint("start", total);
+
+    let path = profile_input_path();
+    println!("profile_file:{}", path.display());
+    let mut book = reader::xlsx::lazy_read(&path).unwrap();
+    print_large_file_checkpoint("lazy_read", total);
+
+    if env::var_os("UMYA_PROFILE_DESERIALIZE").is_some() {
+        let sheet_name = env::var("UMYA_PROFILE_SHEET").unwrap_or_else(|_| "Sheet1".to_string());
+        book.read_sheet_by_name(&sheet_name);
+        print_large_file_checkpoint("deserialize_sheet", total);
+    }
+
+    if env::var_os("UMYA_PROFILE_EDIT").is_some() {
+        let ns = book.new_sheet("profile sheet").unwrap();
+        for r in 1..5000 {
+            for c in 1..30 {
+                let cell = ns.cell_mut((c, r));
+                let _unused = cell.set_value_string(format!("r{}c{}", r, c));
+            }
+        }
+        print_large_file_checkpoint("edit", total);
+    }
+
+    let output_path = env::var_os("UMYA_PROFILE_OUTPUT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("./tests/result_files/profile_large_string.xlsx"));
+    match env::var("UMYA_PROFILE_WRITER").as_deref() {
+        Ok("buffer") => {
+            let file = File::create(&output_path).unwrap();
+            writer::xlsx::write_writer(&book, BufWriter::new(file)).unwrap();
+        }
+        Ok("light") => writer::xlsx::write_light(&book, &output_path).unwrap(),
+        _ => writer::xlsx::write(&book, &output_path).unwrap(),
+    }
+    print_large_file_checkpoint("write", total);
+}
+
+#[test]
+#[ignore]
+fn profile_large_string_stream_memory() {
+    let total = Instant::now();
+    print_large_file_checkpoint("start", total);
+
+    let path = profile_input_path();
+    let sheet_name = env::var("UMYA_PROFILE_SHEET").unwrap_or_else(|_| "Sheet1".to_string());
+    println!("profile_file:{}", path.display());
+    println!("profile_sheet:{sheet_name}");
+
+    let mut cell_count = 0usize;
+    reader::xlsx::read_sheet_by_name_stream(&path, &sheet_name, |_| {
+        cell_count += 1;
+        if cell_count % 500_000 == 0 {
+            print_large_file_checkpoint(&format!("stream_cells_{cell_count}"), total);
+        }
+    })
+    .unwrap();
+
+    println!("stream_cell_count:{cell_count}");
+    print_large_file_checkpoint("stream_done", total);
 }
 
 #[test]


### PR DESCRIPTION
I encountered a fairly serious performance issue when processing large tables. In some cases, memory usage would continue growing and could even reach tens of gigabytes.

I used AI-assisted optimization to refactor the lazy-read path into a streaming-based approach. With this change, memory usage now stays at a much healthier level (around 50 MB in my test case).

That said, I have to admit I did not manually review every part of the generated code in depth.

If you notice any issues or have suggestions, please let me know and I’ll be happy to make further adjustments.
