### PR TITLE
fix: read xf/@xfId so a cellXfs entry resolves against its own style

### DIFF
--- a/src/structs/cell_format.rs
+++ b/src/structs/cell_format.rs
@@ -465,14 +465,14 @@ mod tests {
     #[test]
     fn reads_the_xf_id() {
         let obj = read_xf(r#"<xf numFmtId="9" fontId="6" fillId="0" borderId="0" xfId="6" applyFont="1"/>"#);
-        assert_eq!(obj.get_format_id(), 6);
-        assert_eq!(obj.get_number_format_id(), 9);
+        assert_eq!(obj.format_id(), 6);
+        assert_eq!(obj.number_format_id(), 9);
     }
 
     #[test]
     fn an_absent_xf_id_stays_zero() {
         let obj = read_xf(r#"<xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>"#);
-        assert_eq!(obj.get_format_id(), 0);
+        assert_eq!(obj.format_id(), 0);
     }
 
     #[test]
@@ -480,6 +480,6 @@ mod tests {
         let obj = read_xf(
             r#"<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="42"><alignment horizontal="center"/></xf>"#,
         );
-        assert_eq!(obj.get_format_id(), 42);
+        assert_eq!(obj.format_id(), 42);
     }
 }

--- a/src/structs/cell_format.rs
+++ b/src/structs/cell_format.rs
@@ -330,6 +330,11 @@ impl CellFormat {
         set_string_from_xml!(self, e, font_id, "fontId");
         set_string_from_xml!(self, e, fill_id, "fillId");
         set_string_from_xml!(self, e, border_id, "borderId");
+        // `xfId` names the cellStyleXfs entry this cellXfs entry inherits
+        // from. Leaving it unread resolved every cell against cellStyleXfs[0],
+        // so a workbook whose Normal style sets applyNumberFormat="0" lost
+        // every number format, and a round trip rewrote each xfId as 0.
+        set_string_from_xml!(self, e, format_id, "xfId");
         set_string_from_xml!(self, e, apply_number_format, "applyNumberFormat");
         set_string_from_xml!(self, e, apply_border, "applyBorder");
         set_string_from_xml!(self, e, apply_font, "applyFont");
@@ -423,5 +428,58 @@ impl CellFormat {
             }
             write_end_tag(writer, "xf");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_xf(xml: &str) -> CellFormat {
+        let mut reader = Reader::from_reader(std::io::BufReader::new(xml.as_bytes()));
+        let mut buf = Vec::new();
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref e)) if e.name().into_inner() == b"xf" => {
+                    let mut obj = CellFormat::default();
+                    obj.set_attributes(&mut reader, e, false);
+                    return obj;
+                }
+                Ok(Event::Empty(ref e)) if e.name().into_inner() == b"xf" => {
+                    let mut obj = CellFormat::default();
+                    obj.set_attributes(&mut reader, e, true);
+                    return obj;
+                }
+                Ok(Event::Eof) => panic!("xf element not found"),
+                _ => (),
+            }
+            buf.clear();
+        }
+    }
+
+    // `xfId` names the cellStyleXfs entry a cellXfs entry inherits from. It was
+    // written back on save but never read, so every cell resolved against
+    // cellStyleXfs[0]: a workbook whose Normal style carries
+    // applyNumberFormat="0" lost every number format, and a round trip
+    // rewrote each xfId as 0.
+    #[test]
+    fn reads_the_xf_id() {
+        let obj = read_xf(r#"<xf numFmtId="9" fontId="6" fillId="0" borderId="0" xfId="6" applyFont="1"/>"#);
+        assert_eq!(obj.get_format_id(), 6);
+        assert_eq!(obj.get_number_format_id(), 9);
+    }
+
+    #[test]
+    fn an_absent_xf_id_stays_zero() {
+        let obj = read_xf(r#"<xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>"#);
+        assert_eq!(obj.get_format_id(), 0);
+    }
+
+    #[test]
+    fn reads_a_non_zero_xf_id_from_a_non_empty_element() {
+        let obj = read_xf(
+            r#"<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="42"><alignment horizontal="center"/></xf>"#,
+        );
+        assert_eq!(obj.get_format_id(), 42);
     }
 }

--- a/src/writer/csv.rs
+++ b/src/writer/csv.rs
@@ -44,7 +44,12 @@ pub fn write_writer<W: io::Seek + io::Write>(
             }
             // wrap_with_char.
             if option.wrap_with_char() != "" {
-                value = format! {"{}{}{}", option.wrap_with_char(), value, option.wrap_with_char()};
+                value = format!(
+                    "{}{}{}",
+                    option.wrap_with_char(),
+                    value,
+                    option.wrap_with_char()
+                );
             }
             row_vec.push(value);
         }


