### PR TITLE
fix(formula): translate-to-origin semantics for shared-formula siblings

### DIFF
--- a/src/structs/cell_formula.rs
+++ b/src/structs/cell_formula.rs
@@ -17,9 +17,11 @@ use crate::{
         coordinate::index_from_coordinate,
         formula::{
             FormulaToken,
+            adjustment_formula_coordinate,
             adjustment_insert_formula_coordinate,
             adjustment_remove_formula_coordinate,
             parse_to_tokens,
+            render,
         },
     },
     reader::driver::{
@@ -323,22 +325,25 @@ impl CellFormula {
                         return;
                     };
 
-                    let root_col_num = parent_col_num;
-                    let root_row_num = parent_row_num;
-                    let offset_col_num = self_col_num.wrapping_sub(root_col_num);
-                    let offset_row_num = self_row_num.wrapping_sub(root_row_num);
+                    // Shared-formula sibling rebasing: translate every
+                    // RELATIVE reference in the master's formula by
+                    // (self - master) so each sibling references the cells at
+                    // its own offset; absolute refs ($A$1) stay put.
+                    //
+                    // `adjustment_insert_formula_coordinate` has insert-shift
+                    // semantics (shift refs at >= root by N) — the wrong
+                    // primitive here: it left every sibling pointing at the
+                    // master's relative cells (e.g. C1 rendered as `A1+1`
+                    // instead of `B1+1`). `adjustment_formula_coordinate` is
+                    // the translate-to-new-origin primitive.
+                    let offset_col_num: i32 = num_traits::cast::<_, i32>(self_col_num).unwrap()
+                        - num_traits::cast::<_, i32>(parent_col_num).unwrap();
+                    let offset_row_num: i32 = num_traits::cast::<_, i32>(self_row_num).unwrap()
+                        - num_traits::cast::<_, i32>(parent_row_num).unwrap();
 
                     let mut token_new = token.clone();
-                    let value = adjustment_insert_formula_coordinate(
-                        &mut token_new,
-                        root_col_num,
-                        offset_col_num,
-                        root_row_num,
-                        offset_row_num,
-                        "",
-                        "",
-                        true,
-                    );
+                    adjustment_formula_coordinate(&mut token_new, offset_col_num, offset_row_num);
+                    let value = render(token_new.as_ref());
                     self.text_view.set_value(value);
                 }
                 None => {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2742,8 +2742,7 @@ fn alignment_indent_preserved_from_external_xlsx() {
     let out_path = std::path::Path::new("./tests/result_files/alignment_indent_input.xlsx");
     umya_spreadsheet::writer::xlsx::write(&book, out_path).unwrap();
 
-    let mut zip =
-        zip::ZipArchive::new(std::fs::File::open(out_path).unwrap()).unwrap();
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(out_path).unwrap()).unwrap();
     let mut styles_xml = String::new();
     zip.by_name("xl/styles.xml")
         .unwrap()
@@ -2753,4 +2752,50 @@ fn alignment_indent_preserved_from_external_xlsx() {
         styles_xml.contains("indent=\"3\""),
         "indent attribute missing from round-tripped styles.xml; got:\n{styles_xml}"
     );
+}
+
+#[test]
+fn shared_formula_siblings_rebase_relative_references() {
+    use umya_spreadsheet::{
+        reader,
+        writer,
+    };
+    let mut book = umya_spreadsheet::new_file();
+    let ws = book.get_sheet_mut(&0).unwrap();
+    ws.get_cell_mut("A1").set_value_number(10);
+    let mut master = umya_spreadsheet::CellFormula::default();
+    master.set_text("A1+1");
+    master.set_formula_type(umya_spreadsheet::CellFormulaValues::Shared);
+    master.set_shared_index(7);
+    master.set_reference("B1:F1");
+    ws.get_cell_mut("B1")
+        .get_cell_value_mut()
+        .set_formula_obj(master);
+    for col in ["C1", "D1", "E1", "F1"] {
+        let mut sib = umya_spreadsheet::CellFormula::default();
+        sib.set_formula_type(umya_spreadsheet::CellFormulaValues::Shared);
+        sib.set_shared_index(7);
+        ws.get_cell_mut(col)
+            .get_cell_value_mut()
+            .set_formula_obj(sib);
+    }
+    let out_dir = std::path::PathBuf::from("./tests/result_files");
+    std::fs::create_dir_all(&out_dir).expect("mkdir");
+    let path = out_dir.join("repro_shared_formula_rebase.xlsx");
+    writer::xlsx::write(&book, &path).expect("write");
+    let book2 = reader::xlsx::read(&path).expect("read");
+    let ws = book2.get_sheet(&0).unwrap();
+    for (addr, want) in [
+        ("B1", "A1+1"),
+        ("C1", "B1+1"),
+        ("D1", "C1+1"),
+        ("E1", "D1+1"),
+        ("F1", "E1+1"),
+    ] {
+        let cell = ws
+            .get_cell(addr)
+            .unwrap_or_else(|| panic!("missing {addr}"));
+        let got = cell.get_cell_value().get_formula();
+        assert_eq!(got, want, "sibling {addr}: expected `{want}`, got `{got}`");
+    }
 }


### PR DESCRIPTION
## Problem

Shared-formula sibling cells — `<f t="shared" si="N"/>` with no inline text, sharing a master via `si` — are expanded incorrectly. The master's formula should be re-based onto each sibling by translating every **relative** reference by `(sibling_col - master_col, sibling_row - master_row)` (absolute refs like `$A$1` stay put). Instead, every sibling ends up referencing the **master's** relative cells.

Concretely, for `A1=10`, master `B1==A1+1` shared across `B1:F1`:

| cell | expected | actual (before) |
|------|----------|-----------------|
| C1   | `B1+1`   | `A1+1`          |
| D1   | `C1+1`   | `A1+1`          |
| …    | …        | `A1+1`          |

## Root cause

`CellFormula::set_attributes` expands shared siblings with `adjustment_insert_formula_coordinate`, which has **insert-shift** semantics ("shift references at >= root by N", used when a row/column is inserted). That is the wrong primitive for re-basing relative refs to a new origin — it leaves refs below/left of the root untouched, so siblings collapse to the master's references.

## Fix

Use `adjustment_formula_coordinate` + `render` — the translate-to-new-origin primitive the crate already uses in `Cell::set_coordinate`. Signed offsets are built via `num_traits::cast` to match that existing caller.

## Test

Adds `shared_formula_siblings_rebase_relative_references`: builds a 5-cell shared chain in memory, round-trips through write+read, and asserts each sibling re-based. It **fails on the current code** (`C1` reads `A1+1`) and passes with this change.

## Checks

`cargo +nightly fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --test integration_test` (full suite) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)