### PR TITLE
Fix #352 — Pivot table corruption, sheetFormatPr/pageMargins defaults, workbook namespaces

### DIFF
--- a/src/helper/const_str.rs
+++ b/src/helper/const_str.rs
@@ -47,6 +47,7 @@ declare_const_strings! {
     PACKAGE_NS           => "http://schemas.openxmlformats.org/officeDocument/2006/relationships/package",
     PASSWORD_NS          => "http://schemas.microsoft.com/office/2006/keyEncryptor/password",
     PIVOT_CACHE_DEF_NS   => "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition",
+    PIVOT_CACHE_REC_NS   => "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords",
     PRINTER_SETTINGS_NS  => "http://schemas.openxmlformats.org/officeDocument/2006/relationships/printerSettings",
     PRNTR_SETTINGS_TYPE  => "application/vnd.openxmlformats-officedocument.spreadsheetml.printerSettings",
     REL_NS               => "http://schemas.openxmlformats.org/package/2006/relationships",
@@ -67,6 +68,7 @@ declare_const_strings! {
     TABLE_TYPE           => "application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml",
     PIVOT_TABLE_TYPE     => "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml",
     PIVOT_CACHE_DEF_TYPE => "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml",
+    PIVOT_CACHE_REC_TYPE => "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheRecords+xml",
     THEME_NS             => "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme",
     THEME_TYPE           => "application/vnd.openxmlformats-officedocument.theme+xml",
     VBA_PROJECT_NS       => "http://schemas.microsoft.com/office/2006/relationships/vbaProject",
@@ -104,6 +106,13 @@ declare_const_strings! {
     PKG_PIVOT_CACHE      => "xl/pivotCache",
     PKG_PIVOT_CACHE_RELS => "xl/pivotCache/_rels/pivotCache",
     PKG_WORKBOOK         => "xl/workbook.xml",
+    // Additional workbook namespace declarations commonly present in Excel-generated files.
+    // These are emitted alongside the standard xmlns and xmlns:r to avoid stripping metadata.
+    MC_IGNORABLE_WB       => "x15 xr xr6 xr10 xr2",
+    X15_NS                => "http://schemas.microsoft.com/office/spreadsheetml/2010/11/main",
+    XR2_NS                => "http://schemas.microsoft.com/office/spreadsheetml/2015/revision2",
+    XR6_NS                => "http://schemas.microsoft.com/office/spreadsheetml/2016/revision6",
+    XR10_NS               => "http://schemas.microsoft.com/office/spreadsheetml/2016/revision10",
     PKG_WORKBOOK_RELS    => "xl/_rels/workbook.xml.rels",
 
     ARC_APP              => "docProps/app.xml",

--- a/src/reader/xlsx.rs
+++ b/src/reader/xlsx.rs
@@ -230,6 +230,7 @@ pub(crate) fn raw_to_deserialize_by_worksheet(
                         worksheet,
                         relationship.raw_file(),
                         raw_data_of_worksheet.pivot_table_relationships(),
+                        raw_data_of_worksheet.pivot_cache_relationships(),
                     );
                 }
                 _ => {}

--- a/src/reader/xlsx/pivot_cache.rs
+++ b/src/reader/xlsx/pivot_cache.rs
@@ -11,7 +11,11 @@ use crate::{
     },
 };
 
-pub(crate) fn read(raw_file: &RawFile, pivot_table: &mut PivotTable) {
+pub(crate) fn read(
+    raw_file: &RawFile,
+    pivot_table: &mut PivotTable,
+    raw_cache_records: Option<&RawFile>,
+) {
     let data = std::io::Cursor::new(raw_file.file_data());
     let mut reader = Reader::from_reader(data);
     reader.config_mut().trim_text(false);
@@ -35,6 +39,11 @@ pub(crate) fn read(raw_file: &RawFile, pivot_table: &mut PivotTable) {
             _ => (),
         }
         buf.clear();
+    }
+
+    // Preserve raw cache records if available from the template.
+    if let Some(records_file) = raw_cache_records {
+        pivot_cache_def.set_raw_cache_records(records_file.file_data().to_vec());
     }
 
     pivot_table.set_pivot_cache_definition(pivot_cache_def);

--- a/src/reader/xlsx/pivot_table.rs
+++ b/src/reader/xlsx/pivot_table.rs
@@ -4,7 +4,10 @@ use quick_xml::{
 };
 
 use crate::{
-    helper::const_str::PIVOT_CACHE_DEF_NS,
+    helper::const_str::{
+        PIVOT_CACHE_DEF_NS,
+        PIVOT_CACHE_REC_NS,
+    },
     raw::RawRelationships,
     reader::xlsx::pivot_cache,
     structs::{
@@ -19,6 +22,7 @@ pub(crate) fn read(
     worksheet: &mut Worksheet,
     pivot_table_file: &RawFile,
     pivot_table_relationships: Option<&RawRelationships>,
+    pivot_cache_relationships: Option<&RawRelationships>,
 ) {
     let data = std::io::Cursor::new(pivot_table_file.file_data());
     let mut reader = Reader::from_reader(data);
@@ -47,9 +51,19 @@ pub(crate) fn read(
     }
 
     if let Some(rrs_list) = pivot_table_relationships {
+        // Find cache records from the pivot cache definition's own relationships
+        let records_file = pivot_cache_relationships.and_then(|cache_rels| {
+            cache_rels
+                .relationship_list()
+                .iter()
+                .find(|r| r.get_type() == PIVOT_CACHE_REC_NS)
+                .map(|r| r.raw_file())
+        });
+
         pivot_cache::read(
             rrs_list.relationship_by_type(PIVOT_CACHE_DEF_NS).raw_file(),
             &mut pivot_table,
+            records_file,
         );
     }
 

--- a/src/structs/page_margins.rs
+++ b/src/structs/page_margins.rs
@@ -156,18 +156,35 @@ impl PageMargins {
 
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
         // pageMargins
+        // If all margins are zero (common for minimal template sheets),
+        // use Excel-compatible defaults to avoid "Line 2, column 0" errors.
+        let is_all_zero = self.left.value() == 0.0
+            && self.right.value() == 0.0
+            && self.top.value() == 0.0
+            && self.bottom.value() == 0.0
+            && self.header.value() == 0.0
+            && self.footer.value() == 0.0;
+
+        let (left, right, top, bottom, header, footer) = if is_all_zero {
+            (
+                "0.7".to_string(),  "0.7".to_string(),
+                "0.75".to_string(), "0.75".to_string(),
+                "0.3".to_string(),  "0.3".to_string(),
+            )
+        } else {
+            (
+                self.left.value_string(),   self.right.value_string(),
+                self.top.value_string(),    self.bottom.value_string(),
+                self.header.value_string(), self.footer.value_string(),
+            )
+        };
+
         let mut attributes: crate::structs::AttrCollection = Vec::new();
-        let left = self.left.value_string();
         attributes.push(("left", &left).into());
-        let right = self.right.value_string();
         attributes.push(("right", &right).into());
-        let top = self.top.value_string();
         attributes.push(("top", &top).into());
-        let bottom = self.bottom.value_string();
         attributes.push(("bottom", &bottom).into());
-        let header = self.header.value_string();
         attributes.push(("header", &header).into());
-        let footer = self.footer.value_string();
         attributes.push(("footer", &footer).into());
         write_start_tag(writer, "pageMargins", attributes, true);
     }

--- a/src/structs/pivot_cache_definition.rs
+++ b/src/structs/pivot_cache_definition.rs
@@ -47,6 +47,9 @@ pub struct PivotCacheDefinition {
     record_count:            UInt32Value,
     cache_source:            CacheSource,
     cache_fields:            CacheFields,
+    /// Raw XML data for pivotCacheRecords (if available from template).
+    /// Written alongside the cache definition as pivotCacheRecordsN.xml.
+    raw_cache_records:       Vec<u8>,
 }
 
 impl PivotCacheDefinition {
@@ -241,6 +244,24 @@ impl PivotCacheDefinition {
     pub fn set_cache_fields(&mut self, value: CacheFields) -> &mut Self {
         self.cache_fields = value;
         self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn raw_cache_records(&self) -> &[u8] {
+        &self.raw_cache_records
+    }
+
+    #[inline]
+    pub fn set_raw_cache_records(&mut self, value: Vec<u8>) -> &mut Self {
+        self.raw_cache_records = value;
+        self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn has_raw_cache_records(&self) -> bool {
+        !self.raw_cache_records.is_empty()
     }
 
     /// Create a new minimal pivot cache definition with required fields

--- a/src/structs/pivot_field.rs
+++ b/src/structs/pivot_field.rs
@@ -14,15 +14,17 @@ use crate::{
     }, structs::{
         BooleanValue,
         Items,
+        UInt32Value,
     }, writer::driver::{write_end_tag, write_start_tag}, xml_read_loop
 };
 
 #[derive(Clone, Default, Debug)]
 pub struct PivotField {
-    data_field: BooleanValue,
-    show_all:   BooleanValue,
-    items: Items,
-    axis: EnumValue<PivotTableAxisValues>,
+    data_field:          BooleanValue,
+    show_all:            BooleanValue,
+    items:               Items,
+    axis:                EnumValue<PivotTableAxisValues>,
+    missing_items_limit: UInt32Value,
 }
 impl PivotField {
     #[inline]
@@ -94,6 +96,24 @@ impl PivotField {
     }
 
     #[inline]
+    #[must_use]
+    pub fn missing_items_limit(&self) -> u32 {
+        self.missing_items_limit.value()
+    }
+
+    #[inline]
+    #[deprecated(since = "3.0.0", note = "Use missing_items_limit()")]
+    pub fn get_missing_items_limit(&self) -> u32 {
+        self.missing_items_limit()
+    }
+
+    #[inline]
+    pub fn set_missing_items_limit(&mut self, value: u32) -> &mut Self {
+        self.missing_items_limit.set_value(value);
+        self
+    }
+
+    #[inline]
     pub(crate) fn set_attributes<R: std::io::BufRead>(
         &mut self,
         reader: &mut Reader<R>,
@@ -103,6 +123,7 @@ impl PivotField {
         set_string_from_xml!(self, e, data_field, "dataField");
         set_string_from_xml!(self, e, show_all, "showAll");
         set_string_from_xml!(self, e, axis, "axis");
+        set_string_from_xml!(self, e, missing_items_limit, "missingItemsLimit");
 
         if empty_flg {
             return;
@@ -138,6 +159,10 @@ impl PivotField {
         }
         if self.show_all.has_value() {
             attributes.push(("showAll", self.show_all.value_string()).into());
+        }
+        if self.missing_items_limit.has_value() {
+            let val = self.missing_items_limit.value_string();
+            attributes.push(("missingItemsLimit", &val).into());
         }
         write_start_tag(
             writer,

--- a/src/structs/pivot_field.rs
+++ b/src/structs/pivot_field.rs
@@ -102,12 +102,6 @@ impl PivotField {
     }
 
     #[inline]
-    #[deprecated(since = "3.0.0", note = "Use missing_items_limit()")]
-    pub fn get_missing_items_limit(&self) -> u32 {
-        self.missing_items_limit()
-    }
-
-    #[inline]
     pub fn set_missing_items_limit(&mut self, value: u32) -> &mut Self {
         self.missing_items_limit.set_value(value);
         self

--- a/src/structs/pivot_table_definition.rs
+++ b/src/structs/pivot_table_definition.rs
@@ -50,7 +50,12 @@ pub struct PivotTableDefinition {
     outline:                    BooleanValue,
     outline_data:               BooleanValue,
     multiple_field_filters:     BooleanValue,
+    refresh_on_load:            BooleanValue,
+    row_grand_totals:           BooleanValue,
+    col_grand_totals:           BooleanValue,
+    compact_data:               BooleanValue,
     name:                       StringValue,
+    xr_uid:                     StringValue,
     cache_id:                   UInt32Value,
     indent:                     UInt32Value,
     local_name:                 StringValue,
@@ -279,6 +284,78 @@ impl PivotTableDefinition {
 
     #[inline]
     #[must_use]
+    pub fn refresh_on_load(&self) -> bool {
+        self.refresh_on_load.value()
+    }
+
+    #[inline]
+    #[deprecated(since = "3.0.0", note = "Use refresh_on_load()")]
+    pub fn get_refresh_on_load(&self) -> bool {
+        self.refresh_on_load()
+    }
+
+    #[inline]
+    pub fn set_refresh_on_load(&mut self, value: bool) -> &mut Self {
+        self.refresh_on_load.set_value(value);
+        self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn row_grand_totals(&self) -> bool {
+        self.row_grand_totals.value()
+    }
+
+    #[inline]
+    #[deprecated(since = "3.0.0", note = "Use row_grand_totals()")]
+    pub fn get_row_grand_totals(&self) -> bool {
+        self.row_grand_totals()
+    }
+
+    #[inline]
+    pub fn set_row_grand_totals(&mut self, value: bool) -> &mut Self {
+        self.row_grand_totals.set_value(value);
+        self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn col_grand_totals(&self) -> bool {
+        self.col_grand_totals.value()
+    }
+
+    #[inline]
+    #[deprecated(since = "3.0.0", note = "Use col_grand_totals()")]
+    pub fn get_col_grand_totals(&self) -> bool {
+        self.col_grand_totals()
+    }
+
+    #[inline]
+    pub fn set_col_grand_totals(&mut self, value: bool) -> &mut Self {
+        self.col_grand_totals.set_value(value);
+        self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn compact_data(&self) -> bool {
+        self.compact_data.value()
+    }
+
+    #[inline]
+    #[deprecated(since = "3.0.0", note = "Use compact_data()")]
+    pub fn get_compact_data(&self) -> bool {
+        self.compact_data()
+    }
+
+    #[inline]
+    pub fn set_compact_data(&mut self, value: bool) -> &mut Self {
+        self.compact_data.set_value(value);
+        self
+    }
+
+    #[inline]
+    #[must_use]
     pub fn name(&self) -> &str {
         self.name.value_str()
     }
@@ -293,6 +370,25 @@ impl PivotTableDefinition {
     #[inline]
     pub fn set_name<S: Into<String>>(&mut self, value: S) -> &mut Self {
         self.name.set_value(value);
+        self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn xr_uid(&self) -> &str {
+        self.xr_uid.value_str()
+    }
+
+    #[inline]
+    #[must_use]
+    #[deprecated(since = "3.0.0", note = "Use xr_uid()")]
+    pub fn get_xr_uid(&self) -> &str {
+        self.xr_uid()
+    }
+
+    #[inline]
+    pub fn set_xr_uid<S: Into<String>>(&mut self, value: S) -> &mut Self {
+        self.xr_uid.set_value(value);
         self
     }
 
@@ -687,6 +783,7 @@ impl PivotTableDefinition {
         e: &BytesStart,
     ) {
         set_string_from_xml!(self, e, name, "name");
+        set_string_from_xml!(self, e, xr_uid, "xr:uid");
         set_string_from_xml!(self, e, cache_id, "cacheId");
         set_string_from_xml!(self, e, apply_number_formats, "applyNumberFormats");
         set_string_from_xml!(self, e, apply_border_formats, "applyBorderFormats");
@@ -708,7 +805,11 @@ impl PivotTableDefinition {
         set_string_from_xml!(self, e, indent, "indent");
         set_string_from_xml!(self, e, outline, "outline");
         set_string_from_xml!(self, e, outline_data, "outlineData");
+        set_string_from_xml!(self, e, row_grand_totals, "rowGrandTotals");
+        set_string_from_xml!(self, e, col_grand_totals, "colGrandTotals");
+        set_string_from_xml!(self, e, compact_data, "compactData");
         set_string_from_xml!(self, e, multiple_field_filters, "multipleFieldFilters");
+        set_string_from_xml!(self, e, refresh_on_load, "refreshOnLoad");
 
         xml_read_loop!(
             reader,
@@ -777,6 +878,9 @@ impl PivotTableDefinition {
 
         if self.name.has_value() {
             attributes.push(("name", self.name.value_str()).into());
+        }
+        if self.xr_uid.has_value() {
+            attributes.push(("xr:uid", self.xr_uid.value_str()).into());
         }
         let cache_id_str = self.cache_id.value_string();
         if self.cache_id.has_value() {
@@ -888,6 +992,42 @@ impl PivotTableDefinition {
                     .into(),
             );
         }
+        if self.refresh_on_load.has_value() {
+            attributes.push(
+                (
+                    "refreshOnLoad",
+                    self.refresh_on_load.value_string(),
+                )
+                    .into(),
+            );
+        }
+        if self.row_grand_totals.has_value() {
+            attributes.push(
+                (
+                    "rowGrandTotals",
+                    self.row_grand_totals.value_string(),
+                )
+                    .into(),
+            );
+        }
+        if self.col_grand_totals.has_value() {
+            attributes.push(
+                (
+                    "colGrandTotals",
+                    self.col_grand_totals.value_string(),
+                )
+                    .into(),
+            );
+        }
+        if self.compact_data.has_value() {
+            attributes.push(
+                (
+                    "compactData",
+                    self.compact_data.value_string(),
+                )
+                    .into(),
+            );
+        }
         write_start_tag(writer, "pivotTableDefinition", attributes, false);
 
         // location
@@ -915,5 +1055,97 @@ impl PivotTableDefinition {
         self.pivot_table_style.write_to(writer);
 
         write_end_tag(writer, "pivotTableDefinition");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_pivot_table_attributes_preserved() {
+        let mut def = PivotTableDefinition::default();
+        def.set_name("TestPivot");
+        def.set_cache_id(1);
+        def.set_refresh_on_load(true);
+        def.set_row_grand_totals(true);
+        def.set_col_grand_totals(false);
+        def.set_compact_data(true);
+        def.set_outline(false);
+        def.set_xr_uid("test-uid-12345");
+
+        assert_eq!(def.name(), "TestPivot");
+        assert!(def.refresh_on_load());
+        assert!(def.row_grand_totals());
+        assert!(!def.col_grand_totals());
+        assert!(def.compact_data());
+        assert!(!def.outline());
+        assert_eq!(def.xr_uid(), "test-uid-12345");
+    }
+
+    #[test]
+    fn test_pivot_table_definition_write_read_roundtrip() {
+        let mut def = PivotTableDefinition::default();
+        def.set_name("RoundTrip");
+        def.set_cache_id(2);
+        def.set_refresh_on_load(true);
+        def.set_row_grand_totals(true);
+        def.set_col_grand_totals(true);
+        def.set_compact_data(false);
+        def.set_xr_uid("uid-roundtrip");
+
+        // Write to XML
+        let mut writer = Writer::new(Cursor::new(Vec::new()));
+        def.write_to(&mut writer);
+        let xml = String::from_utf8(writer.into_inner().into_inner()).unwrap();
+
+        // Verify XML contains the attributes
+        assert!(xml.contains("name=\"RoundTrip\""));
+        assert!(xml.contains("cacheId=\"2\""));
+        assert!(xml.contains("refreshOnLoad=\"1\""));
+        assert!(xml.contains("rowGrandTotals=\"1\""));
+        assert!(xml.contains("colGrandTotals=\"1\""));
+        assert!(xml.contains("compactData=\"0\""));
+        assert!(xml.contains("xr:uid=\"uid-roundtrip\""));
+    }
+
+    #[test]
+    fn test_row_items_multiple_x_children() {
+        use crate::structs::{
+            member_property_index::MemberPropertyIndex,
+            row_item::RowItem,
+            row_items::RowItems,
+        };
+
+        let mut row_items = RowItems::default();
+        let mut item = RowItem::default();
+        item.set_index(0);
+        item.set_item_type(crate::structs::item_values::ItemValues::Data);
+
+        // Simulate 2 row fields => 2 <x/> children
+        let mut x1 = MemberPropertyIndex::default();
+        x1.set_val(0);
+        item.add_member_property_index(x1);
+
+        let mut x2 = MemberPropertyIndex::default();
+        x2.set_val(1);
+        item.add_member_property_index(x2);
+
+        row_items.add_list_mut(item);
+
+        // Write to XML
+        let mut writer = Writer::new(Cursor::new(Vec::new()));
+        row_items.write_to(&mut writer);
+        let xml = String::from_utf8(writer.into_inner().into_inner()).unwrap();
+
+        // Should contain two <x> elements
+        assert_eq!(
+            xml.matches("<x ").count(),
+            2,
+            "Expected 2 <x> elements (one per row field), XML: {}",
+            xml
+        );
+        assert!(xml.contains("v=\"0\""));
+        assert!(xml.contains("v=\"1\""));
     }
 }

--- a/src/structs/pivot_table_definition.rs
+++ b/src/structs/pivot_table_definition.rs
@@ -289,12 +289,6 @@ impl PivotTableDefinition {
     }
 
     #[inline]
-    #[deprecated(since = "3.0.0", note = "Use refresh_on_load()")]
-    pub fn get_refresh_on_load(&self) -> bool {
-        self.refresh_on_load()
-    }
-
-    #[inline]
     pub fn set_refresh_on_load(&mut self, value: bool) -> &mut Self {
         self.refresh_on_load.set_value(value);
         self
@@ -304,12 +298,6 @@ impl PivotTableDefinition {
     #[must_use]
     pub fn row_grand_totals(&self) -> bool {
         self.row_grand_totals.value()
-    }
-
-    #[inline]
-    #[deprecated(since = "3.0.0", note = "Use row_grand_totals()")]
-    pub fn get_row_grand_totals(&self) -> bool {
-        self.row_grand_totals()
     }
 
     #[inline]
@@ -325,12 +313,6 @@ impl PivotTableDefinition {
     }
 
     #[inline]
-    #[deprecated(since = "3.0.0", note = "Use col_grand_totals()")]
-    pub fn get_col_grand_totals(&self) -> bool {
-        self.col_grand_totals()
-    }
-
-    #[inline]
     pub fn set_col_grand_totals(&mut self, value: bool) -> &mut Self {
         self.col_grand_totals.set_value(value);
         self
@@ -340,12 +322,6 @@ impl PivotTableDefinition {
     #[must_use]
     pub fn compact_data(&self) -> bool {
         self.compact_data.value()
-    }
-
-    #[inline]
-    #[deprecated(since = "3.0.0", note = "Use compact_data()")]
-    pub fn get_compact_data(&self) -> bool {
-        self.compact_data()
     }
 
     #[inline]
@@ -377,13 +353,6 @@ impl PivotTableDefinition {
     #[must_use]
     pub fn xr_uid(&self) -> &str {
         self.xr_uid.value_str()
-    }
-
-    #[inline]
-    #[must_use]
-    #[deprecated(since = "3.0.0", note = "Use xr_uid()")]
-    pub fn get_xr_uid(&self) -> &str {
-        self.xr_uid()
     }
 
     #[inline]

--- a/src/structs/row_item.rs
+++ b/src/structs/row_item.rs
@@ -93,30 +93,42 @@ impl RowItem {
         self
     }
 
+    /// Returns the first `<x/>` child (backward-compatible convenience method).
+    /// Use [`member_property_indices()`] to access all row-field children.
+    #[inline]
+    #[must_use]
+    pub fn member_property_index(&self) -> Option<&MemberPropertyIndex> {
+        self.member_property_indices.first()
+    }
+
+    /// Returns a mutable reference to the first `<x/>` child.
+    #[inline]
+    pub fn member_property_index_mut(&mut self) -> Option<&mut MemberPropertyIndex> {
+        self.member_property_indices.first_mut()
+    }
+
+    /// Sets a single `<x/>` child (replaces any existing entries).
+    /// For multiple row fields, use [`add_member_property_index()`].
+    #[inline]
+    pub fn set_member_property_index_color(&mut self, value: MemberPropertyIndex) -> &mut Self {
+        self.member_property_indices = vec![value];
+        self
+    }
+
+    /// Returns all `<x/>` children — one per row field.
     #[inline]
     #[must_use]
     pub fn member_property_indices(&self) -> &[MemberPropertyIndex] {
         &self.member_property_indices
     }
 
-    #[inline]
-    #[must_use]
-    #[deprecated(since = "3.0.0", note = "Use member_property_indices()")]
-    pub fn get_member_property_indices(&self) -> &[MemberPropertyIndex] {
-        self.member_property_indices()
-    }
-
+    /// Returns a mutable reference to all `<x/>` children.
     #[inline]
     pub fn member_property_indices_mut(&mut self) -> &mut Vec<MemberPropertyIndex> {
         &mut self.member_property_indices
     }
 
-    #[inline]
-    #[deprecated(since = "3.0.0", note = "Use member_property_indices_mut()")]
-    pub fn get_member_property_indices_mut(&mut self) -> &mut Vec<MemberPropertyIndex> {
-        self.member_property_indices_mut()
-    }
-
+    /// Appends an `<x/>` child. Call once per row field.
     #[inline]
     pub fn add_member_property_index(&mut self, value: MemberPropertyIndex) -> &mut Self {
         self.member_property_indices.push(value);

--- a/src/structs/row_item.rs
+++ b/src/structs/row_item.rs
@@ -30,10 +30,10 @@ use crate::{
 
 #[derive(Clone, Default, Debug)]
 pub struct RowItem {
-    index:                 UInt32Value,
-    item_type:             EnumValue<ItemValues>,
-    repeated_item_count:   UInt32Value,
-    member_property_index: Option<MemberPropertyIndex>,
+    index:                  UInt32Value,
+    item_type:              EnumValue<ItemValues>,
+    repeated_item_count:    UInt32Value,
+    member_property_indices: Vec<MemberPropertyIndex>,
 }
 impl RowItem {
     #[inline]
@@ -95,31 +95,31 @@ impl RowItem {
 
     #[inline]
     #[must_use]
-    pub fn member_property_index(&self) -> Option<&MemberPropertyIndex> {
-        self.member_property_index.as_ref()
+    pub fn member_property_indices(&self) -> &[MemberPropertyIndex] {
+        &self.member_property_indices
     }
 
     #[inline]
     #[must_use]
-    #[deprecated(since = "3.0.0", note = "Use member_property_index()")]
-    pub fn get_member_property_index(&self) -> Option<&MemberPropertyIndex> {
-        self.member_property_index()
+    #[deprecated(since = "3.0.0", note = "Use member_property_indices()")]
+    pub fn get_member_property_indices(&self) -> &[MemberPropertyIndex] {
+        self.member_property_indices()
     }
 
     #[inline]
-    pub fn member_property_index_mut(&mut self) -> Option<&mut MemberPropertyIndex> {
-        self.member_property_index.as_mut()
+    pub fn member_property_indices_mut(&mut self) -> &mut Vec<MemberPropertyIndex> {
+        &mut self.member_property_indices
     }
 
     #[inline]
-    #[deprecated(since = "3.0.0", note = "Use member_property_index_mut()")]
-    pub fn get_member_property_index_mut(&mut self) -> Option<&mut MemberPropertyIndex> {
-        self.member_property_index_mut()
+    #[deprecated(since = "3.0.0", note = "Use member_property_indices_mut()")]
+    pub fn get_member_property_indices_mut(&mut self) -> &mut Vec<MemberPropertyIndex> {
+        self.member_property_indices_mut()
     }
 
     #[inline]
-    pub fn set_member_property_index_color(&mut self, value: MemberPropertyIndex) -> &mut Self {
-        self.member_property_index = Some(value);
+    pub fn add_member_property_index(&mut self, value: MemberPropertyIndex) -> &mut Self {
+        self.member_property_indices.push(value);
         self
     }
 
@@ -140,11 +140,13 @@ impl RowItem {
 
         xml_read_loop!(
             reader,
+            // Support multiple <x/> children — one per row field.
+            // A pivot table with N row fields produces N <x/> elements per <i> row item.
             Event::Empty(ref e) => {
                 if e.name().into_inner() == b"x" {
                     let mut obj = MemberPropertyIndex::default();
                     obj.set_attributes(reader, e);
-                    self.set_member_property_index_color(obj);
+                    self.member_property_indices.push(obj);
                 }
             },
             Event::End(ref e) => {
@@ -158,7 +160,7 @@ impl RowItem {
 
     #[inline]
     pub(crate) fn write_to(&self, writer: &mut Writer<Cursor<Vec<u8>>>) {
-        let empty_flg = self.member_property_index.is_none();
+        let empty_flg = self.member_property_indices.is_empty();
         // i
         let mut attributes: crate::structs::AttrCollection = Vec::new();
         let index_str = self.index.value_string();
@@ -175,7 +177,8 @@ impl RowItem {
         }
         write_start_tag(writer, "i", attributes, empty_flg);
         if !empty_flg {
-            if let Some(v) = &self.member_property_index {
+            // Write all <x/> children — one per row field.
+            for v in &self.member_property_indices {
                 v.write_to(writer);
             }
             write_end_tag(writer, "i");

--- a/src/structs/sheet_format_properties.rs
+++ b/src/structs/sheet_format_properties.rs
@@ -247,15 +247,23 @@ impl SheetFormatProperties {
             attributes.push(("defaultColWidth", &str_default_column_width).into());
         }
 
-        let str_default_row_height = self.default_row_height.value_string();
-        if self.default_row_height.has_value() {
-            attributes.push(("defaultRowHeight", &str_default_row_height).into());
-        }
+        // Always emit defaultRowHeight — Excel requires it.
+        // Use 14.25 (Excel default) if the template didn't supply one.
+        let str_default_row_height = if self.default_row_height.has_value() {
+            self.default_row_height.value_string()
+        } else {
+            "14.25".to_string()
+        };
+        attributes.push(("defaultRowHeight", &str_default_row_height).into());
 
-        let str_dy_descent = self.dy_descent.value_string();
-        if self.dy_descent.has_value() {
-            attributes.push(("x14ac:dyDescent", &str_dy_descent).into());
-        }
+        // Always emit x14ac:dyDescent — Excel requires it.
+        // Use 0.45 (Excel default) if the template didn't supply one.
+        let str_dy_descent = if self.dy_descent.has_value() {
+            self.dy_descent.value_string()
+        } else {
+            "0.45".to_string()
+        };
+        attributes.push(("x14ac:dyDescent", &str_dy_descent).into());
 
         let str_outline_level_column = self.outline_level_column.value_string();
         if self.outline_level_column.has_value() {

--- a/src/structs/writer_manager.rs
+++ b/src/structs/writer_manager.rs
@@ -17,6 +17,7 @@ use crate::{
         DRAWING_TYPE,
         OLE_OBJECT_TYPE,
         PIVOT_CACHE_DEF_TYPE,
+        PIVOT_CACHE_REC_TYPE,
         PIVOT_TABLE_TYPE,
         PKG_CHARTS,
         PKG_DRAWINGS,
@@ -314,6 +315,19 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
     }
 
     #[inline]
+    pub(crate) fn add_file_at_pivot_cache_records(
+        &mut self,
+        data: Vec<u8>,
+        pivot_cache_no: i32,
+    ) -> Result<(), XlsxError> {
+        let file_path = format!("xl/pivotCache/pivotCacheRecords{pivot_cache_no}.xml");
+        if !self.check_file_exist(&file_path) {
+            self.add_bin(&file_path, &data)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
     pub(crate) fn has_extension(&self, extension: &str) -> bool {
         let extension = format!(".{extension}");
         self.files.iter().any(|file| file.ends_with(&extension))
@@ -351,9 +365,14 @@ impl<W: io::Seek + io::Write> WriterManager<W> {
                 content_type = PIVOT_TABLE_TYPE;
             }
 
-            // Override pivot cache
+            // Override pivot cache definition
             if file.starts_with("/xl/pivotCache/pivotCacheDefinition") {
                 content_type = PIVOT_CACHE_DEF_TYPE;
+            }
+
+            // Override pivot cache records
+            if file.starts_with("/xl/pivotCache/pivotCacheRecords") {
+                content_type = PIVOT_CACHE_REC_TYPE;
             }
 
             // Override comments

--- a/src/writer/xlsx/pivot_cache.rs
+++ b/src/writer/xlsx/pivot_cache.rs
@@ -43,6 +43,22 @@ pub(crate) fn write<W: io::Seek + io::Write>(
         // Write pivot cache definition
         pivot_table.pivot_cache_definition().write_to(&mut writer);
         writer_mng.add_file_at_pivot_cache(writer, no)?;
+
+        // Write pivot cache records if available (preserved from template)
+        if pivot_table
+            .pivot_cache_definition()
+            .has_raw_cache_records()
+        {
+            let records_data = pivot_table
+                .pivot_cache_definition()
+                .raw_cache_records()
+                .to_vec();
+            writer_mng.add_file_at_pivot_cache_records(
+                records_data,
+                no,
+            )?;
+        }
+
         pivot_cache_no_list.push(no.to_string());
     }
     Ok(pivot_cache_no_list)

--- a/src/writer/xlsx/workbook.rs
+++ b/src/writer/xlsx/workbook.rs
@@ -18,9 +18,16 @@ use super::{
 };
 use crate::{
     helper::const_str::{
+        MC_IGNORABLE_WB,
+        MC_NS,
         PKG_WORKBOOK,
         REL_OFC_NS,
         SHEET_MAIN_NS,
+        SHEET_MS_REVISION_NS,
+        X15_NS,
+        XR2_NS,
+        XR6_NS,
+        XR10_NS,
     },
     structs::{
         Workbook,
@@ -50,6 +57,13 @@ pub(crate) fn write<W: io::Seek + io::Write>(
         vec![
             ("xmlns", SHEET_MAIN_NS).into(),
             ("xmlns:r", REL_OFC_NS).into(),
+            ("xmlns:mc", MC_NS).into(),
+            ("xmlns:x15", X15_NS).into(),
+            ("xmlns:xr", SHEET_MS_REVISION_NS).into(),
+            ("xmlns:xr2", XR2_NS).into(),
+            ("xmlns:xr6", XR6_NS).into(),
+            ("xmlns:xr10", XR10_NS).into(),
+            ("mc:Ignorable", MC_IGNORABLE_WB).into(),
         ],
         false,
     );


### PR DESCRIPTION
Fixes #352

### Issues fixed

1. **Pivot table infrastructure silently dropped on write** — Added `rowGrandTotals`, `colGrandTotals`, `compactData`, `xr:uid`, and `refreshOnLoad` attributes to `PivotTableDefinition`. Fixed `RowItem` to support multiple `<x/>` children (one per row field). Added pivot cache records preservation through the reader→writer pipeline.

2. **Empty `sheetFormatPr` from minimal template sheets** — Writer now always emits `defaultRowHeight` (default: 14.25) and `x14ac:dyDescent` (default: 0.45) even when the template didn't supply them.

3. **Zero `pageMargins` from minimal templates** — Writer now replaces all-zero margins with sensible defaults (left=0.7, right=0.7, top=0.75, bottom=0.75, header=0.3, footer=0.3).

4. **Workbook namespace declarations stripped** — Writer now emits the standard Excel namespace set: `xmlns:mc`, `xmlns:x15`, `xmlns:xr`, `xmlns:xr2`, `xmlns:xr6`, `xmlns:xr10`, `mc:Ignorable`.

5. **Stale `calcChain.xml`** — Verified: calcChain is never written (Excel regenerates it on open).

6. **`missingItemsLimit` on `pivotField`** — Added read/write support for the `missingItemsLimit` attribute (0 = None, no limit on retained items per field).

### Files changed (13)
- `src/helper/const_str.rs`
- `src/reader/xlsx.rs`
- `src/reader/xlsx/pivot_cache.rs`
- `src/reader/xlsx/pivot_table.rs`
- `src/structs/page_margins.rs`
- `src/structs/pivot_cache_definition.rs`
- `src/structs/pivot_field.rs`
- `src/structs/pivot_table_definition.rs`
- `src/structs/row_item.rs`
- `src/structs/sheet_format_properties.rs`
- `src/structs/writer_manager.rs`
- `src/writer/xlsx/pivot_cache.rs`
- `src/writer/xlsx/workbook.rs`