### PR TITLE
fix(number_format): re-attach literal affixes around formatted numbers

### DIFF
--- a/src/helper/number_format/number_formater.rs
+++ b/src/helper/number_format/number_formater.rs
@@ -34,6 +34,7 @@ pub(crate) fn format_as_number(value: f64, format: &str) -> Cow<'_, str> {
 
         format = trailing_comma_regex.replace_all(&format, "$1").into();
     }
+    let mut attached_affixes = false;
     if fraction_regex.is_match(&format).unwrap_or(false) {
         if value.parse::<usize>().is_err() {
             value = format_as_fraction(value.parse::<f64>().unwrap_or(0.0), &format);
@@ -59,23 +60,56 @@ pub(crate) fn format_as_number(value: f64, format: &str) -> Cow<'_, str> {
                 use_thousands,
                 r"(0+)(\.?)(0*)",
             );
+
+            // Re-attach literal text around the digit placeholders ('#'
+            // became '0' above; quotes and escapes are already stripped).
+            // Excel renders `#,##0.00" €"` with the euro sign after the
+            // digits and wraps parenthesized sections; dropping the affixes
+            // loses currency symbols (office2pdf#365).
+            if let (Some(first), Some(last)) = (m.find('0'), m.rfind('0')) {
+                let prefix = replace_skip_width_placeholders(&m[..first]);
+                let suffix = replace_skip_width_placeholders(&m[last + 1..]);
+                if !prefix.is_empty() || !suffix.is_empty() {
+                    value = format!("{prefix}{value}{suffix}");
+                }
+                attached_affixes = true;
+            }
         }
     }
 
-    let re = compile_regex!(r"\$[^0-9]*");
-    if re.find(&format).ok().flatten().is_some() {
-        let item: Vec<&str> = re
-            .captures(&format)
-            .ok()
-            .flatten()
-            .unwrap()
-            .iter()
-            .map(|ite| ite.unwrap().as_str())
-            .collect();
-        value = format!("{}{}", item.first().unwrap(), value);
+    if !attached_affixes {
+        let re = compile_regex!(r"\$[^0-9]*");
+        if re.find(&format).ok().flatten().is_some() {
+            let item: Vec<&str> = re
+                .captures(&format)
+                .ok()
+                .flatten()
+                .unwrap()
+                .iter()
+                .map(|ite| ite.unwrap().as_str())
+                .collect();
+            value = format!("{}{}", item.first().unwrap(), value);
+        }
     }
 
     Cow::Owned(value)
+}
+
+/// Replace Excel skip-width placeholders (`_` followed by a mimicked
+/// character) with a plain space, which is how they render in practice.
+fn replace_skip_width_placeholders(literal: &str) -> String {
+    let mut result = String::with_capacity(literal.len());
+    let mut chars = literal.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '_' {
+            if chars.next().is_some() {
+                result.push(' ');
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+    result
 }
 
 fn format_straight_numeric_value(
@@ -226,4 +260,28 @@ fn complex_number_format_mask(number: f64, mask: &str, split_on_point: bool) -> 
 
     let result = process_complex_number_format_mask(number, mask);
     format!("{}{}", if sign { "-" } else { "" }, result)
+}
+
+#[cfg(test)]
+mod literal_affix_tests {
+    use super::*;
+
+    #[test]
+    fn format_as_number_keeps_quoted_literal_suffix() {
+        // #,##0.00" €" printed only the bare number, dropping the currency
+        // suffix Excel renders after the digits.
+        assert_eq!(format_as_number(1240.0, "#,##0.00\" €\""), "1,240.00 €");
+        assert_eq!(format_as_number(187.55, "#,##0.00\" €\""), "187.55 €");
+    }
+
+    #[test]
+    fn format_as_number_keeps_literal_prefix() {
+        assert_eq!(format_as_number(39.15, "€ 0.00"), "€ 39.15");
+        assert_eq!(format_as_number(39.15, "$0.00"), "$39.15");
+    }
+
+    #[test]
+    fn format_as_number_wraps_parenthesized_sections() {
+        assert_eq!(format_as_number(1234.0, "(#,##0)"), "(1,234)");
+    }
 }


### PR DESCRIPTION
## Problem

`get_formatted_value()` drops literal text around the digit placeholders in numeric formats:

- Quoted suffixes disappear: `#,##0.00" €"` returns `1,240.00` — Excel shows `1,240.00 €`.
- Prefixes other than `$` disappear: `€ 0.00` returns `39.15` — Excel shows `€ 39.15` (only a `\$[^0-9]*` match was ever prepended).
- Parenthesized sections lose their parentheses: `(#,##0)` returns `1,234` — Excel shows `(1,234)`.

## Fix

After the numeric core is formatted, re-attach the literal text found before the first and after the last digit placeholder of the (bracket-stripped) format. Quotes and escapes are already stripped at that point; `_x` skip-width placeholders render as a plain space, which is how they display in practice. The dollar-only prefix special case now applies only on paths that don't attach affixes (fractions), preserving its previous behavior there.

Note: test values deliberately avoid decimal-rounding ties, which are addressed separately in #345.

## Testing

- New unit tests: quoted euro suffix, non-dollar literal prefix, parenthesized section
- `cargo test` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)