### PR TITLE
Preserve t="str" on empty-string formula results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "umya-spreadsheet"
-version = "3.1.0"
+version = "3.1.1"
 authors = ["MathNya <umya.net.info@gmail.com>"]
 repository = "https://github.com/MathNya/umya-spreadsheet"
 keywords = ["excel", "spreadsheet", "xlsx", "reader", "writer"]

--- a/src/structs/cell.rs
+++ b/src/structs/cell.rs
@@ -655,13 +655,32 @@ impl Cell {
                     }
                     _ => (),
                 },
-                Ok(Event::Empty(ref e)) => {
-                    if e.name().into_inner() == b"f" {
+                Ok(Event::Empty(ref e)) => match e.name().into_inner() {
+                    b"f" => {
                         let mut obj = CellFormula::default();
                         obj.set_attributes(reader, e, true, &cell_reference, formula_shared_list);
                         self.cell_value.set_formula_obj(obj);
                     }
-                }
+                    // A self-closing `<v/>` (written by Excel/LibreOffice for an
+                    // empty cached value) still carries the cell's declared type, so
+                    // an empty-string formula result must keep `t="str"` on write.
+                    b"v" => match type_value.as_str() {
+                        "str" => {
+                            self.set_value_string_crate(String::new());
+                        }
+                        "b" => {
+                            self.set_value_bool_crate(false);
+                        }
+                        "e" => {
+                            self.set_error(String::new());
+                        }
+                        "" | "n" => {
+                            self.set_value_crate(String::new());
+                        }
+                        _ => {}
+                    },
+                    _ => (),
+                },
                 Ok(Event::End(ref e)) => if e.name().into_inner() == b"c" { return },
                 Ok(Event::Eof) => panic!("Error: Could not find {} end element", "c"),
                 Err(e) => panic!("Error at position {}: {:?}", reader.buffer_position(), e),
@@ -855,5 +874,32 @@ mod tests {
         assert_eq!(cell.formatted_value(), "0050");
         assert_eq!(cell.data_type(), "s");
         assert!(cell.value_number().is_none());
+    }
+
+    #[test]
+    fn empty_string_formula_result_keeps_str_type() {
+        // Excel/LibreOffice write an empty cached result as a self-closing `<v/>`.
+        let mut reader = Reader::from_str(r#"<c r="A1" t="str"><f>IF(TRUE,"","x")</f><v/></c>"#);
+        let cell_start = match reader.read_event().unwrap() {
+            Event::Start(event) => event,
+            event => panic!("expected cell start event, got {event:?}"),
+        };
+        let mut cell = Cell::default();
+        let mut formula_shared_list = HashMap::new();
+
+        cell.set_attributes(
+            &mut reader,
+            &cell_start,
+            &SharedStringTable::default(),
+            &Stylesheet::default(),
+            false,
+            &mut formula_shared_list,
+        );
+
+        assert_eq!(cell.formula(), "IF(TRUE,\"\",\"x\")");
+        assert_eq!(cell.value(), "");
+        // The writer emits `t` from `data_type_crate`; it must stay "str" so the
+        // empty-string result is not silently downgraded to a blank/untyped cell.
+        assert_eq!(cell.data_type_crate(), "str");
     }
 }


### PR DESCRIPTION
Fixes #356.

## Problem

When the reader encounters a formula cell whose cached result is an empty string — written by Excel/LibreOffice as a self-closing `<v/>` with `t="str"` — the value is dropped and the cell decays to `Empty`, losing its string type. On write the `t="str"` attribute disappears, so `=IF(cond,"","x")` evaluating to `""` becomes an untyped/blank cell. Non-empty string results are unaffected.

Root cause: in `Cell::set_attributes`, the `Event::Start` arm dispatches `<v>` on the declared `t` type, but the `Event::Empty` arm (which is how a self-closing `<v/>` arrives) only handled `<f/>` and ignored `<v/>` entirely.

## Fix

Handle `<v/>` in the `Event::Empty` arm, dispatching on the declared type the same way the `Event::Start` arm does, so an empty string result keeps `t="str"`.

## Repro (before this PR)

`input.xlsx` cell: `<c r="A1" t="str"><f>IF(TRUE,"","x")</f><v/></c>`

```rust
let book = umya_spreadsheet::reader::xlsx::read(Path::new("input.xlsx")).unwrap();
let cell = book.get_sheet(&0).unwrap().get_cell((1, 1)).unwrap();
assert_eq!(cell.get_data_type(), "str"); // was "", now "str"
```

After the fix the written cell keeps its type: `<c r="A1" t="str"><f>IF(TRUE,"","x")</f><v></v></c>`.

## Tests

Added `empty_string_formula_result_keeps_str_type` covering the read path. Full `cargo test --lib` passes (114 tests).