### PR TITLE
Fix #328, panic when writing a workbook to a file without an extension.

### DIFF
--- a/src/writer/xlsx.rs
+++ b/src/writer/xlsx.rs
@@ -236,7 +236,11 @@ pub fn write_writer_light<W: io::Write>(wb: &Workbook, mut writer: W) -> Result<
 /// let _unused = umya_spreadsheet::writer::xlsx::write(&book, path);
 /// ```
 pub fn write<P: AsRef<Path>>(wb: &Workbook, path: P) -> Result<(), XlsxError> {
-    let extension = path.as_ref().extension().unwrap_or("xlsx").to_str().unwrap_or("xlsx");
+    // Fix #328, add default extension
+    let extension = match path.as_ref() {
+        Some(ext) => ext.to_str().unwrap_or("xlsx"),
+        None => "xlsx",
+    };
     let path_tmp = path
         .as_ref()
         .with_extension(format!("{}{}", extension, "tmp"));

--- a/src/writer/xlsx.rs
+++ b/src/writer/xlsx.rs
@@ -237,7 +237,7 @@ pub fn write_writer_light<W: io::Write>(wb: &Workbook, mut writer: W) -> Result<
 /// ```
 pub fn write<P: AsRef<Path>>(wb: &Workbook, path: P) -> Result<(), XlsxError> {
     // Fix #328, add default extension
-    let extension = match path.as_ref() {
+    let extension = match path.as_ref().extension() {
         Some(ext) => ext.to_str().unwrap_or("xlsx"),
         None => "xlsx",
     };

--- a/src/writer/xlsx.rs
+++ b/src/writer/xlsx.rs
@@ -236,7 +236,7 @@ pub fn write_writer_light<W: io::Write>(wb: &Workbook, mut writer: W) -> Result<
 /// let _unused = umya_spreadsheet::writer::xlsx::write(&book, path);
 /// ```
 pub fn write<P: AsRef<Path>>(wb: &Workbook, path: P) -> Result<(), XlsxError> {
-    let extension = path.as_ref().extension().unwrap().to_str().unwrap();
+    let extension = path.as_ref().extension().unwrap_or("xlsx").to_str().unwrap_or("xlsx");
     let path_tmp = path
         .as_ref()
         .with_extension(format!("{}{}", extension, "tmp"));


### PR DESCRIPTION
See issue #328 for detail.
Add default extension to temporary file if output file with no extension.