### PR TITLE
fix: preserve numeric-looking inline strings

### DIFF
--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -651,7 +651,7 @@ impl Cell {
                     },
                     b"is" => {
                         if type_value == "inlineStr" {
-                            self.set_value_crate(&string_value);
+                            self.set_value_string_crate(&string_value);
                         }
                     }
                     b"c" => return,
@@ -822,5 +822,34 @@ impl AdjustmentCoordinateWith2Sheet for Cell {
             root_row_num,
             offset_row_num,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_string_that_looks_numeric_stays_string() {
+        let mut reader = Reader::from_str(r#"<c r="A1" t="inlineStr"><is><t>0050</t></is></c>"#);
+        let cell_start = match reader.read_event().unwrap() {
+            Event::Start(event) => event,
+            event => panic!("expected cell start event, got {event:?}"),
+        };
+        let mut cell = Cell::default();
+        let mut formula_shared_list = HashMap::new();
+
+        cell.set_attributes(
+            &mut reader,
+            &cell_start,
+            &SharedStringTable::default(),
+            &Stylesheet::default(),
+            false,
+            &mut formula_shared_list,
+        );
+
+        assert_eq!(cell.value(), "0050");
+        assert_eq!(cell.data_type(), "s");
+        assert!(cell.value_number().is_none());
     }
 }

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -530,6 +530,13 @@ impl Cell {
     pub fn formatted_value(&self) -> String {
         let value = self.value();
 
+        if matches!(
+            self.raw_value(),
+            CellRawValue::String(_) | CellRawValue::RichText(_)
+        ) {
+            return value.into_owned();
+        }
+
         // convert value
         let result = match self.style().number_format() {
             Some(number_format) => to_formatted_string(&value, number_format.format_code()),
@@ -849,6 +856,7 @@ mod tests {
         );
 
         assert_eq!(cell.value(), "0050");
+        assert_eq!(cell.formatted_value(), "0050");
         assert_eq!(cell.data_type(), "s");
         assert!(cell.value_number().is_none());
     }


### PR DESCRIPTION
## Summary

- Preserve `inlineStr` cell values as strings instead of guessing their type.
- Return string and rich-text cells unchanged from `formatted_value()` instead of applying numeric number-format coercion.
- Add parser-level regression coverage for a numeric-looking inline string (`0050`) through both raw and formatted value APIs.

## Root cause

The XLSX reader routed `inlineStr` text through `set_value_crate`, which guesses scalar types. That converted values such as `0050` to the number `50`, losing both the leading zeros and the source cell type. After preserving the raw string type, `formatted_value()` still passed the text through the number formatter, which again normalized it to `50` under the General format.

The reader now uses the existing `set_value_string_crate` path, and formatted text values bypass numeric formatting just as Excel text cells do.

## Impact

Numeric-looking text stored as OOXML inline or shared strings now remains text through both value APIs. Numeric cells continue to use their number formats.

## Validation

- `cargo test` (86 library tests, 112 integration tests, 4 streaming-writer tests, and 79 doc tests passed; 23 tests ignored)
- `cargo clippy --lib -- -D warnings`
- `cargo +nightly fmt --all -- --check`