### PR TITLE
fix(chart): preserve absence of <c:legend> on read/write round-trip

### DIFF
--- a/src/structs/drawing/charts/chart.rs
+++ b/src/structs/drawing/charts/chart.rs
@@ -33,7 +33,7 @@ use crate::{
     xml_read_loop,
 };
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Debug)]
 pub struct Chart {
     title:                         Option<Title>,
     auto_title_deleted:            AutoTitleDeleted,
@@ -43,9 +43,38 @@ pub struct Chart {
     back_wall:                     Option<BackWall>,
     plot_area:                     PlotArea,
     legend:                        Legend,
+    /// Tracks whether the source xlsx had a `<c:legend>` element (or the
+    /// caller explicitly opted in via `set_legend` / `set_legend_present`).
+    /// When `false`, `write_to` omits the legend block entirely, matching how
+    /// Excel and `rust_xlsxwriter` signal "no legend on this chart". Without
+    /// this guard a read/write round-trip silently re-emits a default legend
+    /// block on any chart whose source xlsx had none.
+    legend_present:                bool,
     plot_visible_only:             PlotVisibleOnly,
     display_blanks_as:             DisplayBlanksAs,
     show_data_labels_over_maximum: ShowDataLabelsOverMaximum,
+}
+
+impl Default for Chart {
+    fn default() -> Self {
+        Self {
+            title:                         None,
+            auto_title_deleted:            AutoTitleDeleted::default(),
+            view_3d:                       None,
+            floor:                         None,
+            side_wall:                     None,
+            back_wall:                     None,
+            plot_area:                     PlotArea::default(),
+            legend:                        Legend::default(),
+            // Backwards-compat: a default-constructed Chart historically wrote
+            // the legend on save. Preserve that for code that builds a Chart
+            // and then mutates it via `legend_mut()`.
+            legend_present:                true,
+            plot_visible_only:             PlotVisibleOnly::default(),
+            display_blanks_as:             DisplayBlanksAs::default(),
+            show_data_labels_over_maximum: ShowDataLabelsOverMaximum::default(),
+        }
+    }
 }
 
 impl Chart {
@@ -239,6 +268,9 @@ impl Chart {
     }
 
     pub fn legend_mut(&mut self) -> &mut Legend {
+        // Mutable access implies the caller wants the legend to appear; flip
+        // the presence flag so a post-read mutation isn't dropped on save.
+        self.legend_present = true;
         &mut self.legend
     }
 
@@ -249,6 +281,23 @@ impl Chart {
 
     pub fn set_legend(&mut self, value: Legend) -> &mut Self {
         self.legend = value;
+        // Explicit `set_legend` is the strongest "I want this legend" signal.
+        self.legend_present = true;
+        self
+    }
+
+    /// Returns whether the `<c:legend>` block will be emitted on save.
+    #[must_use]
+    pub fn legend_present(&self) -> bool {
+        self.legend_present
+    }
+
+    /// Override legend presence. `set_legend_present(false)` suppresses the
+    /// `<c:legend>` element on save without modifying the legend's contents,
+    /// matching Excel's "no legend" toggle and `rust_xlsxwriter`'s
+    /// `chart.legend().set_hidden()`.
+    pub fn set_legend_present(&mut self, value: bool) -> &mut Self {
+        self.legend_present = value;
         self
     }
 
@@ -344,6 +393,11 @@ impl Chart {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
+        // Reset legend presence so "no legend in source" round-trips through
+        // the writer. Default-constructed Charts have `legend_present == true`
+        // for backwards compatibility; on a real read we start over and let
+        // the loop below set it only if `<c:legend>` is actually present.
+        self.legend_present = false;
         xml_read_loop!(
             reader,
             Event::Start(ref e) => match e.name().into_inner() {
@@ -377,6 +431,7 @@ impl Chart {
                 }
                 b"c:legend" => {
                     self.legend.set_attributes(reader, e);
+                    self.legend_present = true;
                 }
                 _ => (),
             },
@@ -439,8 +494,12 @@ impl Chart {
         // c:plotArea
         self.plot_area.write_to(writer, wb);
 
-        // c:legend
-        self.legend.write_to(writer);
+        // c:legend - gated on `legend_present` so a chart whose source xlsx
+        // had no `<c:legend>` element (or whose author explicitly hid the
+        // legend) round-trips faithfully without re-emitting a default legend.
+        if self.legend_present {
+            self.legend.write_to(writer);
+        }
 
         // c:plotVisOnly
         self.plot_visible_only.write_to(writer);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2742,8 +2742,7 @@ fn alignment_indent_preserved_from_external_xlsx() {
     let out_path = std::path::Path::new("./tests/result_files/alignment_indent_input.xlsx");
     umya_spreadsheet::writer::xlsx::write(&book, out_path).unwrap();
 
-    let mut zip =
-        zip::ZipArchive::new(std::fs::File::open(out_path).unwrap()).unwrap();
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(out_path).unwrap()).unwrap();
     let mut styles_xml = String::new();
     zip.by_name("xl/styles.xml")
         .unwrap()
@@ -2752,5 +2751,137 @@ fn alignment_indent_preserved_from_external_xlsx() {
     assert!(
         styles_xml.contains("indent=\"3\""),
         "indent attribute missing from round-tripped styles.xml; got:\n{styles_xml}"
+    );
+}
+
+#[test]
+fn chart_legend_absence_roundtrips() {
+    // Regression: a chart whose source xlsx has NO <c:legend> must round-trip
+    // through read -> write without umya re-emitting a default legend block.
+    // Demonstrated independent of the new presence API: build a no-legend
+    // fixture from aaa.xlsx (strip <c:legend>..</c:legend> from each chart
+    // part), read+write it, and assert no legend reappears. With the pre-fix
+    // writer (which always called legend.write_to) this fails.
+    use std::io::{
+        Read,
+        Write,
+    };
+
+    use umya_spreadsheet::{
+        reader,
+        writer,
+    };
+
+    let src = std::path::Path::new("./tests/test_files/aaa.xlsx");
+    let out_dir = std::path::Path::new("./tests/result_files");
+    std::fs::create_dir_all(out_dir).unwrap();
+
+    let fixture = out_dir.join("aaa_no_legend.xlsx");
+    {
+        let mut zin = zip::ZipArchive::new(std::fs::File::open(src).unwrap()).unwrap();
+        let mut zout = zip::ZipWriter::new(std::fs::File::create(&fixture).unwrap());
+        for i in 0..zin.len() {
+            let mut e = zin.by_index(i).unwrap();
+            let name = e.name().to_string();
+            let mut buf = Vec::new();
+            e.read_to_end(&mut buf).unwrap();
+            if name.starts_with("xl/charts/chart") && name.ends_with(".xml") {
+                let mut s = String::from_utf8(buf).unwrap();
+                while let (Some(a), Some(b)) = (s.find("<c:legend>"), s.find("</c:legend>")) {
+                    let end = b + "</c:legend>".len();
+                    s.replace_range(a..end, "");
+                }
+                buf = s.into_bytes();
+            }
+            zout.start_file(name, zip::write::SimpleFileOptions::default())
+                .unwrap();
+            zout.write_all(&buf).unwrap();
+        }
+        zout.finish().unwrap();
+    }
+
+    fn chart_xmls(path: &std::path::Path) -> Vec<String> {
+        let mut zip = zip::ZipArchive::new(std::fs::File::open(path).unwrap()).unwrap();
+        let mut out = Vec::new();
+        for i in 0..zip.len() {
+            let mut e = zip.by_index(i).unwrap();
+            let name = e.name().to_string();
+            if name.starts_with("xl/charts/chart") && name.ends_with(".xml") {
+                let mut s = String::new();
+                e.read_to_string(&mut s).unwrap();
+                out.push(s);
+            }
+        }
+        out
+    }
+
+    let pre = chart_xmls(&fixture);
+    assert!(!pre.is_empty(), "fixture should contain chart parts");
+    assert_eq!(
+        pre.iter().filter(|x| x.contains("<c:legend>")).count(),
+        0,
+        "fixture precondition: no chart should have a legend"
+    );
+
+    let book = reader::xlsx::read(&fixture).expect("read no-legend fixture");
+    let out_path = out_dir.join("aaa_no_legend_roundtrip.xlsx");
+    writer::xlsx::write(&book, &out_path).expect("write");
+
+    let after = chart_xmls(&out_path);
+    let regained = after.iter().filter(|x| x.contains("<c:legend>")).count();
+    assert_eq!(
+        regained,
+        0,
+        "read -> write must not re-add legends; {regained}/{} charts regained one",
+        after.len()
+    );
+}
+
+#[test]
+fn set_legend_present_false_suppresses_legend() {
+    // Public API: set_legend_present(false) drops the <c:legend> block on save
+    // (matches Excel's "no legend" toggle / rust_xlsxwriter set_hidden()).
+    use std::io::Read;
+
+    use umya_spreadsheet::{
+        reader,
+        writer,
+    };
+
+    let src = std::path::Path::new("./tests/test_files/aaa.xlsx");
+    let out_dir = std::path::Path::new("./tests/result_files");
+    std::fs::create_dir_all(out_dir).unwrap();
+
+    let mut book = reader::xlsx::read(src).expect("read aaa.xlsx");
+    for sheet in book.sheet_collection_mut().iter_mut() {
+        for chart in sheet.chart_collection_mut().iter_mut() {
+            chart
+                .chart_space_mut()
+                .chart_mut()
+                .set_legend_present(false);
+        }
+    }
+    let out_path = out_dir.join("aaa_legend_suppressed.xlsx");
+    writer::xlsx::write(&book, &out_path).expect("write");
+
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(&out_path).unwrap()).unwrap();
+    let mut charts = 0;
+    let mut with_legend = 0;
+    for i in 0..zip.len() {
+        let mut e = zip.by_index(i).unwrap();
+        let name = e.name().to_string();
+        if name.starts_with("xl/charts/chart") && name.ends_with(".xml") {
+            charts += 1;
+            let mut s = String::new();
+            e.read_to_string(&mut s).unwrap();
+            if s.contains("<c:legend>") {
+                with_legend += 1;
+            }
+        }
+    }
+    assert!(charts > 0, "aaa.xlsx should contain charts");
+    assert_eq!(
+        with_legend, 0,
+        "set_legend_present(false) should suppress all legends; {with_legend}/{charts} remain"
     );
 }


### PR DESCRIPTION
## Problem

A chart whose source xlsx has **no** `<c:legend>` element gains one on a read→write round-trip. `Chart::write_to` calls `self.legend.write_to(writer)` unconditionally, and `Legend::write_to` always emits the `<c:legend>` block — there is no notion of "this chart has no legend." This silently undoes, e.g., `rust_xlsxwriter`'s `chart.legend().set_hidden()` on any file that passes through umya.

## Fix

Track legend presence on `Chart`:
- `legend_present: bool`, set to `true` on read only when a `<c:legend>` element is actually seen (reset to `false` at the start of `set_attributes`).
- `write_to` emits the legend only when `legend_present`.
- Defaults to `true` for programmatically-constructed charts (`Chart::default()`), and `legend_mut()` / `set_legend()` flip it to `true`, so existing code that builds or mutates a legend is unaffected.
- Adds `legend_present()` / `set_legend_present()` — the latter is the public "no legend" toggle (matches Excel / `rust_xlsxwriter` `set_hidden()`).

## Tests

- `chart_legend_absence_roundtrips` — builds a no-legend fixture (strips `<c:legend>` from `aaa.xlsx`'s chart parts), reads + writes it, and asserts no legend reappears. **Fails on the current code** (11/11 charts regain a legend).
- `set_legend_present_false_suppresses_legend` — exercises the new public API.
- Existing charts-with-legends continue to round-trip with their legends (full suite green).

## Checks

`cargo +nightly fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --test integration_test` (full suite) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)