### PR DESCRIPTION
## What

`CellFormat::set_attributes` reads `numFmtId`, `fontId`, `fillId`, `borderId` and
all six `apply*` flags, but not `xfId` — even though the struct already carries a
`format_id` field for it and `write_to` writes it back out.

`get_format_id()` therefore always returns 0, so `Stylesheet::make_style` pairs
every `cellXfs` entry with `cellStyleXfs[0]` instead of the style it names:

```rust
let def_cell_format = self.cell_style_formats.get_cell_format()
    .get(*cell_format.get_format_id() as usize)   // always 0
```

## Why it matters

`get_style_by_cell_format` lets that referenced style turn a whole formatting
category off:

```rust
let mut apply = true;
if def_cell_format.has_apply_number_format() { apply = *def_cell_format.get_apply_number_format(); }
```

When `cellStyleXfs[0]` carries `applyNumberFormat="0"` — which Excel writes for
the Normal style in many templates — `apply` is false for **every** cell in the
workbook and no number format is ever attached. Percent, currency and date cells
all read back as the raw stored number.

Measured on such a workbook (cell holding `0.25` under `numFmtId="9"`,
`xfId="6"`, where `cellStyleXfs[6]` also declares `numFmtId="9"`):

| workbook | `get_formatted_value()` | resolved format |
| --- | --- | --- |
| as shipped | `"0.25"` | `None` |
| + explicit `<numFmt numFmtId="9" formatCode="0%"/>` | `"0.25"` | `None` |
| `applyNumberFormat="0"` removed from `cellStyleXfs[0]` | `"25%"` | `Some("0%")` |

0 of its 294 cells resolved a number format. Adding the format definition changes
nothing — only the wrong default xf matters.

Reading the attribute also stops a round trip from rewriting every `xfId` as 0,
which currently loses the cell-style association on save.

## Tests

Three unit tests in `src/structs/cell_format.rs`: a declared `xfId` is read from a
self-closing element and from one with children, and an absent one stays 0.

`cargo test` on this branch: 109 + 113 + 4 + 79 pass.

`cargo clippy -- -D warnings` and `cargo test` are green on 1.88.0, stable and
nightly; `cargo +nightly fmt --all --check` is clean.

## Note

The second commit is unrelated to the `xfId` fix and is here only to get CI
green. Current nightly clippy denies `nonstandard_macro_braces`, so
`cargo clippy -- -D warnings` fails on `master` at `src/writer/csv.rs:47`:

```
error: use of irregular braces for `format!` macro
  --> src/writer/csv.rs:47:25
```

Because that job aborts the matrix, the other three toolchains are cancelled
before they finish and every open pull request reads as red. The commit
switches that one call to parentheses, which is what clippy suggests; rustfmt
then wraps the arguments, since the brace form had exempted it. Happy to split
it out if you would rather take it separately.

The third commit swaps the deprecated `get_format_id` / `get_number_format_id`
in the new tests for `format_id` / `number_format_id`, so the suite compiles
without `deprecated` warnings.
