### PR TITLE
Update dependencies and fix various parsing and encryption issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,32 +14,31 @@ rust-version = "1.88.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aes = "0.8.4"
+aes = "0.9"
 base64 = "0.22.1"
 byteorder = "1.5"
-cbc = "0.1.2"
-cfb = "0.10.0"
-chrono = { version = "0.4.39", default-features = false, features = ["clock"] }
+cbc = "0.2"
+cfb = "0.14"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 encoding_rs = "0.8.35"
-fancy-regex = "0.14.0"
-hmac = "0.12.1"
-html_parser = "0.7.0"
+fancy-regex = "0.18"
+hmac = "0.13"
+html5gum = "0.8"
 imagesize = "0.14"
-jiff = { version = "0.2.24", default-features = false }
-md-5 = "0.10.6"
+jiff = { version = "0.2", default-features = false }
+md-5 = "0.11"
 num-traits = "0.2.19"
-phf = { version = "0.11.2", features = ["macros"] }
-quick-xml = { version = "0.37.1", features = ["serialize"] }
-rand = "0.8.5"
-rgb = "0.8.50"
-sha2 = "0.10.8"
+phf = { version = "0.13", features = ["macros"] }
+quick-xml = { version = "0.40", features = ["serialize"] }
+rand = "0.10"
+rgb = "0.8"
+sha2 = "0.11"
 thousands = "0.2.0"
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
-hex-literal = "0.4.1"
+hex-literal = "1.1"
 rstest = { version = "0.26.1", default-features = false }
 
 
 [features]
-

--- a/src/helper/crypt/algo.rs
+++ b/src/helper/crypt/algo.rs
@@ -61,8 +61,8 @@ use std::io;
 use aes::{
     Aes256,
     cipher::{
-        BlockDecryptMut,
-        BlockEncryptMut,
+        BlockModeDecrypt,
+        BlockModeEncrypt,
         KeyIvInit,
         block_padding::NoPadding,
     },
@@ -197,7 +197,7 @@ pub(crate) fn crypt(encrypt: bool, key: &[u8], iv: &[u8], input: &[u8]) -> Resul
                     .map_err(|e| format!("Error creating cipher: {e}"))?;
                 let mut buffer = input.to_vec();
                 cipher
-                    .encrypt_padded_mut::<NoPadding>(&mut buffer, input.len())
+                    .encrypt_padded::<NoPadding>(&mut buffer, input.len())
                     .map_err(|e| format!("Encryption error: {e}"))?;
                 Ok(buffer)
             } else {
@@ -206,7 +206,7 @@ pub(crate) fn crypt(encrypt: bool, key: &[u8], iv: &[u8], input: &[u8]) -> Resul
                     .map_err(|e| format!("Error creating cipher: {e}"))?;
                 let mut buffer = input.to_vec();
                 cipher
-                    .decrypt_padded_mut::<NoPadding>(&mut buffer)
+                    .decrypt_padded::<NoPadding>(&mut buffer)
                     .map_err(|e| format!("Decryption error: {e}"))?;
                 Ok(buffer)
             }

