### PR TITLE
fix: preserve quoted sheet refs in shared formula expansion

### DIFF
--- a/src/helper/address.rs
+++ b/src/helper/address.rs
@@ -14,7 +14,31 @@ pub fn join_address(sheet_name: &str, address: &str) -> String {
     if sheet_name.is_empty() {
         return address.to_string();
     }
+    if sheet_name_needs_quoting(sheet_name) {
+        let escaped = sheet_name.replace('\'', "''");
+        return format!("'{escaped}'!{address}");
+    }
     format!("{sheet_name}!{address}")
+}
+
+/// A sheet name can appear unquoted in a formula only when it is a bare
+/// identifier: it starts with a letter or underscore and otherwise contains
+/// only letters, digits, underscores or periods. Anything else (spaces,
+/// punctuation such as `(`/`)`, a leading digit, …) must be wrapped in single
+/// quotes when re-serialized.
+fn sheet_name_needs_quoting(sheet_name: &str) -> bool {
+    let mut chars = sheet_name.chars();
+    match chars.next() {
+        None => false,
+        Some(first) => {
+            if !(first.is_ascii_alphabetic() || first == '_') {
+                return true;
+            }
+            sheet_name
+                .chars()
+                .any(|c| !(c.is_ascii_alphanumeric() || c == '_' || c == '.'))
+        }
+    }
 }
 
 /// Checks if the given input string is a valid address format.

--- a/src/helper/formula.rs
+++ b/src/helper/formula.rs
@@ -212,6 +212,7 @@ fn parse_into_intermediate_tokens(formula: &str) -> (Vec<FormulaToken>, Vec<Form
             &mut tokens1,
             &mut stack,
             &mut in_string,
+            &mut in_path,
             &mut in_range,
             &mut in_error,
         ) {
@@ -361,9 +362,12 @@ fn handle_in_path(formula: &str, index: &mut usize, value: &mut String, in_path:
         if (*index + 2) <= formula.chars().count()
             && formula.chars().nth(*index + 1).unwrap() == QUOTE_SINGLE
         {
-            *value = format!("{value}{QUOTE_SINGLE}");
+            // escaped quote inside the sheet name: keep both so it round-trips
+            *value = format!("{value}{QUOTE_SINGLE}{QUOTE_SINGLE}");
             *index += 1;
         } else {
+            // closing quote: keep it so the sheet reference stays quoted
+            value.push(QUOTE_SINGLE);
             *in_path = false;
         }
     } else {
@@ -424,6 +428,7 @@ fn handle_special_characters(
     tokens1: &mut Vec<FormulaToken>,
     stack: &mut Vec<FormulaToken>,
     in_string: &mut bool,
+    in_path: &mut bool,
     in_range: &mut bool,
     in_error: &mut bool,
 ) -> bool {
@@ -443,16 +448,10 @@ fn handle_special_characters(
         return true;
     }
 
-    // handle single quote
+    // handle single quote (start of a quoted sheet path, e.g. '(1)'!$E$38)
     if current_char == QUOTE_SINGLE {
-        if !value.is_empty() {
-            let mut obj = FormulaToken::default();
-            obj.set_value(value.clone());
-            obj.set_token_type(FormulaTokenTypes::Unknown);
-            tokens1.push(obj);
-            value.clear();
-        }
-        *in_string = true;
+        *in_path = true;
+        value.push(QUOTE_SINGLE);
         *index += 1;
         return true;
     }
@@ -1072,5 +1071,24 @@ mod tests {
             format!("={}", render(parse_to_tokens(formula).as_ref())),
             formula
         );
+    }
+}
+
+#[cfg(test)]
+mod shared_formula_quoted_sheet_tests {
+    use super::*;
+
+    #[test]
+    fn quoted_sheet_ref_round_trips() {
+        let f = r#"IF(A2=1,'(1)'!$E$38&"-x","")"#;
+        assert_eq!(render(&parse_to_tokens(format!("={f}"))), f);
+    }
+
+    #[test]
+    fn shared_adjustment_preserves_quoted_sheet() {
+        let mut tokens = parse_to_tokens(r#"=IF(A2=1,'(1)'!$E$38&"-x","")"#);
+        let out = adjustment_insert_formula_coordinate(&mut tokens, 0, 0, 2, 1, "", "Main", true);
+        assert!(out.contains("'(1)'!$E$38"), "quoted sheet ref corrupted: {out}");
+        assert!(!out.contains("(1)!$E$38"), "sheet name lost its quotes: {out}");
     }
 }


### PR DESCRIPTION
## Problem

Loading a real `.xlsx` whose **shared formulas** reference a sheet whose name
needs quoting (e.g. `'(1)'!$E$38`, common with numbered sheets) fails at ingest:

```
Formula parse error: ... Reached end of formula while parsing string
```

A shared-formula member (`<f t="shared" si="..."/>`) is reconstructed from its
master by `parse_to_tokens` → coordinate adjustment → `render`, and that
round-trip mangles any single-quoted sheet reference. Non-shared formulas are
unaffected (their text is returned verbatim, without the token round-trip).

**Impact:** any workbook with a sheet name requiring quotes (`(1)`, `My Sheet`,
names starting with a digit, …) that appears inside a *shared* formula cannot be
loaded.

## Root cause (3 issues)

In `src/helper/formula.rs`:

1. On a `'` (start of a quoted sheet path), the tokenizer set `in_string = true`
   instead of using the existing `in_path` mode, so it scanned for a closing `"`
   and swallowed the sheet reference and everything after it as one "string".
2. `handle_in_path` dropped the surrounding quotes, so re-serialization lost them.

In `src/helper/address.rs`:

3. `split_address` strips the surrounding quotes from the sheet name, but
   `join_address` never re-added them — so `'(1)'!$E$38` round-trips to the
   invalid `(1)!$E$38`.

## Fix

- Route a leading `'` to the already-present `in_path` mode and keep the opening
  quote in the accumulated value.
- `handle_in_path` now preserves the closing quote and doubled internal `''`.
- `join_address` re-quotes sheet names that are not bare identifiers
  (start with a letter/`_`, otherwise only alphanumerics/`_`/`.`) and doubles
  internal single quotes. This also fixes the same corruption for non-shared
  cases that go through coordinate adjustment (e.g. `'New Sheet'!...`).

## Tests

Two regression tests added in `src/helper/formula.rs` (both fail on `master`,
pass with this change):

- `quoted_sheet_ref_round_trips` — `parse_to_tokens` → `render` round-trips
  `IF(A2=1,'(1)'!$E$38&"-x","")` unchanged.
- `shared_adjustment_preserves_quoted_sheet` — coordinate adjustment keeps
  `'(1)'!$E$38` and never produces the invalid `(1)!$E$38`.

Verified locally:

- `cargo test --lib` → **82 passed, 0 failed**
- `cargo fmt --check` → clean
- `cargo clippy --lib` → no warnings

Surgical change, limited to `src/helper/formula.rs` and `src/helper/address.rs`.