### PR TITLE
Fix formula text truncated on XML character references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+### Bug Fixed
+* Data validation / formula character data containing XML numeric character references (e.g. `&#8211;`) was truncated. `formula1`/`formula2` text is now accumulated across successive `Text` and `GeneralRef` events from quick-xml.
+
 # Change Detail -> 3.0.0
 ### We have changed the name of the Getter.
 ```rust

--- a/src/helper/number_format/number_formater.rs
+++ b/src/helper/number_format/number_formater.rs
@@ -344,6 +344,7 @@ mod tests {
     #[test]
     fn format_as_number_wraps_parenthesized_sections() {
         assert_eq!(format_as_number(1234.0, "(#,##0)"), "(1,234)");
+    }
 
     #[test]
     fn format_as_number_rounds_half_away_from_zero() {

--- a/src/helper/utils.rs
+++ b/src/helper/utils.rs
@@ -21,6 +21,42 @@ pub(crate) fn unescape_xml_text(e: &quick_xml::events::BytesText<'_>) -> String 
         .into_owned()
 }
 
+/// Append a text event to an accumulating element value.
+///
+/// Callers that read element character data must **append** successive text
+/// events rather than overwrite: quick-xml emits numeric character references
+/// (e.g. `&#8211;`) as separate [`Event::GeneralRef`] nodes between
+/// [`Event::Text`] fragments.
+pub(crate) fn append_xml_text(out: &mut String, e: &quick_xml::events::BytesText<'_>) {
+    out.push_str(&unescape_xml_text(e));
+}
+
+/// Append a general/character reference event (`&#…;`, `&amp;`, …) to an
+/// accumulating element value.
+pub(crate) fn append_xml_general_ref(out: &mut String, e: &quick_xml::events::BytesRef<'_>) {
+    if let Ok(Some(ch)) = e.resolve_char_ref() {
+        out.push(ch);
+        return;
+    }
+    // Named entities that quick-xml may surface as GeneralRef when not
+    // expanded into Text.
+    if let Ok(name) = e.decode() {
+        match name.as_ref() {
+            "amp" => out.push('&'),
+            "lt" => out.push('<'),
+            "gt" => out.push('>'),
+            "quot" => out.push('"'),
+            "apos" => out.push('\''),
+            other => {
+                // Preserve unknown refs so callers can still inspect them.
+                out.push('&');
+                out.push_str(other);
+                out.push(';');
+            }
+        }
+    }
+}
+
 /// A macro that implements the `From` trait for converting from one error type
 /// to another.
 ///

--- a/src/structs/data_validation.rs
+++ b/src/structs/data_validation.rs
@@ -332,8 +332,15 @@ impl DataValidation {
         let mut buf = Vec::new();
         loop {
             match reader.read_event_into(&mut buf) {
+                // quick-xml may split character data across multiple Text events
+                // interleaved with GeneralRef for numeric character references
+                // (e.g. `&#8211;`). Append rather than overwrite so the full
+                // formula is reconstructed.
                 Ok(Event::Text(e)) => {
-                    value = crate::helper::utils::unescape_xml_text(&e);
+                    crate::helper::utils::append_xml_text(&mut value, &e);
+                }
+                Ok(Event::GeneralRef(e)) => {
+                    crate::helper::utils::append_xml_general_ref(&mut value, &e);
                 }
                 Ok(Event::End(ref e)) => match e.name().into_inner() {
                     b"formula1" => {
@@ -428,5 +435,55 @@ impl DataValidation {
             }
             write_end_tag(writer, "dataValidation");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quick_xml::Reader;
+
+    #[test]
+    fn formula1_preserves_numeric_character_references() {
+        // Excel/LibreOffice may emit en-dashes as `&#8211;`. quick-xml surfaces
+        // those as GeneralRef events between Text fragments; we must append both.
+        let xml = concat!(
+            r#"<dataValidation type="list" sqref="D41" allowBlank="1">"#,
+            r#"<formula1>"0&#8211;3 years ago,4&#8211;5 years ago,6&#8211;7 years ago"</formula1>"#,
+            r#"</dataValidation>"#,
+        );
+        let mut reader = Reader::from_str(xml);
+        reader.config_mut().trim_text(true);
+        let mut buf = Vec::new();
+        let Event::Start(e) = reader.read_event_into(&mut buf).unwrap() else {
+            panic!("expected Start dataValidation");
+        };
+        let mut dv = DataValidation::default();
+        dv.set_attributes(&mut reader, &e, false);
+        assert_eq!(
+            dv.formula1(),
+            "\"0–3 years ago,4–5 years ago,6–7 years ago\"",
+            "full list formula must survive entity split"
+        );
+        assert_eq!(dv.sequence_of_references().get_sqref(), "D41");
+        assert_eq!(dv.get_type(), &DataValidationValues::List);
+    }
+
+    #[test]
+    fn formula1_plain_text_still_works() {
+        let xml = concat!(
+            r#"<dataValidation type="list" sqref="C5" allowBlank="1">"#,
+            r#"<formula1>"petrol,diesel,LPG,electric"</formula1>"#,
+            r#"</dataValidation>"#,
+        );
+        let mut reader = Reader::from_str(xml);
+        reader.config_mut().trim_text(true);
+        let mut buf = Vec::new();
+        let Event::Start(e) = reader.read_event_into(&mut buf).unwrap() else {
+            panic!("expected Start dataValidation");
+        };
+        let mut dv = DataValidation::default();
+        dv.set_attributes(&mut reader, &e, false);
+        assert_eq!(dv.formula1(), "\"petrol,diesel,LPG,electric\"");
     }
 }

--- a/src/structs/formula.rs
+++ b/src/structs/formula.rs
@@ -101,13 +101,22 @@ impl Formula {
         reader: &mut Reader<R>,
         _e: &BytesStart,
     ) {
+        let mut value = String::new();
         xml_read_loop!(
             reader,
+            // Append successive Text / GeneralRef events so character
+            // references (e.g. `&#8211;`) are not dropped mid-formula.
             Event::Text(e) => {
-                self.set_address_str(crate::helper::utils::unescape_xml_text(&e));
+                crate::helper::utils::append_xml_text(&mut value, &e);
+            },
+            Event::GeneralRef(e) => {
+                crate::helper::utils::append_xml_general_ref(&mut value, &e);
             },
             Event::End(ref e) => {
                 if e.name().into_inner() == b"formula" {
+                    if !value.is_empty() {
+                        self.set_address_str(std::mem::take(&mut value));
+                    }
                     return
                 }
             },


### PR DESCRIPTION
## Summary

`dataValidation` / formula character data that contains XML numeric character references (e.g. `&#8211;` for an en-dash) was truncated when reading `.xlsx` files.

### Root cause

quick-xml emits those references as `Event::GeneralRef` nodes between successive `Event::Text` fragments. The parsers for `DataValidation` (`formula1` / `formula2`) and `Formula` **replaced** the accumulator on each `Text` event and ignored `GeneralRef`, so only the last text fragment survived.

Example list formula in a real workbook:

```xml
<formula1>"0&#8211;3 years ago,4&#8211;5 years ago,6&#8211;7 years ago"</formula1>
```

was read as:

```text
7 years ago"
```

instead of the full list string.

### Fix

- Append successive `Text` events instead of overwriting
- Resolve and append `GeneralRef` (numeric char refs + common named entities)
- Shared helpers: `append_xml_text` / `append_xml_general_ref`
- Unit tests covering en-dash list formulas and plain list formulas
- Close a missing brace in `number_formater` tests that broke compilation of the local tree