--- a/src/helper/crypt/key.rs
+++ b/src/helper/crypt/key.rs
@@ -60,6 +60,7 @@ use std::cmp::Ordering;
 
 use hmac::{
     Hmac,
+    KeyInit,
     Mac,
 };
 use sha2::{

--- a/src/helper/crypt/mod.rs
+++ b/src/helper/crypt/mod.rs
@@ -24,8 +24,6 @@ use std::{
     path::Path,
 };
 
-use rand::Rng;
-
 use crate::structs::{
     SheetProtection,
     WorkbookProtection,

--- a/src/helper/crypt/utils.rs
+++ b/src/helper/crypt/utils.rs
@@ -83,7 +83,7 @@ use sha2::{
 macro_rules! generate_random_bytes {
     ($var_name:ident, $size:expr) => {
         let mut $var_name = [0u8; $size];
-        rand::thread_rng().fill(&mut $var_name);
+        rand::fill(&mut $var_name[..]);
     };
 }
 

--- a/src/helper/formula.rs
+++ b/src/helper/formula.rs
@@ -161,7 +161,7 @@ fn parse_into_intermediate_tokens(formula: &str) -> (Vec<FormulaToken>, Vec<Form
     // state flags
     let mut in_string = false;
     let mut in_path = false;
-    let mut in_range = false;
+    let mut range_depth = 0;
     let mut in_error = false;
 
     let mut index = 1;
@@ -188,8 +188,8 @@ fn parse_into_intermediate_tokens(formula: &str) -> (Vec<FormulaToken>, Vec<Form
         }
 
         // bracketed strings (R1C1 range index or workbook name)
-        if in_range {
-            handle_in_range(formula, &mut index, &mut value, &mut in_range);
+        if range_depth > 0 {
+            handle_in_range(formula, &mut index, &mut value, &mut range_depth);
             continue;
         }
 
@@ -212,7 +212,7 @@ fn parse_into_intermediate_tokens(formula: &str) -> (Vec<FormulaToken>, Vec<Form
             &mut tokens1,
             &mut stack,
             &mut in_string,
-            &mut in_range,
+            &mut range_depth,
             &mut in_error,
         ) {
             continue;
@@ -372,11 +372,14 @@ fn handle_in_path(formula: &str, index: &mut usize, value: &mut String, in_path:
     *index += 1;
 }
 
-fn handle_in_range(formula: &str, index: &mut usize, value: &mut String, in_range: &mut bool) {
-    if formula.chars().nth(*index).unwrap() == BRACKET_CLOSE {
-        *in_range = false;
+fn handle_in_range(formula: &str, index: &mut usize, value: &mut String, range_depth: &mut usize) {
+    let current_char = formula.chars().nth(*index).unwrap();
+    if current_char == BRACKET_OPEN {
+        *range_depth += 1;
+    } else if current_char == BRACKET_CLOSE {
+        *range_depth = range_depth.saturating_sub(1);
     }
-    value.push(formula.chars().nth(*index).unwrap());
+    value.push(current_char);
     *index += 1;
 }
 
@@ -424,7 +427,7 @@ fn handle_special_characters(
     tokens1: &mut Vec<FormulaToken>,
     stack: &mut Vec<FormulaToken>,
     in_string: &mut bool,
-    in_range: &mut bool,
+    range_depth: &mut usize,
     in_error: &mut bool,
 ) -> bool {
     let current_char = formula.chars().nth(*index).unwrap();
@@ -459,7 +462,7 @@ fn handle_special_characters(
 
     // handle bracket open
     if current_char == BRACKET_OPEN {
-        *in_range = true;
+        *range_depth = 1;
         value.push(BRACKET_OPEN);
         *index += 1;
         return true;
@@ -596,6 +599,11 @@ fn handle_special_characters(
 
     // handle subexpression/function stop
     if current_char == PAREN_CLOSE {
+        if stack.is_empty() {
+            value.push(current_char);
+            *index += 1;
+            return true;
+        }
         if !value.is_empty() {
             let mut obj = FormulaToken::default();
             obj.set_value(value.clone());

--- a/src/helper/html.rs
+++ b/src/helper/html.rs
@@ -1,8 +1,13 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    error::Error,
+    fmt,
+};
 
-use html_parser::{
-    Dom,
-    Node,
+use html5gum::{
+    HtmlString,
+    Token,
+    Tokenizer,
 };
 use phf::phf_map;
 
@@ -19,7 +24,7 @@ use crate::structs::{
 /// # Arguments
 /// * `html` - HTML String.
 /// # Return value
-/// * `Result<RichText, html_parser::Error>`
+/// * `Result<RichText, HtmlParseError>`
 /// # Examples
 /// ```
 /// let html = r##"<font color="red">test</font><br><font class="test" color="#48D1CC">TE<b>S</b>T<br/>TEST</font>"##;
@@ -36,7 +41,7 @@ use crate::structs::{
 ///     .set_wrap_text(true);
 /// ```
 #[inline]
-pub fn html_to_richtext(html: &str) -> Result<RichText, html_parser::Error> {
+pub fn html_to_richtext(html: &str) -> Result<RichText, HtmlParseError> {
     html_to_richtext_custom(html, &DataAnalysis::default())
 }
 
@@ -45,75 +50,141 @@ pub fn html_to_richtext(html: &str) -> Result<RichText, html_parser::Error> {
 /// * `html` - HTML String.
 /// * `method` - struct for analysis.
 /// # Return value
-/// * `Result<RichText, html_parser::Error>`
+/// * `Result<RichText, HtmlParseError>`
 #[inline]
 pub fn html_to_richtext_custom(
     html: &str,
     method: &dyn AnalysisMethod,
-) -> Result<RichText, html_parser::Error> {
-    let dom = Dom::parse(html)?;
-    let data = read_node(&dom.children, &Vec::new());
+) -> Result<RichText, HtmlParseError> {
+    let data = read_html(html)?;
     let result = make_rich_text(&data, method);
     Ok(result)
 }
 
-#[allow(clippy::field_reassign_with_default)]
-fn read_node(node_list: &Vec<Node>, parent_element: &[HfdElement]) -> Vec<HtmlFlatData> {
-    let mut result: Vec<HtmlFlatData> = Vec::new();
+/// Error emitted while tokenizing HTML input for rich-text conversion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct HtmlParseError {
+    kind: html5gum::Error,
+}
 
-    if node_list.is_empty() {
-        return result;
+impl HtmlParseError {
+    #[inline]
+    #[must_use]
+    pub const fn new(kind: html5gum::Error) -> Self {
+        Self { kind }
     }
 
-    let mut data = HtmlFlatData::default();
-    data.element.extend_from_slice(parent_element);
+    #[inline]
+    #[must_use]
+    pub const fn kind(&self) -> html5gum::Error {
+        self.kind
+    }
+}
 
-    for node in node_list {
-        match node {
-            Node::Text(text) => {
-                data.text = format!("{}{}", data.text, text);
-            }
-            Node::Element(element) => {
-                if &element.name == "br" {
-                    data.text = format!("{}{}", data.text, "\n");
+impl fmt::Display for HtmlParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "HTML parse error: {}", self.kind)
+    }
+}
+
+impl Error for HtmlParseError {}
+
+impl From<html5gum::Error> for HtmlParseError {
+    #[inline]
+    fn from(value: html5gum::Error) -> Self {
+        Self::new(value)
+    }
+}
+
+fn read_html(html: &str) -> Result<Vec<HtmlFlatData>, HtmlParseError> {
+    let mut result: Vec<HtmlFlatData> = Vec::new();
+    let mut data = HtmlFlatData::default();
+    let mut element_stack: Vec<HfdElement> = Vec::new();
+
+    for token in Tokenizer::new(html) {
+        let token = match token {
+            Ok(token) => token,
+            Err(error) => match error {},
+        };
+
+        match token {
+            Token::StartTag(tag) => {
+                let tag_name = html_string_to_string(&tag.name).to_ascii_lowercase();
+                if tag_name == "br" {
+                    data.text.push('\n');
                     continue;
                 }
-                if !data.text.is_empty() {
-                    result.push(data);
-                    data = HtmlFlatData::default();
-                    data.element.extend_from_slice(parent_element);
+
+                push_text_run(&mut result, &mut data, &element_stack);
+                if !tag.self_closing {
+                    element_stack.push(make_element(tag_name, &tag.attributes));
+                    data.element.clone_from(&element_stack);
                 }
-
-                let mut elm: HfdElement = HfdElement::default();
-                elm.name.clone_from(&element.name);
-
-                elm.attributes = element
-                    .attributes
-                    .iter()
-                    .map(|(name, value)| {
-                        (
-                            name.clone(),
-                            value.as_ref().map(ToString::to_string).unwrap_or_default(),
-                        )
-                    })
-                    .collect();
-
-                elm.classes.clone_from(&element.classes);
-                data.element.push(elm);
-
-                let mut children = read_node(&element.children, &data.element);
-                result.append(&mut children);
-
-                data = HtmlFlatData::default();
-                data.element.extend_from_slice(parent_element);
             }
-            Node::Comment(_) => {}
+            Token::EndTag(tag) => {
+                push_text_run(&mut result, &mut data, &element_stack);
+
+                let tag_name = html_string_to_string(&tag.name).to_ascii_lowercase();
+                if let Some(index) = element_stack
+                    .iter()
+                    .rposition(|element| element.name == tag_name)
+                {
+                    element_stack.truncate(index);
+                }
+                data.element.clone_from(&element_stack);
+            }
+            Token::String(text) => {
+                data.text.push_str(&html_string_to_string(&text.value));
+            }
+            Token::Comment(_) | Token::Doctype(_) => {}
+            Token::Error(error) => return Err(error.value.into()),
         }
     }
-    if !data.text.is_empty() {
-        result.push(data);
+
+    push_text_run(&mut result, &mut data, &element_stack);
+    Ok(result)
+}
+
+fn push_text_run(
+    result: &mut Vec<HtmlFlatData>,
+    data: &mut HtmlFlatData,
+    element_stack: &[HfdElement],
+) {
+    if data.text.is_empty() {
+        return;
     }
-    result
+
+    result.push(std::mem::take(data));
+    data.element.extend_from_slice(element_stack);
+}
+
+fn make_element(
+    name: String,
+    attributes: &std::collections::BTreeMap<HtmlString, html5gum::Spanned<HtmlString, ()>>,
+) -> HfdElement {
+    let mut element = HfdElement {
+        name,
+        ..HfdElement::default()
+    };
+
+    for (name, value) in attributes {
+        let name = html_string_to_string(name).to_ascii_lowercase();
+        let value = html_string_to_string(&value.value);
+
+        if name == "class" {
+            element
+                .classes
+                .extend(value.split_whitespace().map(str::to_string));
+        } else if name != "id" {
+            element.attributes.insert(name, value);
+        }
+    }
+
+    element
+}
+
+fn html_string_to_string(value: &HtmlString) -> String {
+    String::from_utf8_lossy(value.as_ref()).into_owned()
 }
 
 fn make_rich_text(html_flat_data_list: &[HtmlFlatData], method: &dyn AnalysisMethod) -> RichText {
@@ -820,4 +891,65 @@ static COLOR_MAP: phf::Map<&str, &str> = phf_map! {
 fn convert_test() {
     let html = r#"<font color="red">test</font><br><font class="test" color="green">TE<b>S</b>T<br/>TEST</font>"#;
     let _unused = html_to_richtext(html).unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn html_to_richtext_decodes_entities_and_preserves_line_breaks() {
+        let rich_text = html_to_richtext("A&amp;B<br>C&nbsp;D").unwrap();
+
+        assert_eq!(rich_text.text(), "A&B\nC\u{a0}D");
+    }
+
+    #[test]
+    fn html_to_richtext_keeps_nested_formatting_on_each_text_run() {
+        let html = r##"<font face="Arial" size="14" color="#48D1CC">TE<b>S</b><br/>T</font>"##;
+        let rich_text = html_to_richtext(html).unwrap();
+        let elements = rich_text.rich_text_elements();
+
+        assert_eq!(elements.len(), 3);
+        assert_eq!(elements[0].text(), "TE");
+        assert_eq!(elements[1].text(), "S");
+        assert_eq!(elements[2].text(), "\nT");
+
+        let regular_font = elements[0].font().unwrap();
+        assert_eq!(regular_font.name(), "Arial");
+        assert!((regular_font.size() - 14.0).abs() < f64::EPSILON);
+        assert_eq!(regular_font.color().argb_str(), "FF48D1CC");
+        assert!(!regular_font.bold());
+
+        let bold_font = elements[1].font().unwrap();
+        assert!(bold_font.bold());
+        assert_eq!(bold_font.name(), "Arial");
+        assert_eq!(bold_font.color().argb_str(), "FF48D1CC");
+    }
+
+    #[test]
+    fn html_to_richtext_maps_supported_inline_tags_to_font_properties() {
+        let html = "<u><i><del><sup>X</sup></del></i></u><sub>Y</sub>";
+        let rich_text = html_to_richtext(html).unwrap();
+        let elements = rich_text.rich_text_elements();
+
+        assert_eq!(elements.len(), 2);
+        assert_eq!(elements[0].text(), "X");
+        assert_eq!(elements[1].text(), "Y");
+
+        let x_font = elements[0].font().unwrap();
+        assert_eq!(x_font.font_underline().val(), &UnderlineValues::Single);
+        assert!(x_font.italic());
+        assert!(x_font.strikethrough());
+        assert_eq!(
+            x_font.vertical_text_alignment().val(),
+            &VerticalAlignmentRunValues::Superscript
+        );
+
+        let y_font = elements[1].font().unwrap();
+        assert_eq!(
+            y_font.vertical_text_alignment().val(),
+            &VerticalAlignmentRunValues::Subscript
+        );
+    }
 }

--- a/src/helper/utils.rs
+++ b/src/helper/utils.rs
@@ -1,5 +1,26 @@
 #![allow(unused_imports)]
 
+use md5::Digest as _;
+
+pub(crate) fn md5_hash(input: impl AsRef<[u8]>) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+
+    let digest = md5::Md5::digest(input);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest.iter().copied() {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+pub(crate) fn unescape_xml_text(e: &quick_xml::events::BytesText<'_>) -> String {
+    let decoded = e.decode().unwrap();
+    quick_xml::escape::unescape(decoded.as_ref())
+        .unwrap()
+        .into_owned()
+}
+
 /// A macro that implements the `From` trait for converting from one error type
 /// to another.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ extern crate byteorder;
 extern crate cbc;
 extern crate cfb;
 extern crate hmac;
-extern crate html_parser;
+extern crate html5gum;
 extern crate rand;
 extern crate sha2;
 

--- a/src/reader/xlsx/comment.rs
+++ b/src/reader/xlsx/comment.rs
@@ -34,7 +34,7 @@ pub(crate) fn read(worksheet: &mut Worksheet, drawing_file: &RawFile) {
             }
         },
         Event::Text(e) => {
-            value = e.unescape().unwrap().to_string();
+            value = crate::helper::utils::unescape_xml_text(&e);
         },
         Event::End(ref e) => {
             if e.name().into_inner() == b"author" {

--- a/src/reader/xlsx/table.rs
+++ b/src/reader/xlsx/table.rs
@@ -108,7 +108,7 @@ pub(crate) fn read(worksheet: &mut Worksheet, table_file: &RawFile) -> Result<()
                 }
                 _ => (),
             },
-            Ok(Event::Text(e)) => string_value = e.unescape().unwrap().to_string(),
+            Ok(Event::Text(e)) => string_value = crate::helper::utils::unescape_xml_text(&e),
             Ok(Event::Start(ref e)) => match e.name().into_inner() {
                 b"table" => {
                     for attr in e.attributes().with_checks(false).flatten() {

--- a/src/structs/alignment.rs
+++ b/src/structs/alignment.rs
@@ -1,7 +1,6 @@
 // alignment
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -124,17 +123,14 @@ impl Alignment {
     }
 
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}{}{}{}",
-                self.horizontal.hash_string(),
-                self.vertical.hash_string(),
-                self.wrap_text.hash_string(),
-                self.text_rotation.hash_string(),
-                self.indent.hash_string(),
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}{}{}{}",
+            self.horizontal.hash_string(),
+            self.vertical.hash_string(),
+            self.wrap_text.hash_string(),
+            self.text_rotation.hash_string(),
+            self.indent.hash_string(),
+        ))
     }
 
     #[deprecated(since = "3.0.0", note = "Use hash_code()")]

--- a/src/structs/border.rs
+++ b/src/structs/border.rs
@@ -1,7 +1,6 @@
 // left right top bottom
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -108,14 +107,11 @@ impl Border {
     }
 
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}",
-                self.style.value_string(),
-                self.color().unwrap_or_default().argb_str()
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}",
+            self.style.value_string(),
+            self.color().unwrap_or_default().argb_str()
+        ))
     }
 
     #[deprecated(since = "3.0.0", note = "Use hash_code()")]

--- a/src/structs/borders.rs
+++ b/src/structs/borders.rs
@@ -1,7 +1,6 @@
 // border
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -501,21 +500,18 @@ impl Borders {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}{}{}{}{}{}{}{}",
-                self.left_border().hash_code(),
-                self.right_border().hash_code(),
-                self.top_border().hash_code(),
-                self.bottom_border().hash_code(),
-                self.diagonal_border().hash_code(),
-                self.vertical_border().hash_code(),
-                self.horizontal_border().hash_code(),
-                self.diagonal_down.value_string(),
-                self.diagonal_up.value_string()
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}{}{}{}{}{}{}{}",
+            self.left_border().hash_code(),
+            self.right_border().hash_code(),
+            self.top_border().hash_code(),
+            self.bottom_border().hash_code(),
+            self.diagonal_border().hash_code(),
+            self.vertical_border().hash_code(),
+            self.horizontal_border().hash_code(),
+            self.diagonal_down.value_string(),
+            self.diagonal_up.value_string()
+        ))
     }
 
     #[inline]

--- a/src/structs/cache_field.rs
+++ b/src/structs/cache_field.rs
@@ -1,7 +1,6 @@
 // cacheField
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -105,15 +104,12 @@ impl CacheField {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}{}",
-                self.name.value_str(),
-                self.number_format_id.value_string(),
-                self.shared_items.hash_code(),
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}{}",
+            self.name.value_str(),
+            self.number_format_id.value_string(),
+            self.shared_items.hash_code(),
+        ))
     }
 
     #[inline]

--- a/src/structs/cache_fields.rs
+++ b/src/structs/cache_fields.rs
@@ -1,6 +1,5 @@
 // cacheFields
 use std::io::Cursor;
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -56,10 +55,7 @@ impl CacheFields {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(self.list.iter().map(CacheField::hash_code).collect::<String>())
-        )
+        crate::helper::utils::md5_hash(self.list.iter().map(CacheField::hash_code).collect::<String>())
     }
 
     #[inline]

--- a/src/structs/cache_source.rs
+++ b/src/structs/cache_source.rs
@@ -1,7 +1,6 @@
 // cacheSource
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -88,21 +87,18 @@ impl CacheSource {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}",
-                self.r#type.value_string(),
-                match &self.worksheet_source {
-                    Some(v) => {
-                        v.hash_code()
-                    }
-                    None => {
-                        "None".into()
-                    }
-                },
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}",
+            self.r#type.value_string(),
+            match &self.worksheet_source {
+                Some(v) => {
+                    v.hash_code()
+                }
+                None => {
+                    "None".into()
+                }
+            },
+        ))
     }
 
     #[inline]

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -598,7 +598,7 @@ impl Cell {
         let mut buf = Vec::new();
         loop {
             match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => string_value = e.unescape().unwrap().to_string(),
+                Ok(Event::Text(e)) => string_value = crate::helper::utils::unescape_xml_text(&e),
                 Ok(Event::Start(ref e)) => match e.name().into_inner() {
                     b"f" => {
                         let mut obj = CellFormula::default();

--- a/src/structs/cell_formula.rs
+++ b/src/structs/cell_formula.rs
@@ -299,7 +299,7 @@ impl CellFormula {
             xml_read_loop!(
                 reader,
                 Event::Text(e) => {
-                    self.text.set_value(e.unescape().unwrap().to_string());
+                    self.text.set_value(crate::helper::utils::unescape_xml_text(&e));
                 },
                 Event::End(ref e) => {
                     if e.name().into_inner() == b"f" {

--- a/src/structs/color.rs
+++ b/src/structs/color.rs
@@ -4,7 +4,6 @@ use std::{
     io::Cursor,
 };
 
-use md5::Digest;
 use phf::phf_map;
 use quick_xml::{
     Reader,
@@ -475,16 +474,13 @@ impl Color {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}{}{}",
-                self.indexed.map_or(String::new(), |v| v.to_string()),
-                self.theme_index.map_or(String::new(), |v| v.to_string()),
-                self.argb.map_or(String::new(), Self::argb8_to_hex),
-                self.tint.map_or(String::new(), |v| v.to_string())
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}{}{}",
+            self.indexed.map_or(String::new(), |v| v.to_string()),
+            self.theme_index.map_or(String::new(), |v| v.to_string()),
+            self.argb.map_or(String::new(), Self::argb8_to_hex),
+            self.tint.map_or(String::new(), |v| v.to_string())
+        ))
     }
 
     #[inline]

--- a/src/structs/column.rs
+++ b/src/structs/column.rs
@@ -1,4 +1,3 @@
-use md5::Digest;
 use quick_xml::{
     Reader,
     events::BytesStart,
@@ -224,15 +223,12 @@ impl Column {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}{}",
-                self.width.value_string(),
-                self.hidden.value_string(),
-                self.best_fit.value_string(),
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}{}",
+            self.width.value_string(),
+            self.hidden.value_string(),
+            self.best_fit.value_string(),
+        ))
     }
 
     #[inline]

--- a/src/structs/custom_properties/custom_document_property.rs
+++ b/src/structs/custom_properties/custom_document_property.rs
@@ -168,7 +168,7 @@ impl CustomDocumentProperty {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                value = e.unescape().unwrap().to_string();
+                value = crate::helper::utils::unescape_xml_text(&e);
             },
             Event::End(ref e) => {
                 match e.name().into_inner(){

--- a/src/structs/data_validation.rs
+++ b/src/structs/data_validation.rs
@@ -333,7 +333,7 @@ impl DataValidation {
         loop {
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Text(e)) => {
-                    value = e.unescape().unwrap().to_string();
+                    value = crate::helper::utils::unescape_xml_text(&e);
                 }
                 Ok(Event::End(ref e)) => match e.name().into_inner() {
                     b"formula1" => {

--- a/src/structs/defined_name.rs
+++ b/src/structs/defined_name.rs
@@ -222,7 +222,7 @@ impl DefinedName {
         xml_read_loop!(
             reader,
                 Event::Text(e) => {
-                    value = e.unescape().unwrap().to_string();
+                    value = crate::helper::utils::unescape_xml_text(&e);
                 },
                 Event::End(ref e) => {
                     if e.name().into_inner() == b"definedName" {

--- a/src/structs/diagonal_border.rs
+++ b/src/structs/diagonal_border.rs
@@ -93,14 +93,11 @@ impl DiagonalBorder {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}",
-                &self.style.get_value_string(),
-                &self.get_color().get_hash_code()
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}",
+            &self.style.get_value_string(),
+            &self.get_color().get_hash_code()
+        ))
     }
 
     #[inline]

--- a/src/structs/differential_format.rs
+++ b/src/structs/differential_format.rs
@@ -1,7 +1,6 @@
 // dxf
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -172,44 +171,41 @@ impl DifferentialFormat {
     }
 
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}{}{}",
-                match &self.font {
-                    Some(v) => {
-                        v.hash_code()
-                    }
-                    None => {
-                        "None".into()
-                    }
-                },
-                match &self.fill {
-                    Some(v) => {
-                        v.hash_code()
-                    }
-                    None => {
-                        "None".into()
-                    }
-                },
-                match &self.borders {
-                    Some(v) => {
-                        v.hash_code()
-                    }
-                    None => {
-                        "None".into()
-                    }
-                },
-                match &self.alignment {
-                    Some(v) => {
-                        v.hash_code()
-                    }
-                    None => {
-                        "None".into()
-                    }
-                },
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}{}{}",
+            match &self.font {
+                Some(v) => {
+                    v.hash_code()
+                }
+                None => {
+                    "None".into()
+                }
+            },
+            match &self.fill {
+                Some(v) => {
+                    v.hash_code()
+                }
+                None => {
+                    "None".into()
+                }
+            },
+            match &self.borders {
+                Some(v) => {
+                    v.hash_code()
+                }
+                None => {
+                    "None".into()
+                }
+            },
+            match &self.alignment {
+                Some(v) => {
+                    v.hash_code()
+                }
+                None => {
+                    "None".into()
+                }
+            },
+        ))
     }
 
     #[deprecated(since = "3.0.0", note = "Use hash_code()")]

--- a/src/structs/drawing/charts/format_code.rs
+++ b/src/structs/drawing/charts/format_code.rs
@@ -49,7 +49,7 @@ impl FormatCode {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.set_text(e.unescape().unwrap());
+                self.set_text(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"c:formatCode" {

--- a/src/structs/drawing/charts/formula.rs
+++ b/src/structs/drawing/charts/formula.rs
@@ -98,7 +98,7 @@ impl Formula {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.set_address_str(e.unescape().unwrap());
+                self.set_address_str(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                if  e.name().0 == b"c:f" {

--- a/src/structs/drawing/charts/numeric_value.rs
+++ b/src/structs/drawing/charts/numeric_value.rs
@@ -49,7 +49,7 @@ impl NumericValue {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.set_text(e.unescape().unwrap());
+                self.set_text(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"c:v" {

--- a/src/structs/drawing/charts/series_text.rs
+++ b/src/structs/drawing/charts/series_text.rs
@@ -50,7 +50,7 @@ impl SeriesText {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.set_value(e.unescape().unwrap());
+                self.set_value(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"c:tx" {

--- a/src/structs/drawing/run.rs
+++ b/src/structs/drawing/run.rs
@@ -91,7 +91,7 @@ impl Run {
                 }
             },
             Event::Text(e) => {
-                self.set_text(e.unescape().unwrap());
+                self.set_text(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"a:r" {

--- a/src/structs/drawing/spreadsheet/marker_type.rs
+++ b/src/structs/drawing/spreadsheet/marker_type.rs
@@ -151,7 +151,7 @@ impl MarkerType {
         let mut buf = Vec::new();
         loop {
             match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => string_value = e.unescape().unwrap().to_string(),
+                Ok(Event::Text(e)) => string_value = crate::helper::utils::unescape_xml_text(&e),
                 Ok(Event::End(ref e)) => match e.name().into_inner() {
                     b"xdr:col" | b"col" => {
                         self.col = string_value.parse::<u32>().unwrap();

--- a/src/structs/fill.rs
+++ b/src/structs/fill.rs
@@ -1,6 +1,5 @@
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -141,28 +140,25 @@ impl Fill {
     }
 
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}",
-                match &self.pattern_fill {
-                    Some(v) => {
-                        v.hash_code()
-                    }
-                    None => {
-                        "NONE".to_string()
-                    }
-                },
-                match &self.gradient_fill {
-                    Some(v) => {
-                        v.hash_code()
-                    }
-                    None => {
-                        "NONE".to_string()
-                    }
-                },
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}",
+            match &self.pattern_fill {
+                Some(v) => {
+                    v.hash_code()
+                }
+                None => {
+                    "NONE".to_string()
+                }
+            },
+            match &self.gradient_fill {
+                Some(v) => {
+                    v.hash_code()
+                }
+                None => {
+                    "NONE".to_string()
+                }
+            },
+        ))
     }
 
     #[deprecated(since = "3.0.0", note = "Use hash_code()")]

--- a/src/structs/font.rs
+++ b/src/structs/font.rs
@@ -4,7 +4,6 @@ use std::{
     str::FromStr,
 };
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -612,23 +611,20 @@ impl Font {
     }
 
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}{}{}{}{}{}{}{}{}{}",
-                self.font_name.val.hash_string(),
-                self.font_size.val.hash_string(),
-                self.font_family_numbering.val.hash_string(),
-                self.font_bold.val.hash_string(),
-                self.font_italic.val.hash_string(),
-                self.font_underline.val.hash_string(),
-                self.font_strike.val.hash_string(),
-                self.color.hash_code(),
-                self.font_char_set.val.hash_string(),
-                self.font_scheme.val.hash_string(),
-                self.vertical_text_alignment.val.hash_string(),
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}{}{}{}{}{}{}{}{}{}",
+            self.font_name.val.hash_string(),
+            self.font_size.val.hash_string(),
+            self.font_family_numbering.val.hash_string(),
+            self.font_bold.val.hash_string(),
+            self.font_italic.val.hash_string(),
+            self.font_underline.val.hash_string(),
+            self.font_strike.val.hash_string(),
+            self.color.hash_code(),
+            self.font_char_set.val.hash_string(),
+            self.font_scheme.val.hash_string(),
+            self.vertical_text_alignment.val.hash_string(),
+        ))
     }
 
     #[deprecated(since = "3.0.0", note = "Use hash_code()")]

--- a/src/structs/formula.rs
+++ b/src/structs/formula.rs
@@ -104,7 +104,7 @@ impl Formula {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.set_address_str(e.unescape().unwrap());
+                self.set_address_str(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().into_inner() == b"formula" {

--- a/src/structs/from_marker.rs
+++ b/src/structs/from_marker.rs
@@ -140,7 +140,7 @@ impl FromMarker {
         let mut string_value: String = String::new();
         xml_read_loop!(
             reader,
-            Event::Text(e) => string_value = e.unescape().unwrap().to_string(),
+            Event::Text(e) => string_value = crate::helper::utils::unescape_xml_text(&e),
             Event::End(ref e) => match e.name().into_inner() {
                 b"xdr:col" => {
                     self.col = string_value.parse::<usize>().unwrap();

--- a/src/structs/gradient_fill.rs
+++ b/src/structs/gradient_fill.rs
@@ -4,7 +4,6 @@ use std::{
     io::Cursor,
 };
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -91,10 +90,7 @@ impl GradientFill {
         for stop in &self.gradient_stop {
             write!(value, "{}", stop.hash_code()).unwrap();
         }
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!("{}{}", self.degree.value_string(), value))
-        )
+        crate::helper::utils::md5_hash(format!("{}{}", self.degree.value_string(), value))
     }
 
     #[deprecated(since = "3.0.0", note = "Use hash_code()")]

--- a/src/structs/gradient_stop.rs
+++ b/src/structs/gradient_stop.rs
@@ -1,7 +1,6 @@
 // stop
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -85,14 +84,11 @@ impl GradientStop {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}",
-                self.position.value_string(),
-                self.color.hash_code(),
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}",
+            self.position.value_string(),
+            self.color.hash_code(),
+        ))
     }
 
     #[inline]

--- a/src/structs/numbering_format.rs
+++ b/src/structs/numbering_format.rs
@@ -1,6 +1,5 @@
 use std::io::Cursor;
 
-use md5::Digest;
 use phf::phf_map;
 use quick_xml::{
     Reader,
@@ -168,7 +167,7 @@ impl NumberingFormat {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!("{:x}", md5::Md5::digest(&*self.format_code))
+        crate::helper::utils::md5_hash(&*self.format_code)
     }
 
     #[inline]

--- a/src/structs/odd_footer.rs
+++ b/src/structs/odd_footer.rs
@@ -1,7 +1,6 @@
 // oddFooter
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -48,7 +47,7 @@ impl OddFooter {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!("{:x}", md5::Md5::digest(self.value()))
+        crate::helper::utils::md5_hash(self.value())
     }
 
     #[inline]
@@ -70,7 +69,7 @@ impl OddFooter {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.set_value(e.unescape().unwrap());
+                self.set_value(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"oddFooter" {

--- a/src/structs/odd_header.rs
+++ b/src/structs/odd_header.rs
@@ -1,7 +1,6 @@
 // oddHeader
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -48,7 +47,7 @@ impl OddHeader {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!("{:x}", md5::Md5::digest(self.value()))
+        crate::helper::utils::md5_hash(self.value())
     }
 
     #[inline]
@@ -70,7 +69,7 @@ impl OddHeader {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.set_value(e.unescape().unwrap());
+                self.set_value(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"oddHeader" {

--- a/src/structs/office/excel/formula.rs
+++ b/src/structs/office/excel/formula.rs
@@ -67,7 +67,7 @@ impl Formula {
         loop {
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Text(e)) => {
-                    value = e.unescape().unwrap().to_string();
+                    value = crate::helper::utils::unescape_xml_text(&e);
                 }
                 Ok(Event::End(ref e)) => {
                     if e.name().into_inner() == b"xm:f" {

--- a/src/structs/office/excel/reference_sequence.rs
+++ b/src/structs/office/excel/reference_sequence.rs
@@ -105,7 +105,7 @@ impl ReferenceSequence {
         loop {
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Text(e)) => {
-                    value = e.unescape().unwrap().to_string();
+                    value = crate::helper::utils::unescape_xml_text(&e);
                 }
                 Ok(Event::End(ref e)) => {
                     if e.name().into_inner() == b"xm:sqref" {

--- a/src/structs/office2019/threaded_comment_text.rs
+++ b/src/structs/office2019/threaded_comment_text.rs
@@ -50,7 +50,7 @@ impl ThreadedCommentText {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.set_value(e.unescape().unwrap());
+                self.set_value(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"text" {

--- a/src/structs/pattern_fill.rs
+++ b/src/structs/pattern_fill.rs
@@ -1,7 +1,6 @@
 // patternFill
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -151,12 +150,9 @@ impl PatternFill {
             .background_color
             .as_ref()
             .map_or("None".into(), |v| v.hash_code());
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{pattern_type}{foreground_color}{background_color}"
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{pattern_type}{foreground_color}{background_color}"
+        ))
     }
 
     #[deprecated(since = "3.0.0", note = "Use hash_code()")]

--- a/src/structs/pivot_cache_definition.rs
+++ b/src/structs/pivot_cache_definition.rs
@@ -1,7 +1,6 @@
 // pivotCacheDefinition
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -262,21 +261,18 @@ impl PivotCacheDefinition {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}{}{}{}{}{}{}{}",
-                self.id.value_str(),
-                self.refreshed_by.value_str(),
-                self.refreshed_date.value_string(),
-                self.created_version.value_string(),
-                self.refreshed_version.value_string(),
-                self.min_refreshable_version.value_string(),
-                self.record_count.value_string(),
-                self.cache_source.hash_code(),
-                self.cache_fields.hash_code(),
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}{}{}{}{}{}{}{}",
+            self.id.value_str(),
+            self.refreshed_by.value_str(),
+            self.refreshed_date.value_string(),
+            self.created_version.value_string(),
+            self.refreshed_version.value_string(),
+            self.min_refreshable_version.value_string(),
+            self.record_count.value_string(),
+            self.cache_source.hash_code(),
+            self.cache_fields.hash_code(),
+        ))
     }
 
     #[inline]

--- a/src/structs/properties.rs
+++ b/src/structs/properties.rs
@@ -361,7 +361,7 @@ impl Properties {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                value = e.unescape().unwrap().to_string();
+                value = crate::helper::utils::unescape_xml_text(&e);
             },
             Event::End(ref e) => match e.name().into_inner() {
                 b"dc:title" => {self.set_title(std::mem::take(&mut value));},
@@ -398,7 +398,7 @@ impl Properties {
                 }
             },
             Event::Text(e) => {
-                value = e.unescape().unwrap().to_string();
+                value = crate::helper::utils::unescape_xml_text(&e);
             },
             Event::End(ref e) => match e.name().into_inner() {
                 b"Manager" => {self.set_manager(std::mem::take(&mut value));}

--- a/src/structs/protection.rs
+++ b/src/structs/protection.rs
@@ -1,7 +1,6 @@
 // protection
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -61,14 +60,11 @@ impl Protection {
     #[inline]
     #[allow(dead_code)]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}",
-                self.locked.hash_string(),
-                self.hidden.hash_string()
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}",
+            self.locked.hash_string(),
+            self.hidden.hash_string()
+        ))
     }
 
     #[inline]

--- a/src/structs/rich_text.rs
+++ b/src/structs/rich_text.rs
@@ -4,7 +4,6 @@ use std::{
     io::Cursor,
 };
 
-use md5::Digest;
 use quick_xml::Writer;
 
 use super::TextElement;
@@ -82,7 +81,7 @@ impl RichText {
         for ele in &self.rich_text_elements {
             write!(value, "{}", ele.hash_code()).unwrap();
         }
-        format!("{:x}", md5::Md5::digest(&value))
+        crate::helper::utils::md5_hash(&value)
     }
 
     #[deprecated(since = "3.0.0", note = "Use hash_code()")]

--- a/src/structs/shared_items.rs
+++ b/src/structs/shared_items.rs
@@ -5,7 +5,6 @@ use std::{
     str::FromStr,
 };
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -165,41 +164,38 @@ impl SharedItems {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}{}{}{}{}{}",
-                self.contains_semi_mixed_types.value_string(),
-                self.contains_string.value_string(),
-                self.contains_number.value_string(),
-                self.contains_integer.value_string(),
-                self.min_value.value_string(),
-                self.max_value.value_string(),
-                self.items
-                    .iter()
-                    .map(|v| match v {
-                        SharedItemValue::Bool(v) => {
-                            format!("Bool|||{v}")
-                        }
-                        SharedItemValue::Date(v) => {
-                            format!("Date|||{v}")
-                        }
-                        SharedItemValue::Error(v) => {
-                            format!("Error|||{v}")
-                        }
-                        SharedItemValue::Empty => {
-                            "Empty|||".to_string()
-                        }
-                        SharedItemValue::Numeric(v) => {
-                            format!("Numeric|||{v}")
-                        }
-                        SharedItemValue::String(v) => {
-                            format!("String|||{v}")
-                        }
-                    })
-                    .collect::<String>()
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}{}{}{}{}{}",
+            self.contains_semi_mixed_types.value_string(),
+            self.contains_string.value_string(),
+            self.contains_number.value_string(),
+            self.contains_integer.value_string(),
+            self.min_value.value_string(),
+            self.max_value.value_string(),
+            self.items
+                .iter()
+                .map(|v| match v {
+                    SharedItemValue::Bool(v) => {
+                        format!("Bool|||{v}")
+                    }
+                    SharedItemValue::Date(v) => {
+                        format!("Date|||{v}")
+                    }
+                    SharedItemValue::Error(v) => {
+                        format!("Error|||{v}")
+                    }
+                    SharedItemValue::Empty => {
+                        "Empty|||".to_string()
+                    }
+                    SharedItemValue::Numeric(v) => {
+                        format!("Numeric|||{v}")
+                    }
+                    SharedItemValue::String(v) => {
+                        format!("String|||{v}")
+                    }
+                })
+                .collect::<String>()
+        ))
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/tab_color.rs
+++ b/src/structs/tab_color.rs
@@ -176,16 +176,13 @@ impl TabColor {
 
     #[inline]
     pub(crate) fn get_hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}{}{}",
-                &self.indexed.get_hash_string(),
-                &self.theme_index.get_hash_string(),
-                &self.argb.get_hash_string(),
-                &self.tint.get_hash_string()
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}{}{}",
+            &self.indexed.get_hash_string(),
+            &self.theme_index.get_hash_string(),
+            &self.argb.get_hash_string(),
+            &self.tint.get_hash_string()
+        ))
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/src/structs/text.rs
+++ b/src/structs/text.rs
@@ -1,7 +1,6 @@
 // t
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -45,7 +44,7 @@ impl Text {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!("{:x}", md5::Md5::digest(&*self.value))
+        crate::helper::utils::md5_hash(&*self.value)
     }
 
     #[inline]
@@ -62,7 +61,7 @@ impl Text {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.set_value(e.unescape().unwrap());
+                self.set_value(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"t" {

--- a/src/structs/text_element.rs
+++ b/src/structs/text_element.rs
@@ -1,7 +1,6 @@
 // r
 use std::io::Cursor;
 
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -127,21 +126,18 @@ impl TextElement {
     }
 
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}",
-                self.text.value(),
-                match &self.run_properties {
-                    Some(v) => {
-                        v.hash_code()
-                    }
-                    None => {
-                        "None".into()
-                    }
-                },
-            ))
-        )
+        crate::helper::utils::md5_hash(format!(
+            "{}{}",
+            self.text.value(),
+            match &self.run_properties {
+                Some(v) => {
+                    v.hash_code()
+                }
+                None => {
+                    "None".into()
+                }
+            },
+        ))
     }
 
     #[deprecated(since = "3.0.0", note = "Use hash_code()")]

--- a/src/structs/to_marker.rs
+++ b/src/structs/to_marker.rs
@@ -129,7 +129,7 @@ impl ToMarker {
         let mut buf = Vec::new();
         loop {
             match reader.read_event_into(&mut buf) {
-                Ok(Event::Text(e)) => string_value = e.unescape().unwrap().to_string(),
+                Ok(Event::Text(e)) => string_value = crate::helper::utils::unescape_xml_text(&e),
                 Ok(Event::End(ref e)) => match e.name().0 {
                     b"xdr:col" => {
                         self.col = string_value.parse::<usize>().unwrap();

--- a/src/structs/vml/spreadsheet/anchor.rs
+++ b/src/structs/vml/spreadsheet/anchor.rs
@@ -256,7 +256,7 @@ impl Anchor {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                let text = e.unescape().unwrap();
+                let text = crate::helper::utils::unescape_xml_text(&e);
                 let split_str: Vec<&str> = text.split(',').collect();
                 self.set_left_column(Self::number(split_str.first()));
                 self.set_left_offset(Self::number(split_str.get(1)));

--- a/src/structs/vml/spreadsheet/auto_fill.rs
+++ b/src/structs/vml/spreadsheet/auto_fill.rs
@@ -58,7 +58,7 @@ impl AutoFill {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.value.set_value_string(e.unescape().unwrap());
+                self.value.set_value_string(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"x:AutoFill" {

--- a/src/structs/vml/spreadsheet/auto_size_picture.rs
+++ b/src/structs/vml/spreadsheet/auto_size_picture.rs
@@ -58,7 +58,7 @@ impl AutoSizePicture {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.value.set_value_string(e.unescape().unwrap());
+                self.value.set_value_string(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"x:AutoPict" {

--- a/src/structs/vml/spreadsheet/clipboard_format.rs
+++ b/src/structs/vml/spreadsheet/clipboard_format.rs
@@ -54,7 +54,7 @@ impl ClipboardFormat {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.value.set_value_string(e.unescape().unwrap());
+                self.value.set_value_string(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"x:CF" {

--- a/src/structs/vml/spreadsheet/comment_column_target.rs
+++ b/src/structs/vml/spreadsheet/comment_column_target.rs
@@ -59,7 +59,7 @@ impl CommentColumnTarget {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.value.set_value_string(e.unescape().unwrap());
+                self.value.set_value_string(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"x:Column" {

--- a/src/structs/vml/spreadsheet/comment_row_target.rs
+++ b/src/structs/vml/spreadsheet/comment_row_target.rs
@@ -77,7 +77,7 @@ impl CommentRowTarget {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.value.set_value_string(e.unescape().unwrap());
+                self.value.set_value_string(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"x:Row" {

--- a/src/structs/vml/spreadsheet/move_with_cells.rs
+++ b/src/structs/vml/spreadsheet/move_with_cells.rs
@@ -58,7 +58,7 @@ impl MoveWithCells {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.value.set_value_string(e.unescape().unwrap());
+                self.value.set_value_string(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"x:MoveWithCells" {

--- a/src/structs/vml/spreadsheet/resize_with_cells.rs
+++ b/src/structs/vml/spreadsheet/resize_with_cells.rs
@@ -58,7 +58,7 @@ impl ResizeWithCells {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.value.set_value_string(e.unescape().unwrap());
+                self.value.set_value_string(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"x:SizeWithCells" {

--- a/src/structs/vml/spreadsheet/visible.rs
+++ b/src/structs/vml/spreadsheet/visible.rs
@@ -58,7 +58,7 @@ impl Visible {
         xml_read_loop!(
             reader,
             Event::Text(e) => {
-                self.value.set_value_string(e.unescape().unwrap());
+                self.value.set_value_string(crate::helper::utils::unescape_xml_text(&e));
             },
             Event::End(ref e) => {
                 if e.name().0 == b"x:Visible" {

--- a/src/structs/vml/text_box.rs
+++ b/src/structs/vml/text_box.rs
@@ -124,7 +124,7 @@ impl TextBox {
                     inner_text = format!("{inner_text}<{tag}>");
                 }
                 Ok(Event::Text(ref e)) => {
-                    let s = e.unescape().unwrap();
+                    let s = crate::helper::utils::unescape_xml_text(e);
                     inner_text = format!("{inner_text}{s}");
                 }
                 Ok(Event::End(ref e)) => {

--- a/src/structs/worksheet_source.rs
+++ b/src/structs/worksheet_source.rs
@@ -1,6 +1,5 @@
 // worksheetSource
 use std::io::Cursor;
-use md5::Digest;
 use quick_xml::{
     Reader,
     Writer,
@@ -67,14 +66,7 @@ impl WorksheetSource {
 
     #[inline]
     pub(crate) fn hash_code(&self) -> String {
-        format!(
-            "{:x}",
-            md5::Md5::digest(format!(
-                "{}{}",
-                self.address.address(),
-                self.name.value_str()
-            ))
-        )
+        crate::helper::utils::md5_hash(format!("{}{}", self.address.address(), self.name.value_str()))
     }
 
     pub(crate) fn set_attributes<R: std::io::BufRead>(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2452,7 +2452,12 @@ fn shared_formula_signatures(
             }
             Ok(quick_xml::events::Event::Text(e)) => {
                 if in_shared_formula {
-                    shared_text = Some(e.unescape().unwrap().into_owned());
+                    let decoded = e.decode().unwrap();
+                    shared_text = Some(
+                        quick_xml::escape::unescape(decoded.as_ref())
+                            .unwrap()
+                            .into_owned(),
+                    );
                 }
             }
             Ok(quick_xml::events::Event::End(ref e)) => {


### PR DESCRIPTION
This PR introduces several important dependency upgrades and refactors the HTML parsing logic to use a new library, along with various supporting code improvements and bug fixes. The most significant change is the migration from the stale `html_parser` crate to `html5gum` for HTML-to-rich-text conversion, which also includes improved error handling and new tests. Additionally, many dependencies are updated to newer versions, and cryptography-related code is modernized to match new library APIs. Utility functions are added or refactored for XML and MD5 handling.

**HTML Parsing Refactor and Improvements:**
- Replaced the `html_parser` crate with `html5gum` for HTML parsing in `src/helper/html.rs`, introducing a new `HtmlParseError` type, a rewritten parsing function (`read_html`), and improved handling of text runs and tag attributes. Added comprehensive tests to verify entity decoding, formatting preservation, and inline tag mapping. [[1]](diffhunk://#diff-1659082ca7b6952f8d92f4bd2a631cee83c2c5e4d83546b9152df6c808fa769cL1-R10) [[2]](diffhunk://#diff-1659082ca7b6952f8d92f4bd2a631cee83c2c5e4d83546b9152df6c808fa769cL22-R27) [[3]](diffhunk://#diff-1659082ca7b6952f8d92f4bd2a631cee83c2c5e4d83546b9152df6c808fa769cL39-R44) [[4]](diffhunk://#diff-1659082ca7b6952f8d92f4bd2a631cee83c2c5e4d83546b9152df6c808fa769cL48-R187) [[5]](diffhunk://#diff-1659082ca7b6952f8d92f4bd2a631cee83c2c5e4d83546b9152df6c808fa769cR895-R955)

**Dependency Upgrades:**
- Upgraded multiple dependencies in `Cargo.toml`, including `aes`, `cbc`, `cfb`, `chrono`, `fancy-regex`, `hmac`, `html5gum` (replacing `html_parser`), `jiff`, `md-5`, `phf`, `quick-xml`, `rand`, `rgb`, and `sha2`.
- Updated `extern crate` import from `html_parser` to `html5gum` in `src/lib.rs`.

**Cryptography Modernization:**
- Updated cryptography code to use new trait names and APIs from upgraded `aes`, `cbc`, `cfb`, and `hmac` crates, including changes to trait imports and method calls in `src/helper/crypt/algo.rs` and `src/helper/crypt/key.rs`. [[1]](diffhunk://#diff-8480e8b9142fe8272cc36a56425c308bd9ce7b5431b8a16adb42d7e3aec89351L64-R65) [[2]](diffhunk://#diff-8480e8b9142fe8272cc36a56425c308bd9ce7b5431b8a16adb42d7e3aec89351L200-R200) [[3]](diffhunk://#diff-8480e8b9142fe8272cc36a56425c308bd9ce7b5431b8a16adb42d7e3aec89351L209-R209) [[4]](diffhunk://#diff-0fce6baa490a9b32767322bf8243437d4200d2a742daddbc6c2fe58930aa006bR63)
- Changed random number generation to use the new `rand::fill` API. [[1]](diffhunk://#diff-b08b5ef47448036f23994ce3e73afd98dab55f1e1a52256f2bdec51d1f59a581L86-R86) [[2]](diffhunk://#diff-9843265a108571411d4e25d10ea93ab590d7d9c2db015243ad6548113d156dd4L27-L28)

**Formula Parsing Bug Fixes:**
- Refactored formula parsing logic to handle nested ranges using a `range_depth` counter instead of a boolean, fixing edge cases with nested brackets in `src/helper/formula.rs`. [[1]](diffhunk://#diff-9bf6a5094096e86ab32f98cd4271a7143e0be32bf60701326f7b9b8af6fa1c17L164-R164) [[2]](diffhunk://#diff-9bf6a5094096e86ab32f98cd4271a7143e0be32bf60701326f7b9b8af6fa1c17L191-R192) [[3]](diffhunk://#diff-9bf6a5094096e86ab32f98cd4271a7143e0be32bf60701326f7b9b8af6fa1c17L215-R215) [[4]](diffhunk://#diff-9bf6a5094096e86ab32f98cd4271a7143e0be32bf60701326f7b9b8af6fa1c17L375-R382) [[5]](diffhunk://#diff-9bf6a5094096e86ab32f98cd4271a7143e0be32bf60701326f7b9b8af6fa1c17L427-R430) [[6]](diffhunk://#diff-9bf6a5094096e86ab32f98cd4271a7143e0be32bf60701326f7b9b8af6fa1c17L462-R465) [[7]](diffhunk://#diff-9bf6a5094096e86ab32f98cd4271a7143e0be32bf60701326f7b9b8af6fa1c17R602-R606)

**Utility Functions and XML Handling:**
- Added `md5_hash` and `unescape_xml_text` utility functions to `src/helper/utils.rs` for consistent hashing and XML text decoding.
- Refactored XML text extraction in `src/reader/xlsx/comment.rs` and `src/reader/xlsx/table.rs` to use the new `unescape_xml_text` function. [[1]](diffhunk://#diff-077c279e59fb324d9552996b92ec689a9718976708fe98871607198b8fb62e47L37-R37) [[2]](diffhunk://#diff-86571c74747dd9d905c775deda366a34879dfc51f024c99677c7435aa45c9b01L111-R111)

